### PR TITLE
Identify tests which timeout when run in parallel

### DIFF
--- a/cmake/UnitTests.cmake
+++ b/cmake/UnitTests.cmake
@@ -13,6 +13,7 @@ list(APPEND CPU_POCL_FAILED_TESTS " ")
 list(APPEND GPU_POCL_FAILED_TESTS " ")  # TODO
 list(APPEND NON_PARALLEL_TESTS " ")
 
+list(APPEND NON_PARALLEL_TESTS "clock")
 list(APPEND NON_PARALLEL_TESTS "Unit_hipMemcpyWithStream_TestwithTwoStream")
 list(APPEND NON_PARALLEL_TESTS "Unit_hipMemcpyWithStream_TestDtoDonSameDevice")
 list(APPEND NON_PARALLEL_TESTS "Unit_hipMemcpy_H2H-H2D-D2H-H2PinMem - int")

--- a/cmake/UnitTests.cmake
+++ b/cmake/UnitTests.cmake
@@ -11,6 +11,46 @@ list(APPEND DGPU_LEVEL0_RCL_FAILED_TESTS " ")
 list(APPEND DGPU_LEVEL0_ICL_FAILED_TESTS " ") 
 list(APPEND CPU_POCL_FAILED_TESTS " ") 
 list(APPEND GPU_POCL_FAILED_TESTS " ")  # TODO
+list(APPEND NON_PARALLEL_TESTS " ")
+
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemcpyWithStream_TestwithTwoStream")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemcpyWithStream_TestDtoDonSameDevice")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemcpy_H2H-H2D-D2H-H2PinMem - int")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemcpy_H2H-H2D-D2H-H2PinMem - float")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemcpy_H2H-H2D-D2H-H2PinMem - double")
+list(APPEND NON_PARALLEL_TESTS "broadcast2")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemsetFunctional_SmallSize_3D")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemcpy_KernelLaunch - int")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemcpy_KernelLaunch - float")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemcpy_KernelLaunch - double")
+list(APPEND NON_PARALLEL_TESTS "fp16")
+list(APPEND NON_PARALLEL_TESTS "SimpleConvolution")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipHostMalloc_Basic")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMalloc_LoopRegressionAllocFreeCycles")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMultiThreadStreams1_AsyncAsync")
+list(APPEND NON_PARALLEL_TESTS "cuda-scan")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemset3DAsync_ConcurrencyMthread")
+list(APPEND NON_PARALLEL_TESTS "cuda-bandwidthTest")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemsetAsync_QueueJobsMultithreaded")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemset2DAsync_MultiThread")
+list(APPEND NON_PARALLEL_TESTS "DCT")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemsetFunctional_ZeroSize_3D")
+list(APPEND NON_PARALLEL_TESTS "cuda-matrixMul")
+list(APPEND NON_PARALLEL_TESTS "cuda-FDTD3d")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMultiThreadStreams1_AsyncSync")
+list(APPEND NON_PARALLEL_TESTS "FastWalshTransform")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMultiStream_sameDevice")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipStreamCreate_MultistreamBasicFunctionalities")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemcpy_MultiThreadWithSerialization")
+list(APPEND NON_PARALLEL_TESTS "dwtHaar1D")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipHostRegister_Memcpy - int")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipHostRegister_Memcpy - float")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipHostRegister_Memcpy - double")
+list(APPEND NON_PARALLEL_TESTS "TestStlFunctionsDouble")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemset_SetMemoryWithOffset")
+list(APPEND NON_PARALLEL_TESTS "Unit_hipMemsetAsync_SetMemoryWithOffset")
+list(APPEND NON_PARALLEL_TESTS "BitonicSort")
+list(APPEND NON_PARALLEL_TESTS "FloydWarshall")
 
 # This test gets enabled only if LLVM' FileCheck tool is found in PATH.
 # It fails with "error: cannot find ROCm device library;
@@ -731,6 +771,9 @@ list(APPEND IGPU_OPENCL_FAILED_TESTS "cuda-simpleCallback") # SEGFAULT
 list(APPEND IGPU_OPENCL_FAILED_TESTS "Unit_hipGraphMemcpyNodeSetParams_Functional") # Subprocess aborted
 
 # dGPU OpenCL Unit Test Failures
