### PR TITLE
Add CI for Intel CPU OpenCL

### DIFF
--- a/.github/actions/get-shas/action.yml
+++ b/.github/actions/get-shas/action.yml
@@ -11,15 +11,33 @@ outputs:
   spirv-llvm-sha:
     description: 'SHA of SIPRV LLVM Translator to checkout'
     value: ${{ steps.spirv-llvm-sha.outputs.sha }}
-  cache-key:
+  pocl-sha:
+    description: 'SHA of pocl to checkout'
+    value: ${{ steps.pocl-sha.outputs.sha }}
+  llvm-cache-key:
     description: 'Key to use when caching LLVM builds'
     value: ${{ runner.os }}-build-cache-llvm-${{ inputs.version }}-${{ steps.llvm-sha.outputs.sha }}-${{ steps.spirv-llvm-sha.outputs.sha }}
+  pocl-cache-key:
+    description: 'Key to use when caching pocl builds'
+    value: ${{ runner.os }}-build-cache-pocl-llvm-${{ inputs.version }}-${{steps.pocl-sha.outputs.sha}}-${{ steps.llvm-sha.outputs.sha }}-${{ steps.spirv-llvm-sha.outputs.sha }}
 runs:
   using: "composite"
   steps:
     - id: llvm-sha
-      run: echo "sha=$( curl -u \"u:${{github.token}}\" https://api.github.com/repos/CHIP-SPV/llvm-project/git/ref/heads/chipStar-llvm-${{ inputs.version }} | jq .object.sha | tr -d '\"' )" >> $GITHUB_OUTPUT
+      run: scripts/get_sha.sh >> $GITHUB_OUTPUT
+      env:
+        URL: https://api.github.com/repos/CHIP-SPV/llvm-project/git/ref/heads/chipStar-llvm-${{ inputs.version }}
+        TOKEN: u:${{github.token}}
       shell: bash
     - id: spirv-llvm-sha
-      run: echo "sha=$( curl -u \"u:${{github.token}}\" https://api.github.com/repos/CHIP-SPV/SPIRV-LLVM-Translator/git/ref/heads/chipStar-llvm-${{ inputs.version }} | jq .object.sha | tr -d '\"' )" >> $GITHUB_OUTPUT
+      run: scripts/get_sha.sh >> $GITHUB_OUTPUT
+      env:
+        URL: https://api.github.com/repos/CHIP-SPV/SPIRV-LLVM-Translator/git/ref/heads/chipStar-llvm-${{ inputs.version }}
+        TOKEN: u:${{github.token}}
+      shell: bash
+    - id: pocl-sha
+      run: scripts/get_sha.sh >> $GITHUB_OUTPUT
+      env:
+        URL: https://api.github.com/repos/pocl/pocl/git/refs/tags/v4.0
+        TOKEN: u:${{ github.token }}
       shell: bash

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -88,7 +88,7 @@ jobs:
           cache-name: cache-llvm-${{ matrix.version }}
         with:
           path: ~/opt/llvm/${{ matrix.version }}
-          key: ${{ steps.get-shas.outputs.cache-key }}
+          key: ${{ steps.get-shas.outputs.llvm-cache-key }}
       - run: sudo apt update; sudo apt install -y gcc cmake
         if: steps.llvm.outputs.cache-hit != 'true'
       - uses: actions/checkout@v3
@@ -128,13 +128,17 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
+      - id: get-shas
+        uses: ./.github/actions/get-shas
+        with:
+          version: ${{ matrix.version }}
       - uses: actions/cache@v3
         id: pocl
         env:
           cache-name: cache-pocl
         with:
           path: ~/opt/pocl/4.0
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-llvm-${{ matrix.version }}
+          key: ${{ steps.get-shas.outputs.pocl-cache-key }}
       - uses: actions/cache@v3
         id: spirv-tools
         env:
