### PR TITLE
Link chipStar's LLVM pass plugin to LLVM

### DIFF
--- a/llvm_passes/CMakeLists.txt
+++ b/llvm_passes/CMakeLists.txt
@@ -101,6 +101,9 @@ add_library(LLVMHipPasses MODULE HipPasses.cpp
     HipLowerZeroLengthArrays.cpp HipSanityChecks.cpp HipLowerSwitch.cpp
     ${EXTRA_OBJS})
 
+target_link_libraries(LLVMHipPasses PRIVATE LLVM)
+target_link_options(LLVMHipPasses PRIVATE -Wl,--no-undefined)
+
 if("${LLVM_VERSION}" VERSION_GREATER_EQUAL 14.0)
   set_target_properties(LLVMHipPasses PROPERTIES
     # HIP-Clang 14+ automatically searches for libLLVMHipSpvPasses.so in


### PR DESCRIPTION
Additionally, ensure there is no undefined references while linking the plugin to LLVM (`--no-undefined`).

This attempts to fix issue seen in https://github.com/CHIP-SPV/chipStar/pull/570 where the plugin loaded by statically built opt tool does not provide the symbols needed by the plugin.