+list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipGraphEventRecordNodeSetEvent_SetEventProperty") # flaky
+list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipGraphAddEventRecordNode_Functional_ElapsedTime") # flaky
+list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipEventRecord") # flaky
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipMultiThreadStreams1_AsyncSame") # invalid free()
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipStreamPerThread_MultiThread") 
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipStreamPerThread_DeviceReset_1") 
@@ -2056,8 +2099,7 @@ string(REGEX REPLACE ";" "\$|" IGPU_LEVEL0_RCL_FAILED_TESTS_STR "${IGPU_LEVEL0_R
 string(REGEX REPLACE ";" "\$|" IGPU_LEVEL0_ICL_FAILED_TESTS_STR "${IGPU_LEVEL0_ICL_FAILED_TESTS}")
 string(REGEX REPLACE ";" "\$|"    CPU_POCL_FAILED_TESTS_STR "${CPU_POCL_FAILED_TESTS}")
 string(REGEX REPLACE ";" "\$|" ALL_FAILED_TESTS_STR "${ALL_FAILED_TESTS}")
-
-add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} ${TEST_OPTIONS} -E ${ALL_FAILED_TESTS_STR} VERBATIM)
+string(REGEX REPLACE ";" "\$|" NON_PARALLEL_TESTS_STR "${NON_PARALLEL_TESTS}")
 
 string(CONCAT DGPU_OPENCL_FAILED_TESTS_STR ${DGPU_OPENCL_FAILED_TESTS_STR} "\$|")
 string(CONCAT IGPU_OPENCL_FAILED_TESTS_STR ${IGPU_OPENCL_FAILED_TESTS_STR} "\$|")
