### PR TITLE
Level Zero - env var CHIP_L0_IMM_CMD_LISTS

### DIFF
--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -541,8 +541,18 @@ public:
 };
 
 class CHIPBackendLevel0 : public chipstar::Backend {
+  bool useImmCmdLists_ = false;
 
 public:
+  bool useImmCmdLists() { return useImmCmdLists_; }
+  void setUseImmCmdLists() {
+    auto str = readEnvVar("CHIP_L0_IMM_CMD_LISTS", true);
+    // if str is empty, 0, false, or off, then useImmCmdLists_ is false
+    useImmCmdLists_ =
+        !(str.empty() || str == "0" || str == "false" || str == "off");
+    logDebug("CHIP_L0_IMM_CMD_LISTS = {}", useImmCmdLists_ ? "true" : "false");
+  }
+
   virtual chipstar::ExecItem *createExecItem(dim3 GirdDim, dim3 BlockDim,
                                              size_t SharedMem,
                                              hipStream_t ChipQueue) override;


### PR DESCRIPTION
* Introduce a new env var CHIP_L0_IMM_CMD_LISTS
* This will simplify the use of immediate command lists such that the user will not have to recompile the code
* Easily enable testing without having to recompile which takes a while

TODO:

- [x] Merge #598 
- [ ] Merge hipEventRecord blocking test
- [ ] Add unit testing
- [ ] Run unit tests on Cupcake + Sunspot
- [ ] Adjust test exclusions as necessary