### PR TITLE
Additional mutexes 

### DIFF
--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -450,7 +450,6 @@ public:
  *
  */
 struct AllocationInfo {
-  // TODO make this into a class
   void *DevPtr;
   void *HostPtr;
   size_t Size;


### PR DESCRIPTION
OpenCL calls MemMap/MemUnmap. This results in queue operations inside hipMalloc, etc.

Also seems to decrease the unit test runtime from 17s to 1s which matches Level Zero performance. 

Fixes #657 

- [ ] Merge #682 