### PR TITLE
Fix hipFuncSetCacheConfig() doesn't return hipSuccess

### DIFF
--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -1727,8 +1727,8 @@ hipError_t hipFuncSetCacheConfig(const void *Func, hipFuncCache_t Cfg) {
   CHIPInitialize();
   NULLCHECK(Func);
 
-  UNIMPLEMENTED(hipErrorNotSupported);
-  // RETURN(hipSuccess);
+  // 'Cfg' is ignored for now - API documentation allows it.
+  RETURN(hipSuccess);
 
   CHIP_CATCH
 }

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -84,3 +84,5 @@ add_hip_runtime_test(TestStructWithFnPtr.hip)
 add_hip_runtime_test(TestHipInit.hip)
 
 add_shell_test(TestRuntimeWarnings.bash)
+
+add_hip_runtime_test(TestAPIs.hip)

--- a/tests/runtime/TestAPIs.hip
+++ b/tests/runtime/TestAPIs.hip
@@ -1,0 +1,22 @@
+// Test various HIP API functions.
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <hip/hip_runtime.h>
+#include <cassert>
+
+__global__ void k() {}
+
+int main() {
+  // Non-conformant from C++ spec PoV. Not sure if HIP supports this.
+  auto *KPtr = reinterpret_cast<const void *>(k);
+
+  for (auto Cfg : {hipFuncCachePreferNone, hipFuncCachePreferShared,
+                   hipFuncCachePreferL1, hipFuncCachePreferEqual}) {
+    // Preferences should not return error code.
+    assert(hipFuncSetCacheConfig(KPtr, Cfg) == hipSuccess);
+    assert(hipFuncSetCacheConfig(nullptr, Cfg) != hipSuccess);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Make it return hipSuccess but ignore cache setting for now (API allows this).

Fixes #626.