@@ -2068,6 +2110,7 @@ string(CONCAT IGPU_LEVEL0_RCL_FAILED_TESTS_STR ${IGPU_LEVEL0_RCL_FAILED_TESTS_ST
 string(CONCAT IGPU_LEVEL0_ICL_FAILED_TESTS_STR ${IGPU_LEVEL0_ICL_FAILED_TESTS_STR} "\$|")
 string(CONCAT CPU_POCL_FAILED_TESTS_STR ${CPU_POCL_FAILED_TESTS_STR} "\$|")
 string(CONCAT ALL_FAILED_TESTS_STR ${ALL_FAILED_TESTS_STR} "\$|")
+string(CONCAT NON_PARALLEL_TESTS_STR ${NON_PARALLEL_TESTS_STR} "\$|")
 
 FILE(WRITE "${CMAKE_BINARY_DIR}/test_lists/dgpu_opencl_failed_tests.txt" "\"${DGPU_OPENCL_FAILED_TESTS_STR}\"")
 FILE(WRITE "${CMAKE_BINARY_DIR}/test_lists/igpu_opencl_failed_tests.txt" "\"${IGPU_OPENCL_FAILED_TESTS_STR}\"")
@@ -2078,14 +2121,4 @@ FILE(WRITE "${CMAKE_BINARY_DIR}/test_lists/igpu_level0_failed_reg_tests.txt" "\"
 FILE(WRITE "${CMAKE_BINARY_DIR}/test_lists/igpu_level0_failed_imm_tests.txt" "\"${IGPU_LEVEL0_ICL_FAILED_TESTS_STR}\"")
 FILE(WRITE "${CMAKE_BINARY_DIR}/test_lists/cpu_pocl_failed_tests.txt" "\"${CPU_POCL_FAILED_TESTS_STR}\"")
 FILE(WRITE "${CMAKE_BINARY_DIR}/test_lists/all_failed_tests.txt" "\"${ALL_FAILED_TESTS_STR}\"")
-
-# TODO fix-254 how do I make these read from the environment?
-# MULTI_TESTS_REPEAT=33 make multi_tests
-# Preferably without an additional reconfigure. Every way I tried escaping ${MULTI_TESTS_REPEAT} results in something undesirable like \${MULTI_TESTS_REPEAT}
-set(FLAKY_TESTS_REPEAT 100)
-set(MULTI_TESTS_REPEAT 10)
-set(PARALLEL_TESTS 1)
-
-set(TEST_OPTIONS -j ${PARALLEL_TESTS} --timeout 120 --output-on-failure)
-add_custom_target(flaky_tests COMMAND ${CMAKE_CTEST_COMMAND} ${TEST_OPTIONS} -R ${FLAKY_TESTS} --repeat until-fail:${FLAKY_TESTS_REPEAT} USES_TERMINAL VERBATIM)
-add_custom_target(multi_tests COMMAND ${CMAKE_CTEST_COMMAND} ${TEST_OPTIONS} -R "[Aa]sync|[Mm]ulti[Tt]hread|[Mm]ulti[Ss]tream|[Tt]hread|[Ss]tream" --repeat until-fail:${MULTI_TESTS_REPEAT} USES_TERMINAL VERBATIM)
+FILE(WRITE "${CMAKE_BINARY_DIR}/test_lists/non_parallel_tests.txt" "\"${NON_PARALLEL_TESTS_STR}\"")

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -19,6 +19,7 @@ parser.add_argument('--timeout', type=int, nargs='?', default=200, help='Timeout
 parser.add_argument('-m', '--modules', type=str, choices=['on', 'off'], default="on", help='load modulefiles automatically (default: on)')
 parser.add_argument('-v', '--verbose', action='store_true', help='verbose output')
 parser.add_argument('-d', '--dry-run', '-N', action='store_true', help='dry run')
+parser.add_argument('-c', '--categories', action='store_true', help='run tests by categories, including running a set of tests in a single thread')
 
 args = parser.parse_args()
 
@@ -91,24 +92,33 @@ if not texture_support:
 else:
     texture_cmd = ""
 
-# clock failed
-cmd = f"{modules} {env_vars} ctest --output-on-failure --timeout {args.timeout} --repeat until-fail:{args.num_tries} -j {args.num_threads} -E \"`cat ./test_lists/{args.device_type}_{args.backend}_failed_{level0_cmd_list}tests.txt`{texture_cmd}\" -O checkpy_{args.device_type}_{args.backend}.txt"
-cmd_deviceFunc = f"{modules} {env_vars} ctest --output-on-failure --timeout {args.timeout} --repeat until-fail:{args.num_tries} -j 100 -E \"`cat ./test_lists/{args.device_type}_{args.backend}_failed_{level0_cmd_list}tests.txt`{texture_cmd}\" -R deviceFunc -O checkpy_{args.device_type}_{args.backend}_device.txt"
-cmd_graph = f"{modules} {env_vars} ctest --output-on-failure --timeout {args.timeout} --repeat until-fail:{args.num_tries} -j 100 -E \"`cat ./test_lists/{args.device_type}_{args.backend}_failed_{level0_cmd_list}tests.txt`{texture_cmd}\" -R \"[Gg]raph\" -O checkpy_{args.device_type}_{args.backend}_graph.txt"
-cmd_single = f"{modules} {env_vars} ctest --output-on-failure --timeout {args.timeout} --repeat until-fail:{args.num_tries} -j 1 -E \"`cat ./test_lists/{args.device_type}_{args.backend}_failed_{level0_cmd_list}tests.txt`{texture_cmd}\" -R \"`cat ./test_lists/non_parallel_tests.txt`\" -O checkpy_{args.device_type}_{args.backend}_single.txt"
-cmd_other = f"{modules} {env_vars} ctest --output-on-failure --timeout {args.timeout} --repeat until-fail:{args.num_tries} -j {args.num_threads} -E \"`cat ./test_lists/{args.device_type}_{args.backend}_failed_{level0_cmd_list}tests.txt`{texture_cmd}|deviceFunc|[Gg]raph|`cat ./test_lists/non_parallel_tests.txt`\" -O checkpy_{args.device_type}_{args.backend}_other.txt"
-if(args.dry_run):
-    print(cmd_deviceFunc)
-    print(cmd_graph)
-    print(cmd_single)
-    print(cmd_other)
-    exit(0)
-res_deviceFunc, err  = run_cmd(cmd_deviceFunc)
-res_graph, err = run_cmd(cmd_graph)
-res_single, err = run_cmd(cmd_single)
-res_other, err = run_cmd(cmd_other)
+if args.categories:
+  cmd_deviceFunc = f"{modules} {env_vars} ctest --output-on-failure --timeout {args.timeout} --repeat until-fail:{args.num_tries} -j 100 -E \"`cat ./test_lists/{args.device_type}_{args.backend}_failed_{level0_cmd_list}tests.txt`{texture_cmd}\" -R deviceFunc -O checkpy_{args.device_type}_{args.backend}_device.txt"
+  cmd_graph = f"{modules} {env_vars} ctest --output-on-failure --timeout {args.timeout} --repeat until-fail:{args.num_tries} -j 100 -E \"`cat ./test_lists/{args.device_type}_{args.backend}_failed_{level0_cmd_list}tests.txt`{texture_cmd}\" -R \"[Gg]raph\" -O checkpy_{args.device_type}_{args.backend}_graph.txt"
+  cmd_single = f"{modules} {env_vars} ctest --output-on-failure --timeout {args.timeout} --repeat until-fail:{args.num_tries} -j 1 -E \"`cat ./test_lists/{args.device_type}_{args.backend}_failed_{level0_cmd_list}tests.txt`{texture_cmd}\" -R \"`cat ./test_lists/non_parallel_tests.txt`\" -O checkpy_{args.device_type}_{args.backend}_single.txt"
+  cmd_other = f"{modules} {env_vars} ctest --output-on-failure --timeout {args.timeout} --repeat until-fail:{args.num_tries} -j {args.num_threads} -E \"`cat ./test_lists/{args.device_type}_{args.backend}_failed_{level0_cmd_list}tests.txt`{texture_cmd}|deviceFunc|[Gg]raph|`cat ./test_lists/non_parallel_tests.txt`\" -O checkpy_{args.device_type}_{args.backend}_other.txt"
+  if(args.dry_run):
+      print(cmd_deviceFunc)
+      print(cmd_graph)
+      print(cmd_single)
+      print(cmd_other)
+      exit(0)
+  res_deviceFunc, err  = run_cmd(cmd_deviceFunc)
+  res_graph, err = run_cmd(cmd_graph)
+  res_single, err = run_cmd(cmd_single)
+  res_other, err = run_cmd(cmd_other)
 
-if "0 tests failed" in res_deviceFunc and "0 tests failed" in res_graph and "0 tests failed" in res_single and "0 tests failed" in res_other:
-    exit(0)
+  if "0 tests failed" in res_deviceFunc and "0 tests failed" in res_graph and "0 tests failed" in res_single and "0 tests failed" in res_other:
+      exit(0)
+  else:
+      exit(1)
 else:
-    exit(1)
+  cmd = f"{modules} {env_vars} ctest --output-on-failure --timeout {args.timeout} --repeat until-fail:{args.num_tries} -j {args.num_threads} -E \"`cat ./test_lists/{args.device_type}_{args.backend}_failed_{level0_cmd_list}tests.txt`{texture_cmd}\" -O checkpy_{args.device_type}_{args.backend}.txt"
+  if(args.dry_run):
+    print(cmd)
+    exit(0)
+  res, err = run_cmd(cmd)
+  if "0 tests failed" in res:
+      exit(0)
+  else:
+      exit(1)

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -18,6 +18,7 @@ parser.add_argument('--num-tries', type=int, nargs='?', default=1, help='Number 
 parser.add_argument('--timeout', type=int, nargs='?', default=200, help='Timeout in seconds (default: 200)')
 parser.add_argument('-m', '--modules', type=str, choices=['on', 'off'], default="on", help='load modulefiles automatically (default: on)')
 parser.add_argument('-v', '--verbose', action='store_true', help='verbose output')
+parser.add_argument('-d', '--dry-run', '-N', action='store_true', help='dry run')
 
 args = parser.parse_args()
 
@@ -90,10 +91,24 @@ if not texture_support:
 else:
     texture_cmd = ""
 
-cmd = f"{modules} {env_vars} ctest --output-on-failure --timeout {args.timeout} --repeat until-fail:{args.num_tries} -j {args.num_threads} -E \"`cat ./test_lists/{args.device_type}_{args.backend}_failed_{level0_cmd_list}tests.txt`{texture_cmd}\"  -O checkpy_{args.device_type}_{args.backend}.txt"
-res, ctest_return_code = run_cmd(cmd)
-# check if "0 tests failed" is in the output, if so return 0
-if "0 tests failed" in res:
+# clock failed
+cmd = f"{modules} {env_vars} ctest --output-on-failure --timeout {args.timeout} --repeat until-fail:{args.num_tries} -j {args.num_threads} -E \"`cat ./test_lists/{args.device_type}_{args.backend}_failed_{level0_cmd_list}tests.txt`{texture_cmd}\" -O checkpy_{args.device_type}_{args.backend}.txt"
+cmd_deviceFunc = f"{modules} {env_vars} ctest --output-on-failure --timeout {args.timeout} --repeat until-fail:{args.num_tries} -j 100 -E \"`cat ./test_lists/{args.device_type}_{args.backend}_failed_{level0_cmd_list}tests.txt`{texture_cmd}\" -R deviceFunc -O checkpy_{args.device_type}_{args.backend}_device.txt"
+cmd_graph = f"{modules} {env_vars} ctest --output-on-failure --timeout {args.timeout} --repeat until-fail:{args.num_tries} -j 100 -E \"`cat ./test_lists/{args.device_type}_{args.backend}_failed_{level0_cmd_list}tests.txt`{texture_cmd}\" -R \"[Gg]raph\" -O checkpy_{args.device_type}_{args.backend}_graph.txt"
+cmd_single = f"{modules} {env_vars} ctest --output-on-failure --timeout {args.timeout} --repeat until-fail:{args.num_tries} -j 1 -E \"`cat ./test_lists/{args.device_type}_{args.backend}_failed_{level0_cmd_list}tests.txt`{texture_cmd}\" -R \"`cat ./test_lists/non_parallel_tests.txt`\" -O checkpy_{args.device_type}_{args.backend}_single.txt"
+cmd_other = f"{modules} {env_vars} ctest --output-on-failure --timeout {args.timeout} --repeat until-fail:{args.num_tries} -j {args.num_threads} -E \"`cat ./test_lists/{args.device_type}_{args.backend}_failed_{level0_cmd_list}tests.txt`{texture_cmd}|deviceFunc|[Gg]raph|`cat ./test_lists/non_parallel_tests.txt`\" -O checkpy_{args.device_type}_{args.backend}_other.txt"
+if(args.dry_run):
+    print(cmd_deviceFunc)
+    print(cmd_graph)
+    print(cmd_single)
+    print(cmd_other)
+    exit(0)
+res_deviceFunc, err  = run_cmd(cmd_deviceFunc)
+res_graph, err = run_cmd(cmd_graph)
+res_single, err = run_cmd(cmd_single)
+res_other, err = run_cmd(cmd_other)
+
+if "0 tests failed" in res_deviceFunc and "0 tests failed" in res_graph and "0 tests failed" in res_single and "0 tests failed" in res_other:
     exit(0)
 else:
-    exit(ctest_return_code)
+    exit(1)

--- a/scripts/unit_tests.sh
+++ b/scripts/unit_tests.sh
@@ -36,7 +36,7 @@ shift
 
 # Set the number of tries based on the argument or default to 1
 num_tries=1
-num_threads=1
+num_threads=24
 timeout=200
 for arg in "$@"
 do

--- a/scripts/unit_tests.sh
+++ b/scripts/unit_tests.sh
@@ -183,7 +183,7 @@ echo "end dgpu_level0_failed_imm_tests"
 echo "begin igpu_opencl_failed_tests"
 # module load opencl/igpu
 # module list
-../scripts/check.py ./ igpu opencl --num-threads=${num_threads} --timeout=$timeout --num-tries=$num_tries | tee igpu_opencl_make_check_result.txt
+../scripts/check.py ./ igpu opencl --num-threads=${num_threads} --timeout=$timeout --num-tries=$num_tries --categories | tee igpu_opencl_make_check_result.txt
 # ctest --timeout $timeout --repeat until-fail:${num_tries} $(ctest_j_option 4) --output-on-failure -E "`cat ./test_lists/igpu_opencl_failed_tests.txt`" | tee igpu_opencl_make_check_result.txt
 #pushd ${LIBCEED_DIR}
 #make FC= CC=clang CXX=clang++ BACKENDS="/gpu/hip/ref /gpu/hip/shared /gpu/hip/gen" prove --repeat until-fail:${num_tries} $(ctest_j_option 12) PROVE_OPS="-j" | tee igpu_opencl_make_check_result.txt
@@ -196,7 +196,7 @@ echo "begin dgpu_opencl_failed_tests"
 # module load intel/opencl # sets ICD
 # module load opencl/dgpu # sets CHIP_BE
 # module list
-../scripts/check.py ./ dgpu opencl --num-threads=${num_threads} --timeout=$timeout --num-tries=$num_tries | tee dgpu_opencl_make_check_result.txt
+../scripts/check.py ./ dgpu opencl --num-threads=${num_threads} --timeout=$timeout --num-tries=$num_tries --categories | tee dgpu_opencl_make_check_result.txt
 # ctest --timeout $timeout --repeat until-fail:${num_tries} $(ctest_j_option 8) --output-on-failure -E "`cat ./test_lists/dgpu_opencl_failed_tests.txt`" | tee dgpu_opencl_make_check_result.txt
 # pushd ${LIBCEED_DIR}
 # HIP_DIR=${CHIPSTAR_INSTALL_DIR} make FC= CC=clang CXX=clang++ BACKENDS="/gpu/hip/ref /gpu/hip/shared /gpu/hip/gen" prove --repeat until-fail:${num_tries} $(ctest_j_option 12) PROVE_OPS="-j" | tee dgpu_opencl_make_check_result.txt


### PR DESCRIPTION
* Exclude a couple of tests which were found to be flaky. 
* For OpenCL, there is a set of tests which sometimes timeout when tests are run parallel. Sometimes these tests explode in time taken to complete - from 15s to 1500s, for example. If you set `--repeat until-fail:10` it's almost guaranteed that some of them will timeout. 
* Most of these tests seem to involve managed memory. 
* hipEventRecord sometimes reports negative time for OpenCL

This needs to investigated, but for now let's just run these tests in a single thread to get the CI system to be more stable. 