@@ -144,17 +148,13 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}
           fail-on-cache-miss: true
         if: steps.pocl.outputs.cache-hit != 'true'
-      - id: get-shas
-        uses: ./.github/actions/get-shas
-        with:
-          version: ${{ matrix.version }}
       - uses: actions/cache@v3
         id: llvm
         env:
           cache-name: cache-llvm-${{ matrix.version }}
         with:
           path: ~/opt/llvm/${{ matrix.version }}
-          key: ${{ steps.get-shas.outputs.cache-key }}
+          key: ${{ steps.get-shas.outputs.llvm-cache-key }}
           fail-on-cache-miss: true
         if: steps.pocl.outputs.cache-hit != 'true'
       - run: sudo add-apt-repository ppa:ocl-icd/ppa; sudo apt update
@@ -164,7 +164,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: pocl/pocl
-          ref: v4.0
+          ref: ${{ steps.get-shas.outputs.pocl-sha }}
           path: pocl
         if: steps.pocl.outputs.cache-hit != 'true'
       - run: mkdir -p pocl/build
@@ -210,7 +210,7 @@ jobs:
           cache-name: cache-llvm-${{ matrix.version }}
         with:
           path: ~/opt/llvm/${{ matrix.version }}
-          key: ${{ steps.get-shas.outputs.cache-key }}
+          key: ${{ steps.get-shas.outputs.llvm-cache-key }}
           fail-on-cache-miss: true
       - uses: actions/cache@v3
         id: pocl
@@ -218,7 +218,7 @@ jobs:
           cache-name: cache-pocl
         with:
           path: ~/opt/pocl/4.0
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-llvm-${{ matrix.version }}
+          key: ${{ steps.get-shas.outputs.pocl-cache-key }}
           fail-on-cache-miss: true
       - run: sudo add-apt-repository ppa:ocl-icd/ppa; sudo apt update
       - run: sudo apt install -y python3-dev libpython3-dev build-essential cmake git pkg-config make ninja-build ocl-icd-libopencl1 ocl-icd-dev ocl-icd-opencl-dev libhwloc-dev zlib1g zlib1g-dev clinfo dialog apt-utils libxml2-dev

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -220,17 +220,25 @@ jobs:
           path: ~/opt/pocl/4.0
           key: ${{ steps.get-shas.outputs.pocl-cache-key }}
           fail-on-cache-miss: true
+      - run: wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+      - run: echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
       - run: sudo add-apt-repository ppa:ocl-icd/ppa; sudo apt update
