### PR TITLE
Fix no viable overloaded '*=' error on HIP vectors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,7 +376,7 @@ set(HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_
 
 # Include a header for applying fixups before any user or system includes.
 set(HIP_FIXUPS_HEADER_BUILD
-  -include ${CMAKE_BINARY_DIR}/include/hip/spirv_fixups.h)
+  -include ${CMAKE_SOURCE_DIR}/include/hip/spirv_fixups.h)
 set(HIP_FIXUPS_HEADER_INSTALL
   -include ${CMAKE_INSTALL_PREFIX}/include/hip/spirv_fixups.h)
 
@@ -413,7 +413,10 @@ set(HIP_OFFLOAD_COMPILE_OPTIONS_BUILD_
   ${HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_}
   --hip-path=${CMAKE_BINARY_DIR}
   ${HOST_ARCH}
-  ${HIP_FIXUPS_HEADER_BUILD})
+  ${HIP_FIXUPS_HEADER_BUILD}
+  -I${CMAKE_SOURCE_DIR}/include
+  -I${CMAKE_SOURCE_DIR}/HIP/include
+  -I${CMAKE_BINARY_DIR}/include)
 
 # HIP applications need to link against libCHIP.so; add it to rpath
 list(APPEND HIP_OFFLOAD_LINK_OPTIONS_INSTALL_ "-L${LIB_INSTALL_DIR}" "-lCHIP")
@@ -609,10 +612,6 @@ file(WRITE "${PROJECT_BINARY_DIR}/share/.hipInfo_install" ${_hipInfo_install})
 file(WRITE "${PROJECT_BINARY_DIR}/share/.hipInfo" ${_hipInfo_build})
 install(FILES ${PROJECT_BINARY_DIR}/share/.hipInfo_install
   DESTINATION ${SHARE_INSTALL_DIR} RENAME .hipInfo)
-
-# Copy over includes for hipcc to work in the build dir
-file(COPY ${CMAKE_SOURCE_DIR}/include DESTINATION ${CMAKE_BINARY_DIR})
-file(COPY ${CMAKE_SOURCE_DIR}/HIP/include/hip DESTINATION ${CMAKE_BINARY_DIR}/include)
 
 # Copy hipconfig, hipvars, etc to bin
 install(FILES ${CMAKE_BINARY_DIR}/bin/hipcc.bin DESTINATION ${BIN_INSTALL_DIR} RENAME hipcc PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ)

--- a/include/hip/spirv_hip_vector_types.h
+++ b/include/hip/spirv_hip_vector_types.h
@@ -470,19 +470,18 @@ struct HIP_vector_type : public HIP_vector_base<T, rank> {
     return *this -= HIP_vector_type{x};
   }
 
-  // Struggling to properly specialize these so commenting out for now
-  // __HOST_DEVICE__
-  // HIP_vector_type& operator*=(const HIP_vector_type& x) noexcept
-  // {
-  //     data *= x.data;
-  //     return *this;
-  // }
+  __HOST_DEVICE__
+  HIP_vector_type& operator*=(const HIP_vector_type& x) noexcept
+  {
+      data *= x.data;
+      return *this;
+  }
 
-  // friend __HOST_DEVICE__ inline constexpr HIP_vector_type operator*(
-  // HIP_vector_type x, const HIP_vector_type& y) noexcept
-  // {
-  //   return HIP_vector_type{ x } *= y;
-  // }
+  friend __HOST_DEVICE__ inline constexpr HIP_vector_type operator*(
+  HIP_vector_type x, const HIP_vector_type& y) noexcept
+  {
+    return HIP_vector_type{ x } *= y;
+  }
 
   template <typename U, typename std::enable_if<
                             std::is_convertible<U, T>{}>::type * = nullptr>

--- a/samples/ccompat/CMakeLists.txt
+++ b/samples/ccompat/CMakeLists.txt
@@ -1,10 +1,18 @@
-add_custom_command(OUTPUT saxpy.o   DEPENDS ${CMAKE_SOURCE_DIR}/samples/ccompat/saxpy.hip
-                   COMMAND ${CMAKE_BINARY_DIR}/bin/hipcc.bin ${CMAKE_SOURCE_DIR}/samples/ccompat/saxpy.hip -c -g -pthread)
-add_custom_command(OUTPUT ccompat.o DEPENDS ${CMAKE_SOURCE_DIR}/samples/ccompat/ccompat.c
-                   COMMAND ${CMAKE_BINARY_DIR}/bin/hipcc.bin ${CMAKE_SOURCE_DIR}/samples/ccompat/ccompat.c -c -g -pthread)
+add_custom_command(
+  OUTPUT saxpy.o DEPENDS ${CMAKE_SOURCE_DIR}/samples/ccompat/saxpy.hip
+  COMMAND ${CMAKE_BINARY_DIR}/bin/hipcc.bin
+  ${CMAKE_SOURCE_DIR}/samples/ccompat/saxpy.hip -c -g -pthread
+  -I${CMAKE_SOURCE_DIR}/include -I${CMAKE_SOURCE_DIR}/HIP/include)
+add_custom_command(
+  OUTPUT ccompat.o DEPENDS ${CMAKE_SOURCE_DIR}/samples/ccompat/ccompat.c
+  COMMAND ${CMAKE_BINARY_DIR}/bin/hipcc.bin
+  ${CMAKE_SOURCE_DIR}/samples/ccompat/ccompat.c -c -g -pthread
+  -I${CMAKE_SOURCE_DIR}/include -I${CMAKE_SOURCE_DIR}/HIP/include)
 
-add_custom_target(ccompat ALL DEPENDS saxpy.o ccompat.o
-                  COMMAND ${CMAKE_BINARY_DIR}/bin/hipcc.bin ./ccompat.o ./saxpy.o -o ccompat -g -pthread)
+add_custom_target(
+  ccompat ALL DEPENDS saxpy.o ccompat.o
+  COMMAND ${CMAKE_BINARY_DIR}/bin/hipcc.bin ./ccompat.o ./saxpy.o -o ccompat
+  -g -pthread)
 
 add_dependencies(ccompat hipcc.bin CHIP)
 add_test(NAME ccompat COMMAND ${CMAKE_BINARY_DIR}/samples/ccompat/ccompat)

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -121,3 +121,4 @@ add_test(NAME "TestHipccMultiSource" COMMAND
 
 add_hipcc_test(TestLdg.hip HIPCC_OPTIONS -fsyntax-only)
 add_hipcc_test(TestSwitchCase.hip HIPCC_OPTIONS -O1 -c)
+add_hipcc_test(TestHostSideHIPVectors.hip HIPCC_OPTIONS -fsyntax-only)

--- a/tests/compiler/TestHostSideHIPVectors.hip
+++ b/tests/compiler/TestHostSideHIPVectors.hip
@@ -1,0 +1,7 @@
+// Test HIP vectors on the host-side code.
+// A regression test for https://github.com/CHIP-SPV/chipStar/issues/527.
+#include <hip/hip_runtime.h>
+
+float4 checkMul(float4 x, float4 y) { return x * y; }
+float4 checkMul(float4 x, float y) { return x * y; }
+float4 checkMul(float x, float4 y) { return x * y; }


### PR DESCRIPTION
* Fix HIP samples and tests were not recompiled if HIP headers were modified or updated after `git pull` (the ones under include/hip and HIP/include/hip under the source tree). The compilation relied on HIP headers that were copied to build directory with `file(COPY ...)` command which is only executed once after initial configuration.
* Fix no viable overloaded '*=' error on HIP vectors. Only uncommented a region that was commented out in #513 but the changes didn't propagated before the above fix.

Fixes #527.
