### PR TITLE
CI using pocl-cpu.

### DIFF
--- a/.github/actions/get-shas/action.yml
+++ b/.github/actions/get-shas/action.yml
@@ -1,0 +1,25 @@
+name: 'Get SHAs'
+description: 'Get SHAs of tips of branches we use.'
+inputs:
+  version:
+    description: 'LLVM version'
+    required: true
+outputs:
+  llvm-sha:
+    description: 'SHA of llvm-projetc to checkout'
+    value: ${{ steps.llvm-sha.outputs.sha }}
+  spirv-llvm-sha:
+    description: 'SHA of SIPRV LLVM Translator to checkout'
+    value: ${{ steps.spirv-llvm-sha.outputs.sha }}
+  cache-key:
+    description: 'Key to use when caching LLVM builds'
+    value: ${{ runner.os }}-build-cache-llvm-${{ inputs.version }}-${{ steps.llvm-sha.outputs.sha }}-${{ steps.spirv-llvm-sha.outputs.sha }}
+runs:
+  using: "composite"
+  steps:
+    - id: llvm-sha
+      run: echo "sha=$( curl -u \"u:${{github.token}}\" https://api.github.com/repos/CHIP-SPV/llvm-project/git/ref/heads/chipStar-llvm-${{ inputs.version }} | jq .object.sha | tr -d '\"' )" >> $GITHUB_OUTPUT
+      shell: bash
+    - id: spirv-llvm-sha
+      run: echo "sha=$( curl -u \"u:${{github.token}}\" https://api.github.com/repos/CHIP-SPV/SPIRV-LLVM-Translator/git/ref/heads/chipStar-llvm-${{ inputs.version }} | jq .object.sha | tr -d '\"' )" >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -27,6 +27,7 @@ jobs:
     name: Build and cache spirv-tools
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/cache@v3
         id: spirv-tools
         env:
@@ -68,6 +69,7 @@ jobs:
         version: [15, 16]
       fail-fast: false
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/cache@v3
         id: spirv-tools
         env:
@@ -76,30 +78,29 @@ jobs:
           path: ~/opt/SPIRV-Tools/v2023.2
           key: ${{ runner.os }}-build-${{ env.cache-name }}
           fail-on-cache-miss: true
-      - id: llvm-sha
-        run: echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/CHIP-SPV/llvm-project/git/ref/heads/chipStar-llvm-${{ matrix.version }} | jq .object.sha | tr -d '"' )
-      - id: spirv-llvm-sha
-        run: echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/CHIP-SPV/SPIRV-LLVM-Translator/git/ref/heads/chipStar-llvm-${{ matrix.version }} | jq .object.sha | tr -d '"' )
+      - id: get-shas
+        uses: ./.github/actions/get-shas
+        with:
+          version: ${{ matrix.version }}
       - uses: actions/cache@v3
         id: llvm
         env:
           cache-name: cache-llvm-${{ matrix.version }}
         with:
           path: ~/opt/llvm/${{ matrix.version }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ steps.llvm-sha.outputs.sha }}-${{ steps.spirv-llvm-sha.outputs.sha }}
-        if: steps.llvm.outputs.cache-hit != 'true'
+          key: ${{ steps.get-shas.outputs.cache-key }}
       - run: sudo apt update; sudo apt install -y gcc cmake
         if: steps.llvm.outputs.cache-hit != 'true'
       - uses: actions/checkout@v3
         with:
           repository: CHIP-SPV/llvm-project
-          ref: ${{ steps.llvm-sha.outputs.sha }}
+          ref: ${{ steps.get-shas.outputs.llvm-sha }}
           path: llvm-${{ matrix.version }}
         if: steps.llvm.outputs.cache-hit != 'true'
       - uses: actions/checkout@v3
         with:
           repository: CHIP-SPV/SPIRV-LLVM-Translator
-          ref: ${{ steps.spirv-llvm-sha.outputs.sha }}
+          ref: ${{ steps.get-shas.outputs.spirv-llvm-sha }}
           path: llvm-${{ matrix.version }}/llvm/projects/SPIRV-LLVM-Translator
         if: steps.llvm.outputs.cache-hit != 'true'
       - run: mkdir -p llvm-${{ matrix.version }}/build
