### PR TITLE
add support for Intel USM extension to chipStar OpenCL BE

### DIFF
--- a/CHIPSPVConfig.hh.in
+++ b/CHIPSPVConfig.hh.in
@@ -42,4 +42,6 @@
 // Non-zero integer if the chipStar is built in debug mode.
 #cmakedefine CHIP_DEBUG_BUILD @CHIP_DEBUG_BUILD@
 
+#cmakedefine CHIP_USE_INTEL_USM
+
 #endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,7 +189,7 @@ option(CHIP_USE_EXTERNAL_HIP_TESTS "Use Catch2 tests from the hip-tests submodul
 option(CHIP_USE_OCML_ROUNDED_OPS "Use OCML implementations for devicelib functions with explicit rounding mode such as __dadd_rd. Otherwise, rounding mode will be ignored" OFF)
 option(CHIP_ENABLE_NON_COMPLIANT_DEVICELIB_CODE "Enable non-compliant devicelib code such as calling LLVM builtins from inside kernel code. Enables certain unsigned long devicelib func variants" OFF)
 option(CHIP_FAST_MATH "Use native_ OpenCL functions which are fast but their precision is implementation defined" OFF)
-
+option(CHIP_USE_INTEL_USM "enable support for cl_intel_unified_shared_memory in the OpenCL backend" OFF)
 # Warpsize would optimally be a device-specific, queried and made
 # effective at runtime. However, we need to fix the warpsize since SPIR-Vs need
 # to be portable across multiple devices. It should be more portable to

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -855,8 +855,12 @@ CHIPContextOpenCL::CHIPContextOpenCL(cl::Context CtxIn, cl::Device Dev,
   std::string DevExts = Dev.getInfo<CL_DEVICE_EXTENSIONS>();
   std::memset(&USM, 0, sizeof(USM));
 
+#ifdef CHIP_USE_INTEL_USM
   SupportsIntelUSM =
       DevExts.find("cl_intel_unified_shared_memory") != std::string::npos;
+#else
+  SupportsIntelUSM = false;
+#endif
   if (SupportsIntelUSM) {
     logDebug("Device supports Intel USM");
     USM.clSharedMemAllocINTEL =

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -236,12 +236,12 @@ annotateSvmPointers(const CHIPContextOpenCL &Ctx, cl_kernel KernelAPIHandle) {
   std::vector<void *> SvmAnnotationList;
   std::unique_ptr<std::vector<std::shared_ptr<void>>> SvmKeepAlives;
   LOCK(Ctx.ContextMtx); // CHIPContextOpenCL::SvmMemory
-  auto NumSvmAllocations = Ctx.SvmMemory.getNumAllocations();
+  auto NumSvmAllocations = Ctx.getNumAllocations();
   if (NumSvmAllocations) {
     SvmAnnotationList.reserve(NumSvmAllocations);
     SvmKeepAlives.reset(new std::vector<std::shared_ptr<void>>());
     SvmKeepAlives->reserve(NumSvmAllocations);
-    for (std::shared_ptr<void> Ptr : Ctx.SvmMemory.getSvmPointers()) {
+    for (std::shared_ptr<void> Ptr : Ctx.getSvmPointers()) {
       SvmAnnotationList.push_back(Ptr.get());
       SvmKeepAlives->push_back(Ptr);
     }
@@ -370,17 +370,6 @@ CHIPDeviceOpenCL::CHIPDeviceOpenCL(CHIPContextOpenCL *ChipCtx,
     : Device(ChipCtx, Idx), ClDevice(DevIn), ClContext(ChipCtx->get()) {
   logTrace("CHIPDeviceOpenCL initialized via OpenCL device pointer and context "
            "pointer");
-  cl_device_svm_capabilities DeviceSVMCapabilities;
-  auto Status =
-      DevIn->getInfo(CL_DEVICE_SVM_CAPABILITIES, &DeviceSVMCapabilities);
-  CHIPERR_CHECK_LOG_AND_THROW(Status, CL_SUCCESS, hipErrorTbd);
-  this->SupportsFineGrainSVM =
-      DeviceSVMCapabilities & CL_DEVICE_SVM_FINE_GRAIN_BUFFER;
-  if (this->SupportsFineGrainSVM) {
-    logTrace("Device supports fine grain SVM");
-  } else {
-    logTrace("Device does not support fine grain SVM");
-  }
 }
 
 CHIPDeviceOpenCL *CHIPDeviceOpenCL::create(cl::Device *ClDevice,
@@ -849,13 +838,8 @@ CHIPKernelOpenCL::CHIPKernelOpenCL(cl::Kernel ClKernel, CHIPDeviceOpenCL *Dev,
 // CHIPContextOpenCL
 //*************************************************************************
 
-bool CHIPContextOpenCL::allDevicesSupportFineGrainSVM() {
-  bool allFineGrainSVM = true;
-  if (!static_cast<CHIPDeviceOpenCL *>(this->ChipDevice_)
-           ->supportsFineGrainSVM()) {
-    allFineGrainSVM = false;
-  }
-  return allFineGrainSVM;
+bool CHIPContextOpenCL::allDevicesSupportFineGrainSVMorUSM() {
+  return SupportsFineGrainSVM || SupportsIntelUSM;
 }
 
 void CHIPContextOpenCL::freeImpl(void *Ptr) {
@@ -863,11 +847,47 @@ void CHIPContextOpenCL::freeImpl(void *Ptr) {
   SvmMemory.free(Ptr);
 }
 
-cl::Context *CHIPContextOpenCL::get() { return ClContext; }
-CHIPContextOpenCL::CHIPContextOpenCL(cl::Context *CtxIn) {
+cl::Context *CHIPContextOpenCL::get() { return &ClContext; }
+CHIPContextOpenCL::CHIPContextOpenCL(cl::Context CtxIn, cl::Device Dev,
+                                     cl::Platform Plat) {
   logTrace("CHIPContextOpenCL Initialized via OpenCL Context pointer.");
+
+  std::string DevExts = Dev.getInfo<CL_DEVICE_EXTENSIONS>();
+  std::memset(&USM, 0, sizeof(USM));
+
+  SupportsIntelUSM =
+      DevExts.find("cl_intel_unified_shared_memory") != std::string::npos;
+  if (SupportsIntelUSM) {
+    logDebug("Device supports Intel USM");
+    USM.clSharedMemAllocINTEL =
+        (clSharedMemAllocINTEL_fn)::clGetExtensionFunctionAddressForPlatform(
+            Plat(), "clSharedMemAllocINTEL");
+    USM.clDeviceMemAllocINTEL =
+        (clDeviceMemAllocINTEL_fn)::clGetExtensionFunctionAddressForPlatform(
+            Plat(), "clDeviceMemAllocINTEL");
+    USM.clHostMemAllocINTEL =
+        (clHostMemAllocINTEL_fn)::clGetExtensionFunctionAddressForPlatform(
+            Plat(), "clHostMemAllocINTEL");
+    USM.clMemFreeINTEL =
+        (clMemFreeINTEL_fn)::clGetExtensionFunctionAddressForPlatform(
+            Plat(), "clMemFreeINTEL");
+  } else {
+    logDebug("Device does not support Intel USM");
+  }
+
+  cl_device_svm_capabilities DeviceSVMCapabilities;
+  int Err = Dev.getInfo(CL_DEVICE_SVM_CAPABILITIES, &DeviceSVMCapabilities);
+  CHIPERR_CHECK_LOG_AND_THROW(Err, CL_SUCCESS, hipErrorTbd);
+  SupportsFineGrainSVM =
+      DeviceSVMCapabilities & CL_DEVICE_SVM_FINE_GRAIN_BUFFER;
+  if (SupportsFineGrainSVM) {
+    logTrace("Device supports fine grain SVM");
+  } else {
+    logTrace("Device does not support fine grain SVM");
+  }
+
   ClContext = CtxIn;
-  SvmMemory.init(*CtxIn);
+  SvmMemory.init(ClContext, Dev, USM, SupportsFineGrainSVM, SupportsIntelUSM);
 }
 
 void *CHIPContextOpenCL::allocateImpl(size_t Size, size_t Alignment,
@@ -876,7 +896,7 @@ void *CHIPContextOpenCL::allocateImpl(size_t Size, size_t Alignment,
   void *Retval;
   LOCK(ContextMtx); // CHIPContextOpenCL::SvmMemory
 
-  Retval = SvmMemory.allocate(Size);
+  Retval = SvmMemory.allocate(Size, Alignment, MemType);
   return Retval;
 }
 
@@ -909,14 +929,17 @@ void CL_CALLBACK pfn_notify(cl_event Event, cl_int CommandExecStatus,
 
 void CHIPQueueOpenCL::MemMap(const chipstar::AllocationInfo *AllocInfo,
                              chipstar::Queue::MEM_MAP_TYPE Type) {
+  CHIPContextOpenCL *C = static_cast<CHIPContextOpenCL *>(ChipContext_);
+  if (C->allDevicesSupportFineGrainSVMorUSM()) {
+    logDebug("Device supports fine grain SVM or USM. Skipping MemMap/Unmap");
+    return;
+  }
+
   auto MemMapEvent =
       static_cast<CHIPBackendOpenCL *>(Backend)->createCHIPEvent(ChipContext_);
   auto MemMapEventNative =
       std::static_pointer_cast<CHIPEventOpenCL>(MemMapEvent)->getNativePtr();
-  if (static_cast<CHIPDeviceOpenCL *>(this->getDevice())
-          ->supportsFineGrainSVM()) {
-    logDebug("Device supports fine grain SVM. Skipping MemMap/Unmap");
-  }
+
   cl_int Status;
   if (Type == chipstar::Queue::MEM_MAP_TYPE::HOST_READ) {
     logDebug("CHIPQueueOpenCL::MemMap HOST_READ");
@@ -942,9 +965,10 @@ void CHIPQueueOpenCL::MemMap(const chipstar::AllocationInfo *AllocInfo,
 void CHIPQueueOpenCL::MemUnmap(const chipstar::AllocationInfo *AllocInfo) {
   auto MemMapEvent =
       static_cast<CHIPBackendOpenCL *>(Backend)->createCHIPEvent(ChipContext_);
-  if (static_cast<CHIPDeviceOpenCL *>(this->getDevice())
-          ->supportsFineGrainSVM()) {
-    logDebug("Device supports fine grain SVM. Skipping MemMap/Unmap");
+  CHIPContextOpenCL *C = static_cast<CHIPContextOpenCL *>(ChipContext_);
+  if (C->allDevicesSupportFineGrainSVMorUSM()) {
+    logDebug("Device supports fine grain SVM or USM. Skipping MemMap/Unmap");
+    return;
   }
   logDebug("CHIPQueueOpenCL::MemUnmap");
 
@@ -1536,8 +1560,9 @@ void CHIPBackendOpenCL::initializeImpl(std::string CHIPPlatformStr,
   // Create context which has devices
   // Create queues that have devices each of which has an associated context
   // TODO Change this to spirv_enabled_devices
-  cl::Context *Ctx = new cl::Context(SpirvDevices);
-  CHIPContextOpenCL *ChipContext = new CHIPContextOpenCL(Ctx);
+  cl::Context Ctx(SpirvDevices);
+  CHIPContextOpenCL *ChipContext =
+      new CHIPContextOpenCL(Ctx, Device, SelectedPlatform);
   ::Backend->addContext(ChipContext);
 
   // TODO for now only a single device is supported.
@@ -1553,15 +1578,17 @@ void CHIPBackendOpenCL::initializeFromNative(const uintptr_t *NativeHandles,
                                              int NumHandles) {
   logTrace("CHIPBackendOpenCL InitializeNative");
   MinQueuePriority_ = CL_QUEUE_PRIORITY_MED_KHR;
-  // cl_platform_id PlatId = (cl_platform_id)NativeHandles[0];
+  cl_platform_id PlatId = (cl_platform_id)NativeHandles[0];
   cl_device_id DevId = (cl_device_id)NativeHandles[1];
   cl_context CtxId = (cl_context)NativeHandles[2];
 
-  cl::Context *Ctx = new cl::Context(CtxId);
-  CHIPContextOpenCL *ChipContext = new CHIPContextOpenCL(Ctx);
+  cl::Context Ctx(CtxId);
+  cl::Platform Plat(PlatId);
+  cl::Device *Dev = new cl::Device(DevId);
+
+  CHIPContextOpenCL *ChipContext = new CHIPContextOpenCL(Ctx, *Dev, Plat);
   addContext(ChipContext);
 
-  cl::Device *Dev = new cl::Device(DevId);
   CHIPDeviceOpenCL *ChipDev = CHIPDeviceOpenCL::create(Dev, ChipContext, 0);
   logTrace("CHIPDeviceOpenCL {}", ChipDev->ClDevice->getInfo<CL_DEVICE_NAME>());
 

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -119,12 +119,12 @@ public:
   cl::Program *get();
 };
 
-typedef struct {
+struct CHIPContextUSMExts {
   clSharedMemAllocINTEL_fn clSharedMemAllocINTEL;
   clDeviceMemAllocINTEL_fn clDeviceMemAllocINTEL;
   clHostMemAllocINTEL_fn clHostMemAllocINTEL;
   clMemFreeINTEL_fn clMemFreeINTEL;
-} CHIPContextUSMExts;
+};
 
 using const_svm_alloc_iterator = ConstMapKeyIterator<
     std::map<std::shared_ptr<void>, size_t, PointerCmp<void>>>;

--- a/src/backend/OpenCL/SVMemoryRegion.cc
+++ b/src/backend/OpenCL/SVMemoryRegion.cc
@@ -24,33 +24,71 @@
 
 #define SVM_ALIGNMENT 128
 
+void SVMemoryRegion::init(cl::Context C, cl::Device D, CHIPContextUSMExts &U,
+                          bool FineGrain, bool IntelUSM) {
+  Device_ = D;
+  Context_ = C;
+  USM = U;
+  UseSVMFineGrain = FineGrain;
+  UseIntelUSM = IntelUSM;
+}
+
 SVMemoryRegion &SVMemoryRegion::operator=(SVMemoryRegion &&Rhs) {
   SvmAllocations_ = std::move(Rhs.SvmAllocations_);
   Context_ = std::move(Rhs.Context_);
+  Device_ = std::move(Rhs.Device_);
+  USM = std::move(Rhs.USM);
+  UseSVMFineGrain = Rhs.UseSVMFineGrain;
+  UseIntelUSM = Rhs.UseIntelUSM;
   return *this;
 }
 
-void *SVMemoryRegion::allocate(size_t Size, SVM_ALLOC_GRANULARITY Granularity) {
+void *SVMemoryRegion::allocate(size_t Size, size_t Alignment,
+                               hipMemoryType MemType) {
   // 0 passed for the alignment will use the default alignment which is equal to
   // the largest data type supported.
   void *Ptr;
-  if (Granularity == COARSE_GRAIN) {
-    Ptr = ::clSVMAlloc(Context_(), CL_MEM_READ_WRITE, Size, 0);
-  } else {
+  int Err;
+  if (UseIntelUSM) {
+    switch (MemType) {
+    case hipMemoryTypeHost:
+      Ptr = USM.clHostMemAllocINTEL(Context_(), NULL, Size, Alignment, &Err);
+      break;
+    case hipMemoryTypeDevice:
+      Ptr = USM.clDeviceMemAllocINTEL(Context_(), Device_(), NULL, Size,
+                                      Alignment, &Err);
+      break;
+    case hipMemoryTypeManaged:
+    case hipMemoryTypeUnified:
+    default:
+      Ptr = USM.clSharedMemAllocINTEL(Context_(), Device_(), NULL, Size,
+                                      Alignment, &Err);
+      break;
+    }
+  } else if (UseSVMFineGrain) {
     Ptr = ::clSVMAlloc(
         Context_(), CL_MEM_READ_WRITE | CL_MEM_SVM_FINE_GRAIN_BUFFER, Size, 0);
+  } else {
+    Ptr = ::clSVMAlloc(Context_(), CL_MEM_READ_WRITE, Size, 0);
   }
+
   if (Ptr) {
-    auto Deleter = [Ctx = this->Context_](void *PtrToFree) -> void {
+    auto Deleter = [Ctx = this->Context_, UseUSM = this->UseIntelUSM,
+                    clMemFreeINTEL =
+                        this->USM.clMemFreeINTEL](void *PtrToFree) -> void {
       logTrace("clSVMFree on: {}\n", PtrToFree);
-      clSVMFree(Ctx(), PtrToFree);
+      if (UseUSM)
+        clMemFreeINTEL(Ctx(), PtrToFree);
+      else
+        clSVMFree(Ctx(), PtrToFree);
     };
     auto SPtr = std::shared_ptr<void>(Ptr, Deleter);
+    logTrace("Memory allocated: {} / {}\n", Ptr, Size);
+    assert(SvmAllocations_.find(SPtr) == SvmAllocations_.end());
     SvmAllocations_.emplace(SPtr, Size);
   } else
     CHIPERR_LOG_AND_THROW("clSVMAlloc failed", hipErrorMemoryAllocation);
 
-  logTrace("clSVMAlloc allocated: {} / {}\n", Ptr, Size);
   return Ptr;
 }
 


### PR DESCRIPTION
disabled by default, can be enabled with cmake option `-DINTEL_USM_SUPPORT=1`