### PR TITLE
Resurrect __bitinsert_u32, implement __bitinsert_u64

### DIFF
--- a/bitcode/devicelib.cl
+++ b/bitcode/devicelib.cl
@@ -181,11 +181,19 @@ EXPORT unsigned /* long */ long __bitextract_u64(unsigned /* long */ long src0,
   return width == 0 ? 0 : (src0 << (64 - offset - width)) >> (64 - width);
 }
 
-EXPORT unsigned int __bitinsert_u32(unsigned int src0, unsigned int src1,
-                                    unsigned int src2, unsigned int src3) {
-  unsigned long offset = src2 & 31;
-  unsigned long width = src3 & 31;
-  unsigned long mask = (1 << width) - 1;
+EXPORT unsigned int __chip_bitinsert_u32(uint src0, uint src1, uint raw_offset,
+                                         uint raw_width) {
+  uint offset = raw_offset & 31u;
+  uint width = raw_width & 31u;
+  uint mask = (1u << width) - 1u;
+  return ((src0 & ~(mask << offset)) | ((src1 & mask) << offset));
+}
+
+EXPORT ulong __chip_bitinsert_u64(ulong src0, ulong src1, ulong raw_offset,
+                                  ulong raw_width) {
+  ulong offset = raw_offset & 63ul;
+  ulong width = raw_width & 63ul;
+  ulong mask = (1ul << width) - 1ul;
   return ((src0 & ~(mask << offset)) | ((src1 & mask) << offset));
 }
 

--- a/cmake/UnitTests.cmake
+++ b/cmake/UnitTests.cmake
@@ -11,6 +11,47 @@ list(APPEND DGPU_LEVEL0_RCL_FAILED_TESTS " ")
 list(APPEND DGPU_LEVEL0_ICL_FAILED_TESTS " ") 
 list(APPEND CPU_POCL_FAILED_TESTS " ") 
 list(APPEND GPU_POCL_FAILED_TESTS " ")  # TODO
+list(APPEND NON_PARALLEL_TESTS " ")
+
+list(APPEND NON_PARALLEL_TESTS "clock")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemcpyWithStream_TestwithTwoStream")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemcpyWithStream_TestDtoDonSameDevice")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemcpy_H2H-H2D-D2H-H2PinMem - int")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemcpy_H2H-H2D-D2H-H2PinMem - float")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemcpy_H2H-H2D-D2H-H2PinMem - double")
+list(APPEND NON_PARALLEL_TESTS "broadcast2")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemsetFunctional_SmallSize_3D")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemcpy_KernelLaunch - int")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemcpy_KernelLaunch - float")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemcpy_KernelLaunch - double")
+list(APPEND NON_PARALLEL_TESTS "fp16")
+list(APPEND NON_PARALLEL_TESTS "SimpleConvolution")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipHostMalloc_Basic")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMalloc_LoopRegressionAllocFreeCycles")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMultiThreadStreams1_AsyncAsync")
+list(APPEND NON_PARALLEL_TESTS "cuda-scan")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemset3DAsync_ConcurrencyMthread")
+list(APPEND NON_PARALLEL_TESTS "cuda-bandwidthTest")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemsetAsync_QueueJobsMultithreaded")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemset2DAsync_MultiThread")
+list(APPEND NON_PARALLEL_TESTS "DCT")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemsetFunctional_ZeroSize_3D")
+list(APPEND NON_PARALLEL_TESTS "cuda-matrixMul")
+list(APPEND NON_PARALLEL_TESTS "cuda-FDTD3d")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMultiThreadStreams1_AsyncSync")
+list(APPEND NON_PARALLEL_TESTS "FastWalshTransform")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMultiStream_sameDevice")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipStreamCreate_MultistreamBasicFunctionalities")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemcpy_MultiThreadWithSerialization")
+list(APPEND NON_PARALLEL_TESTS "dwtHaar1D")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipHostRegister_Memcpy - int")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipHostRegister_Memcpy - float")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipHostRegister_Memcpy - double")
+list(APPEND NON_PARALLEL_TESTS "TestStlFunctionsDouble")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemset_SetMemoryWithOffset")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemsetAsync_SetMemoryWithOffset")
+list(APPEND NON_PARALLEL_TESTS "BitonicSort")
+list(APPEND NON_PARALLEL_TESTS "FloydWarshall")
 
 # This test gets enabled only if LLVM' FileCheck tool is found in PATH.
 # It fails with "error: cannot find ROCm device library;