@@ -126,6 +127,7 @@ jobs:
         version: [15, 16]
       fail-fast: false
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/cache@v3
         id: pocl
         env:
@@ -142,17 +144,17 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}
           fail-on-cache-miss: true
         if: steps.pocl.outputs.cache-hit != 'true'
-      - id: llvm-sha
-        run: echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/CHIP-SPV/llvm-project/git/ref/heads/chipStar-llvm-${{ matrix.version }} | jq .object.sha | tr -d '"' )
-      - id: spirv-llvm-sha
-        run: echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/CHIP-SPV/SPIRV-LLVM-Translator/git/ref/heads/chipStar-llvm-${{ matrix.version }} | jq .object.sha | tr -d '"' )
+      - id: get-shas
+        uses: ./.github/actions/get-shas
+        with:
+          version: ${{ matrix.version }}
       - uses: actions/cache@v3
         id: llvm
         env:
           cache-name: cache-llvm-${{ matrix.version }}
         with:
           path: ~/opt/llvm/${{ matrix.version }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ steps.llvm-sha.outputs.sha }}-${{ steps.spirv-llvm-sha.outputs.sha }}
+          key: ${{ steps.get-shas.outputs.cache-key }}
           fail-on-cache-miss: true
         if: steps.pocl.outputs.cache-hit != 'true'
       - run: sudo add-apt-repository ppa:ocl-icd/ppa; sudo apt update
@@ -198,17 +200,17 @@ jobs:
           path: ~/opt/SPIRV-Tools/v2023.2
           key: ${{ runner.os }}-build-${{ env.cache-name }}
           fail-on-cache-miss: true
-      - id: llvm-sha
-        run: echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/CHIP-SPV/llvm-project/git/ref/heads/chipsStar-llvm-${{ matrix.version }} | jq .object.sha | tr -d '"' )
-      - id: spirv-llvm-sha
-        run: echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/CHIP-SPV/SPIRV-LLVM-Translator/git/ref/heads/chipStar-llvm-${{ matrix.version }} | jq .object.sha | tr -d '"' )
+      - id: get-shas
+        uses: ./.github/actions/get-shas
+        with:
+          version: ${{ matrix.version }}
       - uses: actions/cache@v3
         id: llvm
         env:
           cache-name: cache-llvm-${{ matrix.version }}
         with:
           path: ~/opt/llvm/${{ matrix.version }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ steps.llvm-sha.outputs.sha }}-${{ steps.spirv-llvm-sha.outputs.sha }}
+          key: ${{ steps.get-shas.outputs.cache-key }}
           fail-on-cache-miss: true
       - uses: actions/cache@v3
         id: pocl

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -78,13 +78,15 @@ jobs:
           fail-on-cache-miss: true
       - id: llvm-sha
         run: echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/CHIP-SPV/llvm-project/git/ref/heads/chipStar-llvm-${{ matrix.version }} | jq .object.sha | tr -d '"' )
+      - id: spirv-llvm-sha
+        run: echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/CHIP-SPV/SPIRV-LLVM-Translator/git/ref/heads/chipStar-llvm-${{ matrix.version }} | jq .object.sha | tr -d '"' )
       - uses: actions/cache@v3
         id: llvm
         env:
           cache-name: cache-llvm-${{ matrix.version }}
         with:
           path: ~/opt/llvm/${{ matrix.version }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ steps.llvm-sha.outputs.sha }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ steps.llvm-sha.outputs.sha }}-${{ steps.spirv-llvm-sha.outputs.sha }}
         if: steps.llvm.outputs.cache-hit != 'true'
       - run: sudo apt update; sudo apt install -y gcc cmake
         if: steps.llvm.outputs.cache-hit != 'true'
@@ -97,7 +99,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: CHIP-SPV/SPIRV-LLVM-Translator
-          ref: chipStar-llvm-${{ matrix.version }}
+          ref: ${{ steps.spirv-llvm-sha.outputs.sha }}
           path: llvm-${{ matrix.version }}/llvm/projects/SPIRV-LLVM-Translator
         if: steps.llvm.outputs.cache-hit != 'true'
       - run: mkdir -p llvm-${{ matrix.version }}/build
