### PR TITLE
Use a fence for syncing RCL 

### DIFF
--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -244,8 +244,11 @@ protected:
   ze_command_list_desc_t CommandListDesc_;
   ze_command_queue_handle_t ZeCmdQ_;
   ze_command_list_handle_t ZeCmdListImm_;
+  ze_fence_desc_t ZeFenceDesc_ = {ZE_STRUCTURE_TYPE_FENCE_DESC, nullptr, 0};
+  ze_fence_handle_t ZeFence_;
 
   void initializeCmdListImm();
+  void initializeFence();
 
 public:
   void recordEvent(chipstar::Event *ChipEvent) override;


### PR DESCRIPTION
Fences are more fine-grained synchronization primitives offering potentially better performance since it allows other command lists to continue, as opposed to `zeCommandQueueSynchronize` which will hold the host until all work inside the queue is complete.

* Create a fence object for every L0 Queue
* `executeCmdListReg` will reset this fence and set it to trigger upon new invocation of command list execution.
* `Queue::finish()` will wait for this fence to signal. 