-      - run: sudo apt install -y python3-dev libpython3-dev build-essential cmake git pkg-config make ninja-build ocl-icd-libopencl1 ocl-icd-dev ocl-icd-opencl-dev libhwloc-dev zlib1g zlib1g-dev clinfo dialog apt-utils libxml2-dev
-      - run: ls ~/opt/pocl/4.0/etc/OpenCL/vendors/; cat ~/opt/pocl/4.0/etc/OpenCL/vendors/*
-      - run: ldd `cat ~/opt/pocl/4.0/etc/OpenCL/vendors/pocl.icd`
-      - run: OPENCL_VENDOR_PATH=$HOME/opt/pocl/4.0/etc/OpenCL/vendors/ clinfo
+      - run: sudo apt install -y python3-dev libpython3-dev build-essential cmake git pkg-config make ninja-build ocl-icd-libopencl1 ocl-icd-dev ocl-icd-opencl-dev libhwloc-dev zlib1g zlib1g-dev clinfo dialog apt-utils libxml2-dev intel-oneapi-compiler-dpcpp-cpp intel-oneapi-runtime-opencl
+      - run: LD_LIBRARY_PATH=$(dirname $(find /opt/intel | grep libsvml.so)) clinfo
+      - run: LD_LIBRARY_PATH=$(dirname $(find /opt/intel | grep libsvml.so)) OCL_ICD_VENDORS=$HOME/opt/pocl/4.0/etc/OpenCL/vendors/ clinfo
       - run: mkdir -p build
-      - run: cmake .. -DLLVM_CONFIG_BIN=$HOME/opt/llvm/${{ matrix.version }}/bin/llvm-config
+      - name: CMake
+        run: cmake .. -DLLVM_CONFIG_BIN=$HOME/opt/llvm/${{ matrix.version }}/bin/llvm-config
         working-directory: build
-      - run: cmake --build . --parallel 4
+      - name: Build
+        run: LD_LIBRARY_PATH=$(dirname $(find /opt/intel | grep libsvml.so)) cmake --build . --parallel 4
         working-directory: build
-      - run: OPENCL_VENDOR_PATH=$HOME/opt/pocl/4.0/etc/OpenCL/vendors/ CHIP_DEVICE_TYPE=cpu cmake --build . --parallel 4 --target build_tests
+      - name: Build Tests
+        run: LD_LIBRARY_PATH=$(dirname $(find /opt/intel | grep libsvml.so)) OCL_ICD_VENDORS=$HOME/opt/pocl/4.0/etc/OpenCL/vendors/ CHIP_DEVICE_TYPE=cpu cmake --build . --parallel 4 --target build_tests
         working-directory: build
-      - run: OPENCL_VENDOR_PATH=$HOME/opt/pocl/4.0/etc/OpenCL/vendors/ CHIP_DEVICE_TYPE=cpu ctest --timeout 180 --output-on-failure -E "`cat ./test_lists/cpu_pocl_failed_tests.txt`" | tee cpu_pocl_make_check_result.txt
+      - name: Test Intel OpenCL
+        run: LD_LIBRARY_PATH=$(dirname $(find /opt/intel | grep libsvml.so)) OCL_ICD_FILENAMES=$(cat /etc/OpenCL/vendors/intel64.icd) CHIP_DEVICE_TYPE=cpu ctest --timeout 180 --output-on-failure -E "`cat ./test_lists/cpu_opencl_failed_tests.txt`"
+        working-directory: build
+      - name: Test pocl OpenCL
+        run: LD_LIBRARY_PATH=$(dirname $(find /opt/intel | grep libsvml.so)) OCL_ICD_VENDORS=$HOME/opt/pocl/4.0/etc/OpenCL/vendors/ CHIP_DEVICE_TYPE=cpu ctest --timeout 180 --output-on-failure -E "`cat ./test_lists/cpu_pocl_failed_tests.txt`"
         working-directory: build

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -182,11 +182,15 @@ jobs:
   chipstar:
     needs: [pre_job, llvm, spirv-tools, pocl]
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-    name: Build and test chipStar (llvm-${{ matrix.version }})
+    name: Build and test chipStar on ${{ matrix.backend }} (llvm-${{ matrix.version }})
     runs-on: ubuntu-latest
+    env:
+      OPENCL_ENV: ${{ matrix.backend == 'intel' && 'LD_LIBRARY_PATH=$(dirname $(find /opt/intel | grep libsvml.so)) OCL_ICD_FILENAMES=$(cat /etc/OpenCL/vendors/intel64.icd)' || 'OPENCL_VENDOR_PATH=$HOME/opt/pocl/4.0/etc/OpenCL/vendors/' }}
+      EXCLUDE: ${{ matrix.backend == 'intel' && '"`cat ./test_lists/cpu_opencl_failed_tests.txt`"' || '"`cat ./test_lists/cpu_pocl_failed_tests.txt`"' }}
     strategy:
       matrix:
         version: [15, 16]
+        backend: [pocl, intel]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -220,25 +224,26 @@ jobs:
           path: ~/opt/pocl/4.0
           key: ${{ steps.get-shas.outputs.pocl-cache-key }}
           fail-on-cache-miss: true
+        if: ${{ matrix.backend == 'pocl' }}
       - run: wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+        if: ${{ matrix.backend == 'intel' }}
       - run: echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-      - run: sudo add-apt-repository ppa:ocl-icd/ppa; sudo apt update
-      - run: sudo apt install -y python3-dev libpython3-dev build-essential cmake git pkg-config make ninja-build ocl-icd-libopencl1 ocl-icd-dev ocl-icd-opencl-dev libhwloc-dev zlib1g zlib1g-dev clinfo dialog apt-utils libxml2-dev intel-oneapi-compiler-dpcpp-cpp intel-oneapi-runtime-opencl
-      - run: LD_LIBRARY_PATH=$(dirname $(find /opt/intel | grep libsvml.so)) clinfo
-      - run: LD_LIBRARY_PATH=$(dirname $(find /opt/intel | grep libsvml.so)) OCL_ICD_VENDORS=$HOME/opt/pocl/4.0/etc/OpenCL/vendors/ clinfo
+        if: ${{ matrix.backend == 'intel' }}
+      - run: sudo add-apt-repository ppa:ocl-icd/ppa
+        if: ${{ matrix.backend == 'pocl' }}
+      - run: sudo apt update
+      - run: sudo apt install -y python3-dev libpython3-dev build-essential cmake git pkg-config make ninja-build libhwloc-dev zlib1g zlib1g-dev clinfo dialog apt-utils libxml2-dev ${{ matrix.backend == 'intel' && 'intel-oneapi-compiler-dpcpp-cpp intel-oneapi-runtime-opencl' || 'ocl-icd-libopencl1 ocl-icd-dev ocl-icd-opencl-dev' }}
+      - run: ${{ env.OPENCL_ENV }} clinfo
       - run: mkdir -p build
       - name: CMake
-        run: cmake .. -DLLVM_CONFIG_BIN=$HOME/opt/llvm/${{ matrix.version }}/bin/llvm-config
+        run: ${{ env.OPENCL_ENV }} cmake .. -DLLVM_CONFIG_BIN=$HOME/opt/llvm/${{ matrix.version }}/bin/llvm-config
         working-directory: build
       - name: Build
-        run: LD_LIBRARY_PATH=$(dirname $(find /opt/intel | grep libsvml.so)) cmake --build . --parallel 4
+        run: ${{ env.OPENCL_ENV }} cmake --build . --parallel 4
         working-directory: build
       - name: Build Tests
-        run: LD_LIBRARY_PATH=$(dirname $(find /opt/intel | grep libsvml.so)) OCL_ICD_VENDORS=$HOME/opt/pocl/4.0/etc/OpenCL/vendors/ CHIP_DEVICE_TYPE=cpu cmake --build . --parallel 4 --target build_tests
+        run: ${{ env.OPENCL_ENV }} CHIP_DEVICE_TYPE=cpu cmake --build . --parallel 4 --target build_tests
         working-directory: build
-      - name: Test Intel OpenCL
-        run: LD_LIBRARY_PATH=$(dirname $(find /opt/intel | grep libsvml.so)) OCL_ICD_FILENAMES=$(cat /etc/OpenCL/vendors/intel64.icd) CHIP_DEVICE_TYPE=cpu ctest --timeout 180 --output-on-failure -E "`cat ./test_lists/cpu_opencl_failed_tests.txt`"
-        working-directory: build
-      - name: Test pocl OpenCL
-        run: LD_LIBRARY_PATH=$(dirname $(find /opt/intel | grep libsvml.so)) OCL_ICD_VENDORS=$HOME/opt/pocl/4.0/etc/OpenCL/vendors/ CHIP_DEVICE_TYPE=cpu ctest --timeout 180 --output-on-failure -E "`cat ./test_lists/cpu_pocl_failed_tests.txt`"
+      - name: Test OpenCL
+        run: ${{ env.OPENCL_ENV }} CHIP_DEVICE_TYPE=cpu ctest --timeout 180 --output-on-failure -E ${{ env.EXCLUDE }}
         working-directory: build

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -247,3 +247,8 @@ jobs:
       - name: Test OpenCL
         run: ${{ env.OPENCL_ENV }} CHIP_DEVICE_TYPE=cpu ctest --timeout 180 --output-on-failure -E ${{ env.EXCLUDE }}
         working-directory: build
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: build-and-check-${{ matrix.backend }}-llvm-${{ matrix.version }}
+          path: build/Testing/Temporary/LastTest.log

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -169,7 +169,7 @@ jobs:
         if: steps.pocl.outputs.cache-hit != 'true'
       - run: mkdir -p pocl/build
         if: steps.pocl.outputs.cache-hit != 'true'
-      - run: cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/opt/pocl/4.0 -DCMAKE_BUILD_TYPE=Release -DWITH_LLVM_CONFIG=$HOME/opt/llvm/${{ matrix.version }}/bin/llvm-config -DENABLE_TESTS=OFF -DENABLE_EXAMPLES=OFF -DSTATIC_LLVM=ON
+      - run: cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/opt/pocl/4.0 -DCMAKE_BUILD_TYPE=Release -DWITH_LLVM_CONFIG=$HOME/opt/llvm/${{ matrix.version }}/bin/llvm-config -DENABLE_TESTS=OFF -DENABLE_EXAMPLES=OFF -DSTATIC_LLVM=ON -DKERNELLIB_HOST_CPU_VARIANTS=distro
         working-directory: pocl/build
         if: steps.pocl.outputs.cache-hit != 'true'
       - run: cmake --build . --parallel 4

--- a/scripts/get_sha.sh
+++ b/scripts/get_sha.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+url=$URL
+token=$TOKEN
+request=$(curl -s -u \"$token\" $url)
+restype=$(echo "$request" | jq .object.type | tr -d '"')
+if [ $restype = tag ]; then
+  url2=$(echo "$request" | jq .object.url | tr -d '"')
+  request=$(curl -s -u \"$token\" $url2)
+fi
+sha=$(echo "$request" | jq .object.sha  | tr -d '"')
+echo "sha=$sha"

--- a/scripts/unit_tests.sh
+++ b/scripts/unit_tests.sh
@@ -152,12 +152,12 @@ module unload opencl/dgpu
 echo "end dgpu_opencl_failed_tests"
 
 # Test OpenCL CPU
-echo "begin cpu_opencl_failed_tests"
-module load opencl/cpu
-module list
-ctest --timeout 180 -j 8 --output-on-failure -E "`cat ./test_lists/cpu_opencl_failed_tests.txt`" | tee cpu_opencl_make_check_result.txt
-module unload opencl/cpu
-echo "end cpu_opencl_failed_tests"
+# echo "begin cpu_opencl_failed_tests"
+# module load opencl/cpu
+# module list
+# ctest --timeout 180 -j 8 --output-on-failure -E "`cat ./test_lists/cpu_opencl_failed_tests.txt`" | tee cpu_opencl_make_check_result.txt
+# module unload opencl/cpu
+# echo "end cpu_opencl_failed_tests"
 
 function check_tests {
   file="$1"
@@ -186,9 +186,9 @@ function check_libceed {
 overall_status=0
 
 echo "RESULTS:"
-#  igpu_level0_make_check_result.txt
+# igpu_level0_make_check_result.txt
+# cpu_opencl_make_check_result.txt
 for test_result in dgpu_opencl_make_check_result.txt \
-                   cpu_opencl_make_check_result.txt \
                    dgpu_level0_reg_make_check_result.txt \
                    dgpu_level0_imm_make_check_result.txt
 do


### PR DESCRIPTION
This does a couple of things:
- Rebuild pocl on llvm changes
- Remove `tee` that was preventing tests from being reported as failed
- Add test of the Intel OpenCL CPU runtime