@@ -731,6 +772,9 @@ list(APPEND IGPU_OPENCL_FAILED_TESTS "cuda-simpleCallback") # SEGFAULT
 list(APPEND IGPU_OPENCL_FAILED_TESTS "Unit_hipGraphMemcpyNodeSetParams_Functional") # Subprocess aborted
 
 # dGPU OpenCL Unit Test Failures
+list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipGraphEventRecordNodeSetEvent_SetEventProperty") # flaky
+list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipGraphAddEventRecordNode_Functional_ElapsedTime") # flaky
+list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipEventRecord") # flaky
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipMultiThreadStreams1_AsyncSame") # invalid free()
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipStreamPerThread_MultiThread") 
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipStreamPerThread_DeviceReset_1") 
@@ -2056,8 +2100,7 @@ string(REGEX REPLACE ";" "\$|" IGPU_LEVEL0_RCL_FAILED_TESTS_STR "${IGPU_LEVEL0_R
 string(REGEX REPLACE ";" "\$|" IGPU_LEVEL0_ICL_FAILED_TESTS_STR "${IGPU_LEVEL0_ICL_FAILED_TESTS}")
 string(REGEX REPLACE ";" "\$|"    CPU_POCL_FAILED_TESTS_STR "${CPU_POCL_FAILED_TESTS}")
 string(REGEX REPLACE ";" "\$|" ALL_FAILED_TESTS_STR "${ALL_FAILED_TESTS}")
-
-add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} ${TEST_OPTIONS} -E ${ALL_FAILED_TESTS_STR} VERBATIM)
+string(REGEX REPLACE ";" "\$|" NON_PARALLEL_TESTS_STR "${NON_PARALLEL_TESTS}")
 
 string(CONCAT DGPU_OPENCL_FAILED_TESTS_STR ${DGPU_OPENCL_FAILED_TESTS_STR} "\$|")
 string(CONCAT IGPU_OPENCL_FAILED_TESTS_STR ${IGPU_OPENCL_FAILED_TESTS_STR} "\$|")
