### PR TITLE
Fixes for TestStlFunctions case

### DIFF
--- a/cmake/UnitTests.cmake
+++ b/cmake/UnitTests.cmake
@@ -834,7 +834,6 @@ list(APPEND IGPU_OPENCL_FAILED_TESTS "TestStlFunctionsDouble")
 
 # dGPU OpenCL Unit Test Failures
  # Timeout or out-of-resources error in the CI which emulates double FPs.
-list(APPEND DGPU_OPENCL_FAILED_TESTS "TestStlFunctions") #  Timeuot
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipTexObjPitch_texture2D - float") # Issue 517
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipTexObjPitch_texture2D - int") # Issue 517
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipTexObjPitch_texture2D - unsigned char") # Issue 517

--- a/include/hip/devicelib/single_precision/sp_math.hh
+++ b/include/hip/devicelib/single_precision/sp_math.hh
@@ -193,6 +193,7 @@ extern "C++" inline __device__ float ldexpf(float x, int exp) {
 
 extern "C" __device__  float __ocml_lgamma_f32(float x); // OCML
 extern "C++" inline __device__ float lgammaf(float x) { return ::__ocml_lgamma_f32(x); };
+extern "C++" inline __device__ float lgamma(float x) { return ::lgammaf(x); }
 
 extern "C" __device__  long long int __chip_llrint_f32(float x); // Custom
 extern "C++" inline __device__ long long int llrintf(float x) {

--- a/include/hip/spirv_hip_devicelib.hh
+++ b/include/hip/spirv_hip_devicelib.hh
@@ -125,7 +125,17 @@ __HIP_OVERLOAD2(double, min)
 
 namespace std {
 __HIP_OVERLOAD1(long, lrint);
-}
+__HIP_OVERLOAD1(double, lgamma);
+__HIP_OVERLOAD1(double, erfc);
+__HIP_OVERLOAD1(double, erf);
+__HIP_OVERLOAD1(double, tanh);
+__HIP_OVERLOAD1(double, cosh);
+__HIP_OVERLOAD1(double, sinh);
+__HIP_OVERLOAD1(double, atan);
+__HIP_OVERLOAD1(double, acos);
+__HIP_OVERLOAD1(double, asin);
+__HIP_OVERLOAD1(double, tan);
+} // namespace std
 
 #pragma pop_macro("__DEF_FLOAT_FUN")
 #pragma pop_macro("__DEF_FLOAT_FUN2")

--- a/tests/runtime/TestStlFunctions.hip
+++ b/tests/runtime/TestStlFunctions.hip
@@ -52,52 +52,33 @@ template <typename T, typename FnT> void launchBinaryFn(FnT Fn) {
 int main() {
 
   launchUnaryFn<float>([] __device__(auto x) { return std::abs(x); });
-  launchUnaryFn<char>([] __device__(auto x) { return std::abs(x); });
-  launchUnaryFn<short>([] __device__(auto x) { return std::abs(x); });
-  launchUnaryFn<int>([] __device__(auto x) { return std::abs(x); });
-  launchUnaryFn<long>([] __device__(auto x) { return std::abs(x); });
-  launchUnaryFn<bool>([] __device__(auto x) { return std::abs(x); });
-  launchUnaryFn<unsigned char>([] __device__(auto x) { return std::abs(x); });
-  launchUnaryFn<unsigned short>([] __device__(auto x) { return std::abs(x); });
-
   launchUnaryFn<float>([] __device__(auto x) { return std::expm1(x); });
 
   launchUnaryFn<float>([] __device__(auto x) { return std::log1p(x); }, 2);
 
   launchUnaryFn<float>([] __device__(auto x) { return std::trunc(x); });
 
-  launchUnaryFn<int>([] __device__(auto x) { return std::sin(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::sin(x); });
 
-  launchUnaryFn<int>([] __device__(auto x) { return std::cos(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::cos(x); });
 
-  launchUnaryFn<int>([] __device__(int x) { return std::tan(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::tan(x); });
 
-  launchUnaryFn<int>([] __device__(int x) { return std::asin(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::asin(x); });
 
-  launchUnaryFn<int>([] __device__(auto x) { return std::acos(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::acos(x); });
 
-  launchUnaryFn<int>([] __device__(auto x) { return std::atan(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::atan(x); });
 
-  launchUnaryFn<int>([] __device__(auto x) { return std::sinh(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::sinh(x); });
 
-  launchUnaryFn<int>([] __device__(auto x) { return std::cosh(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::cosh(x); });
 
-  launchUnaryFn<int>([] __device__(int x) { return std::tanh(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::tanh(x); });
 
-  launchUnaryFn<int>([] __device__(int x) { return std::floor(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::floor(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::floorf(x); });
 
-  launchUnaryFn<int>([] __device__(int x) { return std::ceil(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::ceil(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::ceilf(x); });
 
@@ -105,60 +86,38 @@ int main() {
   launchUnaryFn<float>([] __device__(auto x) { return std::log(x); }, 2);
   launchUnaryFn<float>([] __device__(auto x) { return std::logf(x); }, 2);
 
-  launchUnaryFn<int>([] __device__(int x) { return std::log2(x); }, 2);
   launchUnaryFn<float>([] __device__(auto x) { return std::log2(x); }, 2);
   launchUnaryFn<float>([] __device__(auto x) { return std::log2f(x); }, 2);
 
-  launchUnaryFn<int>([] __device__(int x) { return std::log10(x); }, 2);
   launchUnaryFn<float>([] __device__(auto x) { return std::log10(x); }, 2);
   launchUnaryFn<float>([] __device__(auto x) { return std::log10f(x); }, 2);
 
-  launchUnaryFn<int>([] __device__(int x) { return std::erf(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::erf(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::erff(x); });
 
-  launchUnaryFn<int>([] __device__(int x) { return std::erfc(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::erfc(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::erfcf(x); });
 
-  launchUnaryFn<int>([] __device__(int x) { return std::sqrt(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::sqrt(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::sqrtf(x); });
 
-  launchUnaryFn<int>([] __device__(int x) { return std::lgamma(x); }, 1);
   launchUnaryFn<float>([] __device__(auto x) { return std::lgamma(x); }, 1);
   launchUnaryFn<float>([] __device__(auto x) { return std::lgammaf(x); }, 1);
 
-  launchUnaryFn<int>([] __device__(int x) { return std::nearbyint(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::nearbyint(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::nearbyintf(x); });
 
-  launchUnaryFn<int>([] __device__(int x) { return std::exp(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::exp(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::expf(x); });
 
-  launchUnaryFn<int>([] __device__(int x) { return std::lrint(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::lrint(x); });
   launchUnaryFn<float>([] __device__(auto x) { return std::lrintf(x); });
 
-
-  // Known issue:
-  // <...>/include/c++/11/cmath:1300:14: error: reference to __host__
-  // function 'copysign' in __host__ __device__ function
-  //
-  // launchBinaryFn<int>(
-  //     [] __device__(int x, int y) { return std::copysign(x, y); });
   launchBinaryFn<float>(
       [] __device__(auto x, auto y) { return std::copysign(x, y); });
   launchBinaryFn<float>(
       [] __device__(auto x, auto y) { return std::copysignf(x, y); });
 
-  // Known issue:
-  // <...>/include/c++/11/cmath:1674:14: error: reference to __host__ function
-  // 'nextafter' in __host__ __device__ function
-  //
-  // launchBinaryFn<int>(
-  //     [] __device__(int x, int y) { return std::nextafter(x, y); });
   launchBinaryFn<float>(
       [] __device__(auto x, auto y) { return std::nextafter(x, y); });
   launchBinaryFn<float>(

--- a/tests/runtime/TestStlFunctionsDouble.hip
+++ b/tests/runtime/TestStlFunctionsDouble.hip
@@ -81,5 +81,47 @@ int main() {
   launchBinaryFn<double>(
       [] __device__(auto x, auto y) { return std::pow(x, y); }, 2.0, 3.0);
 
+  launchUnaryFn<char>([] __device__(auto x) { return std::abs(x); });
+  launchUnaryFn<short>([] __device__(auto x) { return std::abs(x); });
+  launchUnaryFn<int>([] __device__(auto x) { return std::abs(x); });
+  launchUnaryFn<long>([] __device__(auto x) { return std::abs(x); });
+  launchUnaryFn<bool>([] __device__(auto x) { return std::abs(x); });
+  launchUnaryFn<unsigned char>([] __device__(auto x) { return std::abs(x); });
+  launchUnaryFn<unsigned short>([] __device__(auto x) { return std::abs(x); });
+  launchUnaryFn<int>([] __device__(auto x) { return std::sin(x); });
+  launchUnaryFn<int>([] __device__(auto x) { return std::cos(x); });
+  launchUnaryFn<int>([] __device__(int x) { return std::tan(x); });
+  launchUnaryFn<int>([] __device__(int x) { return std::asin(x); });
+  launchUnaryFn<int>([] __device__(auto x) { return std::acos(x); });
+  launchUnaryFn<int>([] __device__(auto x) { return std::atan(x); });
+  launchUnaryFn<int>([] __device__(auto x) { return std::sinh(x); });
+  launchUnaryFn<int>([] __device__(auto x) { return std::cosh(x); });
+  launchUnaryFn<int>([] __device__(int x) { return std::tanh(x); });
+  launchUnaryFn<int>([] __device__(int x) { return std::floor(x); });
+  launchUnaryFn<int>([] __device__(int x) { return std::ceil(x); });
+  launchUnaryFn<int>([] __device__(int x) { return std::log2(x); }, 2);
+  launchUnaryFn<int>([] __device__(int x) { return std::log10(x); }, 2);
+  launchUnaryFn<int>([] __device__(int x) { return std::erf(x); });
+  launchUnaryFn<int>([] __device__(int x) { return std::erfc(x); });
+  launchUnaryFn<int>([] __device__(int x) { return std::sqrt(x); });
+  launchUnaryFn<int>([] __device__(int x) { return std::lgamma(x); }, 1);
+  launchUnaryFn<int>([] __device__(int x) { return std::nearbyint(x); });
+  launchUnaryFn<int>([] __device__(int x) { return std::exp(x); });
+  launchUnaryFn<int>([] __device__(int x) { return std::lrint(x); });
+
+  // Known issue:
+  // <...>/include/c++/11/cmath:1300:14: error: reference to __host__
+  // function 'copysign' in __host__ __device__ function
+  //
+  // launchBinaryFn<int>(
+  //     [] __device__(int x, int y) { return std::copysign(x, y); });
+
+  // Known issue:
+  // <...>/include/c++/11/cmath:1674:14: error: reference to __host__ function
+  // 'nextafter' in __host__ __device__ function
+  //
+  // launchBinaryFn<int>(
+  //     [] __device__(int x, int y) { return std::nextafter(x, y); });
+
   return 0;
 }


### PR DESCRIPTION
* Add missing cmath overloads.

* Move cmath integer overload checks from TestStlFunctions.hip to TestStlFunctionsDouble.hip because the test exclusion comment said the TestStlFunctions case timed out. That might had happened because the integer overloads are delegated to double overloads and double emulation is slow in the CI.