@@ -142,13 +144,15 @@ jobs:
         if: steps.pocl.outputs.cache-hit != 'true'
       - id: llvm-sha
         run: echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/CHIP-SPV/llvm-project/git/ref/heads/chipStar-llvm-${{ matrix.version }} | jq .object.sha | tr -d '"' )
+      - id: spirv-llvm-sha
+        run: echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/CHIP-SPV/SPIRV-LLVM-Translator/git/ref/heads/chipStar-llvm-${{ matrix.version }} | jq .object.sha | tr -d '"' )
       - uses: actions/cache@v3
         id: llvm
         env:
           cache-name: cache-llvm-${{ matrix.version }}
         with:
           path: ~/opt/llvm/${{ matrix.version }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ steps.llvm-sha.outputs.sha }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ steps.llvm-sha.outputs.sha }}-${{ steps.spirv-llvm-sha.outputs.sha }}
           fail-on-cache-miss: true
         if: steps.pocl.outputs.cache-hit != 'true'
       - run: sudo add-apt-repository ppa:ocl-icd/ppa; sudo apt update
@@ -196,13 +200,15 @@ jobs:
           fail-on-cache-miss: true
       - id: llvm-sha
         run: echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/CHIP-SPV/llvm-project/git/ref/heads/chipsStar-llvm-${{ matrix.version }} | jq .object.sha | tr -d '"' )