@@ -2068,6 +2111,7 @@ string(CONCAT IGPU_LEVEL0_RCL_FAILED_TESTS_STR ${IGPU_LEVEL0_RCL_FAILED_TESTS_ST
 string(CONCAT IGPU_LEVEL0_ICL_FAILED_TESTS_STR ${IGPU_LEVEL0_ICL_FAILED_TESTS_STR} "\$|")
 string(CONCAT CPU_POCL_FAILED_TESTS_STR ${CPU_POCL_FAILED_TESTS_STR} "\$|")
 string(CONCAT ALL_FAILED_TESTS_STR ${ALL_FAILED_TESTS_STR} "\$|")
+string(CONCAT NON_PARALLEL_TESTS_STR ${NON_PARALLEL_TESTS_STR} "\$|")
 
 FILE(WRITE "${CMAKE_BINARY_DIR}/test_lists/dgpu_opencl_failed_tests.txt" "\"${DGPU_OPENCL_FAILED_TESTS_STR}\"")
 FILE(WRITE "${CMAKE_BINARY_DIR}/test_lists/igpu_opencl_failed_tests.txt" "\"${IGPU_OPENCL_FAILED_TESTS_STR}\"")
@@ -2078,14 +2122,4 @@ FILE(WRITE "${CMAKE_BINARY_DIR}/test_lists/igpu_level0_failed_reg_tests.txt" "\"
 FILE(WRITE "${CMAKE_BINARY_DIR}/test_lists/igpu_level0_failed_imm_tests.txt" "\"${IGPU_LEVEL0_ICL_FAILED_TESTS_STR}\"")
 FILE(WRITE "${CMAKE_BINARY_DIR}/test_lists/cpu_pocl_failed_tests.txt" "\"${CPU_POCL_FAILED_TESTS_STR}\"")
 FILE(WRITE "${CMAKE_BINARY_DIR}/test_lists/all_failed_tests.txt" "\"${ALL_FAILED_TESTS_STR}\"")
-
-# TODO fix-254 how do I make these read from the environment?
-# MULTI_TESTS_REPEAT=33 make multi_tests
-# Preferably without an additional reconfigure. Every way I tried escaping ${MULTI_TESTS_REPEAT} results in something undesirable like \${MULTI_TESTS_REPEAT}
-set(FLAKY_TESTS_REPEAT 100)
-set(MULTI_TESTS_REPEAT 10)
-set(PARALLEL_TESTS 1)
-
-set(TEST_OPTIONS -j ${PARALLEL_TESTS} --timeout 120 --output-on-failure)
-add_custom_target(flaky_tests COMMAND ${CMAKE_CTEST_COMMAND} ${TEST_OPTIONS} -R ${FLAKY_TESTS} --repeat until-fail:${FLAKY_TESTS_REPEAT} USES_TERMINAL VERBATIM)
-add_custom_target(multi_tests COMMAND ${CMAKE_CTEST_COMMAND} ${TEST_OPTIONS} -R "[Aa]sync|[Mm]ulti[Tt]hread|[Mm]ulti[Ss]tream|[Tt]hread|[Ss]tream" --repeat until-fail:${MULTI_TESTS_REPEAT} USES_TERMINAL VERBATIM)
+FILE(WRITE "${CMAKE_BINARY_DIR}/test_lists/non_parallel_tests.txt" "\"${NON_PARALLEL_TESTS_STR}\"")

--- a/include/hip/devicelib/integer/int_intrinsics.hh
+++ b/include/hip/devicelib/integer/int_intrinsics.hh
@@ -25,6 +25,35 @@
 
 #include <hip/devicelib/macros.hh>
 
+#ifdef CHIP_ENABLE_NON_COMPLIANT_DEVICELIB_CODE
+// __bitinsert_* intrinsics are not found in the HIP programming
+// manual but they are provided by hipamd.
+//
+// They replace a 'width' bits sized block in 'src0' staring at 'offset'
+// with least significant bits extracted from 'src1'.
+
+extern "C" __device__ unsigned int __chip_bitinsert_u32(unsigned int src0,
+                                                        unsigned int src1,
+                                                        unsigned int offset,
+                                                        unsigned int width);
+extern "C++" inline __device__ unsigned int
+__bitinsert_u32(unsigned int src0, unsigned int src1, unsigned int offset,
+                unsigned int width) {
+  return __chip_bitinsert_u32(src0, src1, offset, width);
+}
+
+extern "C" __device__ uint64_t __chip_bitinsert_u64(uint64_t src0,
+                                                    uint64_t src1,
+                                                    uint64_t offset,
+                                                    uint64_t width);
+extern "C++" inline __device__ uint64_t __bitinsert_u64(uint64_t src0,
+                                                        uint64_t src1,
+                                                        uint64_t offset,
+                                                        uint64_t width) {
+  return __chip_bitinsert_u64(src0, src1, offset, width);
+}
+#endif // CHIP_ENABLE_NON_COMPLIANT_DEVICELIB_CODE
+
 extern "C" __device__ unsigned int __chip_brev(unsigned int x); // Custom
 extern "C++" inline __device__ unsigned int __brev(unsigned int x) {
   return __chip_brev(x);

--- a/scripts/unit_tests.sh
+++ b/scripts/unit_tests.sh
@@ -36,7 +36,7 @@ shift
 
 # Set the number of tries based on the argument or default to 1
 num_tries=1
-num_threads=24
+num_threads=1
 timeout=200
 for arg in "$@"
 do

--- a/scripts/unit_tests.sh
+++ b/scripts/unit_tests.sh
@@ -36,7 +36,7 @@ shift
 
 # Set the number of tries based on the argument or default to 1
 num_tries=1
-num_threads=1
+num_threads=24
 timeout=200
 for arg in "$@"
 do
@@ -183,7 +183,7 @@ echo "end dgpu_level0_failed_imm_tests"
 echo "begin igpu_opencl_failed_tests"
 # module load opencl/igpu
 # module list
-../scripts/check.py ./ igpu opencl --num-threads=${num_threads} --timeout=$timeout --num-tries=$num_tries | tee igpu_opencl_make_check_result.txt
+../scripts/check.py ./ igpu opencl --num-threads=${num_threads} --timeout=$timeout --num-tries=$num_tries --categories | tee igpu_opencl_make_check_result.txt
 # ctest --timeout $timeout --repeat until-fail:${num_tries} $(ctest_j_option 4) --output-on-failure -E "`cat ./test_lists/igpu_opencl_failed_tests.txt`" | tee igpu_opencl_make_check_result.txt
 #pushd ${LIBCEED_DIR}
 #make FC= CC=clang CXX=clang++ BACKENDS="/gpu/hip/ref /gpu/hip/shared /gpu/hip/gen" prove --repeat until-fail:${num_tries} $(ctest_j_option 12) PROVE_OPS="-j" | tee igpu_opencl_make_check_result.txt
@@ -196,7 +196,7 @@ echo "begin dgpu_opencl_failed_tests"
 # module load intel/opencl # sets ICD
 # module load opencl/dgpu # sets CHIP_BE
 # module list
-../scripts/check.py ./ dgpu opencl --num-threads=${num_threads} --timeout=$timeout --num-tries=$num_tries | tee dgpu_opencl_make_check_result.txt
+../scripts/check.py ./ dgpu opencl --num-threads=${num_threads} --timeout=$timeout --num-tries=$num_tries --categories | tee dgpu_opencl_make_check_result.txt
 # ctest --timeout $timeout --repeat until-fail:${num_tries} $(ctest_j_option 8) --output-on-failure -E "`cat ./test_lists/dgpu_opencl_failed_tests.txt`" | tee dgpu_opencl_make_check_result.txt
 # pushd ${LIBCEED_DIR}
 # HIP_DIR=${CHIPSTAR_INSTALL_DIR} make FC= CC=clang CXX=clang++ BACKENDS="/gpu/hip/ref /gpu/hip/shared /gpu/hip/gen" prove --repeat until-fail:${num_tries} $(ctest_j_option 12) PROVE_OPS="-j" | tee dgpu_opencl_make_check_result.txt

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -88,3 +88,8 @@ add_shell_test(TestRuntimeWarnings.bash)
 add_hip_runtime_test(TestAPIs.hip)
 add_hip_runtime_test(TestMemFunctions.hip)
 add_hip_runtime_test(TestAlignAttrRuntime.hip)
+
+add_hip_runtime_test(TestBitInsert.hip)
+# Imports __bitinsert_*.
+target_compile_definitions(TestBitInsert
+  PRIVATE CHIP_ENABLE_NON_COMPLIANT_DEVICELIB_CODE)

--- a/tests/runtime/TestBitInsert.hip
+++ b/tests/runtime/TestBitInsert.hip
@@ -1,0 +1,37 @@
+#include <hip/hip_runtime.h>
+
+__global__ void bitInsert(unsigned *Dst, unsigned Src0, unsigned Src1,
+                          unsigned Offset, unsigned Width) {
+  *Dst = __bitinsert_u32(Src0, Src1, Offset, Width);
+}
+
+__global__ void bitInsert(uint64_t *Dst, uint64_t Src0, uint64_t Src1,
+                          uint64_t Offset, uint64_t Width) {
+  *Dst = __bitinsert_u64(Src0, Src1, Offset, Width);
+}
+
+int main() {
+  unsigned *Dst1D, Dst1H = 0;
+  uint64_t *Dst2D, Dst2H = 0;
+
+  (void)hipMalloc(&Dst1D, sizeof(unsigned));
+  (void)hipMalloc(&Dst2D, sizeof(uint64_t));
+
+  (void)bitInsert<<<1, 1>>>(Dst1D, 0xffff4321u, 0xffff8765ul,
+                            // Arguments + a garbage bit that should be ignored.
+                            16u + 32u, 16u + 32u);
+  hipMemcpy(&Dst1H, Dst1D, sizeof(unsigned), hipMemcpyDeviceToHost);
+  if (Dst1H != 0x87654321)
+    return 1;
+
+  (void)bitInsert<<<1, 1>>>(Dst2D, 0xffffffff44332211ul, 0xffffffff88776655ul,
+                            // Arguments + a garbage bit that should be ignored.
+                            32u + 64u, 32u + 64u);
+  (void)hipMemcpy(&Dst2H, Dst2D, sizeof(uint64_t), hipMemcpyDeviceToHost);
+  if (Dst2H != 0x8877665544332211ul)
+    return 2;
+
+  (void)hipFree(Dst1D);
+  (void)hipFree(Dst2D);
+  return 0;
+}


### PR DESCRIPTION
Note that they are made available by passing -DCHIP_ENABLE_NON_COMPLIANT_DEVICELIB_CODE to HIP compilation.
