### PR TITLE
Sink first-touch work-around code into level zero BE

### DIFF
--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -262,7 +262,7 @@ public:
   void executeCommandListImm(std::shared_ptr<chipstar::Event> Event);
 
   ze_command_queue_handle_t getCmdQueue() { return ZeCmdQ_; }
-  void *getSharedBufffer() { return SharedBuf_; };
+  void *getSharedBufffer();
 
   virtual std::shared_ptr<chipstar::Event>
   memFillAsyncImpl(void *Dst, size_t Size, const void *Pattern,


### PR DESCRIPTION
The issue the first-touch code works around is not touched by OpenCL, therefore, sink the code into the level zero backend.

This patch is known to improve performance of HeCBench/extend2-hip 22% on Intel iGPU but not much on PVC.