+      - id: spirv-llvm-sha
+        run: echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/CHIP-SPV/SPIRV-LLVM-Translator/git/ref/heads/chipStar-llvm-${{ matrix.version }} | jq .object.sha | tr -d '"' )
       - uses: actions/cache@v3
         id: llvm
         env:
           cache-name: cache-llvm-${{ matrix.version }}
         with:
           path: ~/opt/llvm/${{ matrix.version }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ steps.llvm-sha.outputs.sha }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ steps.llvm-sha.outputs.sha }}-${{ steps.spirv-llvm-sha.outputs.sha }}
           fail-on-cache-miss: true
       - uses: actions/cache@v3
         id: pocl

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,0 +1,220 @@
+name: pocl-cpu
+
+on:
+  push:
+    paths-ignore: "docs/**"
+  pull_request:
+    paths-ignore: "docs/**"
+
+jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          paths_ignore: '["docs/**"]'
+          do_not_skip: '["pull_request"]'
+
+
+  spirv-tools:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    name: Build and cache spirv-tools
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/cache@v3
+        id: spirv-tools
+        env:
+          cache-name: cache-spirv-tools
+        with:
+          path: ~/opt/SPIRV-Tools/v2023.2
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
+      - run: sudo apt update; sudo apt install -y gcc cmake python3
+        if: steps.spirv-tools.outputs.cache-hit != 'true'
+      - uses: actions/checkout@v3
+        with:
+          repository: KhronosGroup/SPIRV-Tools
+          ref: v2023.2
+          path: SPIRV-Tools
+          fetch-depth: 0
+        if: steps.spirv-tools.outputs.cache-hit != 'true'
+      - run: python3 utils/git-sync-deps
+        working-directory: SPIRV-Tools/
+        if: steps.spirv-tools.outputs.cache-hit != 'true'
+      - run: mkdir -p SPIRV-Tools/build
+        if: steps.spirv-tools.outputs.cache-hit != 'true'
+      - run: cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/opt/SPIRV-Tools/v2023.2 -DSPIRV_SKIP_TESTS=ON
+        working-directory: SPIRV-Tools/build
+        if: steps.spirv-tools.outputs.cache-hit != 'true'
+      - run: cmake --build . --parallel 4
+        working-directory: SPIRV-Tools/build
+        if: steps.spirv-tools.outputs.cache-hit != 'true'
+      - run: cmake --install .
+        working-directory: SPIRV-Tools/build
+        if: steps.spirv-tools.outputs.cache-hit != 'true'
+
+  llvm:
+    needs: [pre_job, spirv-tools]
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    name: Build and cache llvm-${{ matrix.version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [15, 16]
+    steps:
+      - uses: actions/cache@v3
+        id: spirv-tools
+        env:
+          cache-name: cache-spirv-tools
+        with:
+          path: ~/opt/SPIRV-Tools/v2023.2
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
+          fail-on-cache-miss: true
+      - uses: actions/cache@v3
+        id: llvm
+        env:
+          cache-name: cache-llvm-${{ matrix.version }}
+        with:
+          path: ~/opt/llvm/${{ matrix.version }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
+        if: steps.llvm.outputs.cache-hit != 'true'
+      - run: sudo apt update; sudo apt install -y gcc cmake
+        if: steps.llvm.outputs.cache-hit != 'true'
+      - uses: actions/checkout@v3
+        with:
+          repository: CHIP-SPV/llvm-project
+          ref: chipStar-llvm-${{ matrix.version }}
+          path: llvm-${{ matrix.version }}
+        if: steps.llvm.outputs.cache-hit != 'true'
+      - uses: actions/checkout@v3
+        with:
+          repository: CHIP-SPV/SPIRV-LLVM-Translator
+          ref: chipStar-llvm-${{ matrix.version }}
+          path: llvm-${{ matrix.version }}/llvm/projects/SPIRV-LLVM-Translator
+        if: steps.llvm.outputs.cache-hit != 'true'
+      - run: mkdir -p llvm-${{ matrix.version }}/build
+        if: steps.llvm.outputs.cache-hit != 'true'
+      - run: cmake -S llvm -B build -DLLVM_ENABLE_PROJECTS="clang;openmp" -DCMAKE_INSTALL_PREFIX=$HOME/opt/llvm/${{ matrix.version }} -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_SPIRV_INCLUDE_TESTS=OFF
+        env:
+          PKG_CONFIG_PATH: ~/opt/SPIRV-Tools/v2023.2/lib/pkgconfig/
+        working-directory: llvm-${{ matrix.version }}
+        if: steps.llvm.outputs.cache-hit != 'true'
+      - run: cmake --build . --parallel 4
+        working-directory: llvm-${{ matrix.version }}/build
+        if: steps.llvm.outputs.cache-hit != 'true'
+      - run: cmake --install .
+        working-directory: llvm-${{ matrix.version }}/build
+        if: steps.llvm.outputs.cache-hit != 'true'
+
+  pocl:
+    needs: [pre_job, llvm, spirv-tools]
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    name: Build and cache pocl (llvm-${{ matrix.version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [15, 16]
+    steps:
+      - uses: actions/cache@v3
+        id: pocl
+        env:
+          cache-name: cache-pocl
+        with:
+          path: ~/opt/pocl/4.0
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-llvm-${{ matrix.version }}
+      - uses: actions/cache@v3
+        id: spirv-tools
+        env:
+          cache-name: cache-spirv-tools
+        with:
+          path: ~/opt/SPIRV-Tools/v2023.2
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
+          fail-on-cache-miss: true
+        if: steps.pocl.outputs.cache-hit != 'true'
+      - uses: actions/cache@v3
+        id: llvm
+        env:
+          cache-name: cache-llvm-${{ matrix.version }}
+        with:
+          path: ~/opt/llvm/${{ matrix.version }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
+          fail-on-cache-miss: true
+        if: steps.pocl.outputs.cache-hit != 'true'
+      - run: sudo add-apt-repository ppa:ocl-icd/ppa; sudo apt update
+        if: steps.pocl.outputs.cache-hit != 'true'
+      - run: sudo apt install -y python3-dev libpython3-dev build-essential cmake git pkg-config make ninja-build ocl-icd-libopencl1 ocl-icd-dev ocl-icd-opencl-dev libhwloc-dev zlib1g zlib1g-dev clinfo dialog apt-utils libxml2-dev
+        if: steps.pocl.outputs.cache-hit != 'true'
+      - uses: actions/checkout@v3
+        with:
+          repository: pocl/pocl
+          ref: v4.0
+          path: pocl
+        if: steps.pocl.outputs.cache-hit != 'true'
+      - run: mkdir -p pocl/build
+        if: steps.pocl.outputs.cache-hit != 'true'
+      - run: cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/opt/pocl/4.0 -DCMAKE_BUILD_TYPE=Release -DWITH_LLVM_CONFIG=$HOME/opt/llvm/${{ matrix.version }}/bin/llvm-config -DENABLE_TESTS=OFF -DENABLE_EXAMPLES=OFF -DSTATIC_LLVM=ON
+        working-directory: pocl/build
+        if: steps.pocl.outputs.cache-hit != 'true'
+      - run: cmake --build . --parallel 4
+        working-directory: pocl/build
+        if: steps.pocl.outputs.cache-hit != 'true'
+      - run: cmake --install .
+        working-directory: pocl/build
+        if: steps.pocl.outputs.cache-hit != 'true'
+
+  chipstar:
+    needs: [pre_job, llvm, spirv-tools, pocl]
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    name: Build and test chipStar (llvm-${{ matrix.version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [15, 16]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/cache@v3
+        id: spirv-tools
+        env:
+          cache-name: cache-spirv-tools
+        with:
+          path: ~/opt/SPIRV-Tools/v2023.2
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
+          fail-on-cache-miss: true
+      - uses: actions/cache@v3
+        id: llvm
+        env:
+          cache-name: cache-llvm-${{ matrix.version }}
+        with:
+          path: ~/opt/llvm/${{ matrix.version }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
+          fail-on-cache-miss: true
+      - uses: actions/cache@v3
+        id: pocl
+        env:
+          cache-name: cache-pocl
+        with:
+          path: ~/opt/pocl/4.0
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-llvm-${{ matrix.version }}
+          fail-on-cache-miss: true
+      - run: sudo add-apt-repository ppa:ocl-icd/ppa; sudo apt update
+      - run: sudo apt install -y python3-dev libpython3-dev build-essential cmake git pkg-config make ninja-build ocl-icd-libopencl1 ocl-icd-dev ocl-icd-opencl-dev libhwloc-dev zlib1g zlib1g-dev clinfo dialog apt-utils libxml2-dev
+      - run: ls ~/opt/pocl/4.0/etc/OpenCL/vendors/; cat ~/opt/pocl/4.0/etc/OpenCL/vendors/*
+      - run: ldd `cat ~/opt/pocl/4.0/etc/OpenCL/vendors/pocl.icd`
+      - run: OPENCL_VENDOR_PATH=$HOME/opt/pocl/4.0/etc/OpenCL/vendors/ clinfo
+      - run: mkdir -p build
+      - run: cmake .. -DLLVM_CONFIG_BIN=$HOME/opt/llvm/${{ matrix.version }}/bin/llvm-config
+        working-directory: build
+      - run: cmake --build . --parallel 4
+        working-directory: build
+      - run: OPENCL_VENDOR_PATH=$HOME/opt/pocl/4.0/etc/OpenCL/vendors/ CHIP_DEVICE_TYPE=cpu cmake --build . --parallel 4 --target build_tests
+        working-directory: build
+      - run: OPENCL_VENDOR_PATH=$HOME/opt/pocl/4.0/etc/OpenCL/vendors/ CHIP_DEVICE_TYPE=cpu ctest --timeout 180 --output-on-failure -E "`cat ./test_lists/cpu_pocl_failed_tests.txt`" | tee cpu_pocl_make_check_result.txt
+        working-directory: build

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -66,6 +66,7 @@ jobs:
     strategy:
       matrix:
         version: [15, 16]
+      fail-fast: false
     steps:
       - uses: actions/cache@v3
         id: spirv-tools
@@ -119,6 +120,7 @@ jobs:
     strategy:
       matrix:
         version: [15, 16]
+      fail-fast: false
     steps:
       - uses: actions/cache@v3
         id: pocl

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -76,20 +76,22 @@ jobs:
           path: ~/opt/SPIRV-Tools/v2023.2
           key: ${{ runner.os }}-build-${{ env.cache-name }}
           fail-on-cache-miss: true
+      - id: llvm-sha
+        run: echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/CHIP-SPV/llvm-project/git/ref/heads/chipStar-llvm-${{ matrix.version }} | jq .object.sha | tr -d '"' )
       - uses: actions/cache@v3
         id: llvm
         env:
           cache-name: cache-llvm-${{ matrix.version }}
         with:
           path: ~/opt/llvm/${{ matrix.version }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ steps.llvm-sha.outputs.sha }}
         if: steps.llvm.outputs.cache-hit != 'true'
       - run: sudo apt update; sudo apt install -y gcc cmake
         if: steps.llvm.outputs.cache-hit != 'true'
       - uses: actions/checkout@v3
         with:
           repository: CHIP-SPV/llvm-project
-          ref: chipStar-llvm-${{ matrix.version }}
+          ref: ${{ steps.llvm-sha.outputs.sha }}
           path: llvm-${{ matrix.version }}
         if: steps.llvm.outputs.cache-hit != 'true'
       - uses: actions/checkout@v3
@@ -138,13 +140,15 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}
           fail-on-cache-miss: true
         if: steps.pocl.outputs.cache-hit != 'true'
+      - id: llvm-sha
+        run: echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/CHIP-SPV/llvm-project/git/ref/heads/chipStar-llvm-${{ matrix.version }} | jq .object.sha | tr -d '"' )
       - uses: actions/cache@v3
         id: llvm
         env:
           cache-name: cache-llvm-${{ matrix.version }}
         with:
           path: ~/opt/llvm/${{ matrix.version }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ steps.llvm-sha.outputs.sha }}
           fail-on-cache-miss: true
         if: steps.pocl.outputs.cache-hit != 'true'
       - run: sudo add-apt-repository ppa:ocl-icd/ppa; sudo apt update
@@ -190,13 +194,15 @@ jobs:
           path: ~/opt/SPIRV-Tools/v2023.2
           key: ${{ runner.os }}-build-${{ env.cache-name }}
           fail-on-cache-miss: true
+      - id: llvm-sha
+        run: echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/CHIP-SPV/llvm-project/git/ref/heads/chipsStar-llvm-${{ matrix.version }} | jq .object.sha | tr -d '"' )
       - uses: actions/cache@v3
         id: llvm
         env:
           cache-name: cache-llvm-${{ matrix.version }}
         with:
           path: ~/opt/llvm/${{ matrix.version }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ steps.llvm-sha.outputs.sha }}
           fail-on-cache-miss: true
       - uses: actions/cache@v3
         id: pocl

--- a/scripts/unit_tests.sh
+++ b/scripts/unit_tests.sh
@@ -189,8 +189,7 @@ echo "RESULTS:"
 for test_result in dgpu_opencl_make_check_result.txt \
                    cpu_opencl_make_check_result.txt \
                    dgpu_level0_reg_make_check_result.txt \
-                   dgpu_level0_imm_make_check_result.txt \
-                   cpu_pocl_make_check_result.txt
+                   dgpu_level0_imm_make_check_result.txt
 do
   echo -n "${test_result}: "
   check_tests "${test_result}"

--- a/scripts/unit_tests.sh
+++ b/scripts/unit_tests.sh
@@ -75,13 +75,13 @@ export HIP_DIR=`pwd`/install # set HIP_DIR to current build dir
 # ../scripts/compile_libceed.sh ${HIP_DIR}
 module unload opencl/pocl
 
-# Test PoCL CPU
-echo "begin cpu_pocl_failed_tests"
-module load opencl/pocl
-module list
-ctest --timeout 180 -j 8 --output-on-failure -E "`cat ./test_lists/cpu_pocl_failed_tests.txt`" | tee cpu_pocl_make_check_result.txt
-module unload opencl/pocl
-echo "end cpu_pocl_failed_tests"
+# # Test PoCL CPU
+# echo "begin cpu_pocl_failed_tests"
+# module load opencl/pocl
+# module list
+# ctest --timeout 180 -j 8 --output-on-failure -E "`cat ./test_lists/cpu_pocl_failed_tests.txt`" | tee cpu_pocl_make_check_result.txt
+# module unload opencl/pocl
+# echo "end cpu_pocl_failed_tests"
 
 # # Test Level Zero iGPU
 # echo "begin igpu_level0_failed_tests"


### PR DESCRIPTION
This add a working CI that leverages GitHub actions and pocl to test the OpenCL code path.
- Run is 1h
- Building llvm is a couple of hours, but it is cached
- SPIRV-Tools is apparently unneeded, so we may want to remove it to streamline the workflow.

There are many ways we could improve on it I assume, but at least it demonstrates the feasibility of the approach.