### PR TITLE
Fix OpenCL Event memory leak

### DIFF
--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1986,8 +1986,7 @@ public:
    */
   virtual std::shared_ptr<chipstar::Event>
   createEventShared(chipstar::Context *ChipCtx,
-                    chipstar::EventFlags Flags = chipstar::EventFlags(),
-                    bool UserEvent = false) = 0;
+                    chipstar::EventFlags Flags = chipstar::EventFlags()) = 0;
 
   /**
    * @brief Create an unmanaged chipstar::Event.

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1986,7 +1986,7 @@ public:
    * @return chipstar::Event* chipstar::Event
    */
   virtual std::shared_ptr<chipstar::Event>
-  createCHIPEvent(chipstar::Context *ChipCtx,
+  createEventShared(chipstar::Context *ChipCtx,
                   chipstar::EventFlags Flags = chipstar::EventFlags(),
                   bool UserEvent = false) = 0;
   /**

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1976,19 +1976,29 @@ public:
   virtual chipstar::Queue *createCHIPQueue(chipstar::Device *ChipDev) = 0;
 
   /**
-   * @brief Create an chipstar::Event, adding it to the Backend chipstar::Event
-   * list.
+   * @brief Create a managed chipstar::Event, adding it to the Backend
+   * chipstar::Event list. These are managed events for internal chipstar use.
    *
    * @param ChipCtx Context in which to create the event in
    * @param Flags Events falgs
-   * @param UserEvent Is this a user event? If so, increase refcount to 2 to
-   * prevent it from being garbage collected.
-   * @return chipstar::Event* chipstar::Event
+   * @param UserEvent Is this a user event?
+   * @return std::shared_ptr<chipstar::Event>
    */
   virtual std::shared_ptr<chipstar::Event>
   createEventShared(chipstar::Context *ChipCtx,
-                  chipstar::EventFlags Flags = chipstar::EventFlags(),
-                  bool UserEvent = false) = 0;
+                    chipstar::EventFlags Flags = chipstar::EventFlags(),
+                    bool UserEvent = false) = 0;
+
+  /**
+   * @brief Create an unmanaged chipstar::Event.
+   *
+   * @param ChipCtx Context in which to create the event in
+   * @param Flags Events falgs
+   * @return chipstar::Event*
+   */
+  virtual chipstar::Event *
+  createEvent(chipstar::Context *ChipCtx,
+              chipstar::EventFlags Flags = chipstar::EventFlags()) = 0;
   /**
    * @brief Create a Callback Obj object
    * Each backend must implement this function which calls a derived

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2330,15 +2330,7 @@ hipError_t hipEventDestroy(hipEvent_t Event) {
   CHIP_TRY
   CHIPInitialize();
   NULLCHECK(Event);
-  chipstar::Event *ChipEvent = static_cast<chipstar::Event *>(Event);
-
-  LOCK(Backend->UserEventsMtx);
-  Backend->UserEvents.erase(
-      std::remove_if(Backend->UserEvents.begin(), Backend->UserEvents.end(),
-                     [&ChipEvent](const std::shared_ptr<chipstar::Event> &x) {
-                       return x.get() == ChipEvent;
-                     }),
-      Backend->UserEvents.end());
+  delete Event;
 
   RETURN(hipSuccess);
 

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2283,7 +2283,7 @@ static inline hipError_t hipEventCreateWithFlagsInternal(hipEvent_t *Event,
   chipstar::EventFlags EventFlags{Flags};
 
   auto ChipEvent =
-      Backend->createCHIPEvent(Backend->getActiveContext(), EventFlags, true);
+      Backend->createEventShared(Backend->getActiveContext(), EventFlags, true);
   {
     LOCK(Backend->UserEventsMtx);
     Backend->UserEvents.push_back(ChipEvent);

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2282,14 +2282,9 @@ static inline hipError_t hipEventCreateWithFlagsInternal(hipEvent_t *Event,
                                                          unsigned Flags) {
   chipstar::EventFlags EventFlags{Flags};
 
-  auto ChipEvent =
-      Backend->createEventShared(Backend->getActiveContext(), EventFlags, true);
-  {
-    LOCK(Backend->UserEventsMtx);
-    Backend->UserEvents.push_back(ChipEvent);
-  }
+  *Event =
+      Backend->createEvent(Backend->getActiveContext(), EventFlags);
 
-  *Event = ChipEvent.get();
   return hipSuccess;
 }
 

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1661,7 +1661,7 @@ chipstar::ExecItem *CHIPBackendLevel0::createExecItem(dim3 GirdDim,
 };
 
 std::shared_ptr<chipstar::Event> CHIPBackendLevel0::createEventShared(
-    chipstar::Context *ChipCtx, chipstar::EventFlags Flags, bool UserEvent) {
+    chipstar::Context *ChipCtx, chipstar::EventFlags Flags) {
   std::shared_ptr<chipstar::Event> Event;
 
   auto ZeCtx = (CHIPContextLevel0 *)ChipCtx;

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1663,14 +1663,9 @@ chipstar::ExecItem *CHIPBackendLevel0::createExecItem(dim3 GirdDim,
 std::shared_ptr<chipstar::Event> CHIPBackendLevel0::createEventShared(
     chipstar::Context *ChipCtx, chipstar::EventFlags Flags, bool UserEvent) {
   std::shared_ptr<chipstar::Event> Event;
-  if (UserEvent) {
-    Event = std::shared_ptr<chipstar::Event>(
-        new CHIPEventLevel0((CHIPContextLevel0 *)ChipCtx, Flags));
-    Event->setUserEvent(true);
-  } else {
-    auto ZeCtx = (CHIPContextLevel0 *)ChipCtx;
-    Event = ZeCtx->getEventFromPool();
-  }
+
+  auto ZeCtx = (CHIPContextLevel0 *)ChipCtx;
+  Event = ZeCtx->getEventFromPool();
 
   std::static_pointer_cast<CHIPEventLevel0>(Event)->reset();
   assert(!std::static_pointer_cast<CHIPEventLevel0>(Event)->getAssocCmdList());
@@ -1680,7 +1675,13 @@ std::shared_ptr<chipstar::Event> CHIPBackendLevel0::createEventShared(
 }
 
 chipstar::Event *CHIPBackendLevel0::createEvent(chipstar::Context *ChipCtx,
-                                                chipstar::EventFlags Flags) {}
+                                                chipstar::EventFlags Flags) {
+  auto Event = new CHIPEventLevel0((CHIPContextLevel0 *)ChipCtx, Flags);
+  Event->setUserEvent(true);
+  logDebug("CHIPBackendLevel0::createEventd: Context {} Event {}",
+           (void *)ChipCtx, (void *)Event);
+  return Event;
+}
 
 void CHIPBackendLevel0::uninitialize() {
   /**

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1335,7 +1335,8 @@ hipError_t CHIPQueueLevel0::getBackendHandles(uintptr_t *NativeInfo,
 std::shared_ptr<chipstar::Event> CHIPQueueLevel0::enqueueMarkerImpl() {
 
   std::shared_ptr<chipstar::Event> MarkerEvent =
-      static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(ChipContext_);
+      static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(
+          ChipContext_);
 
   MarkerEvent->Msg = "marker";
   LOCK(CommandListMtx);
@@ -1355,7 +1356,8 @@ std::shared_ptr<chipstar::Event> CHIPQueueLevel0::enqueueMarkerImpl() {
 std::shared_ptr<chipstar::Event> CHIPQueueLevel0::enqueueMarkerImplReg() {
   logError("CHIPQueueLevel0::enqueueMarkerImplReg");
   std::shared_ptr<chipstar::Event> MarkerEvent =
-      static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(ChipContext_);
+      static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(
+          ChipContext_);
 
   MarkerEvent->Msg = "marker";
 
@@ -1376,7 +1378,8 @@ std::shared_ptr<chipstar::Event> CHIPQueueLevel0::enqueueMarkerImplReg() {
 std::shared_ptr<chipstar::Event> CHIPQueueLevel0::enqueueBarrierImpl(
     const std::vector<std::shared_ptr<chipstar::Event>> &EventsToWaitFor) {
   std::shared_ptr<chipstar::Event> BarrierEvent =
-      static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(ChipContext_);
+      static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(
+          ChipContext_);
   BarrierEvent->Msg = "barrier";
   size_t NumEventsToWaitFor = 0;
 
@@ -1421,7 +1424,8 @@ std::shared_ptr<chipstar::Event> CHIPQueueLevel0::enqueueBarrierImplReg(
     const std::vector<std::shared_ptr<chipstar::Event>> &EventsToWaitFor) {
   logError("CHIPQueueLevel0::enqueueBarrierImplReg");
   std::shared_ptr<chipstar::Event> BarrierEvent =
-      static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(ChipContext_);
+      static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(
+          ChipContext_);
   BarrierEvent->Msg = "barrier";
   size_t NumEventsToWaitFor = 0;
 
@@ -1520,7 +1524,8 @@ void CHIPQueueLevel0::executeCommandList(
 void CHIPQueueLevel0::executeCommandListReg(
     ze_command_list_handle_t CommandList) {
   std::shared_ptr<chipstar::Event> LastCmdListEvent =
-      static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(ChipContext_);
+      static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(
+          ChipContext_);
   LastCmdListEvent->Msg = "CmdListFinishTracker";
 
   ze_result_t Status;
@@ -1655,9 +1660,8 @@ chipstar::ExecItem *CHIPBackendLevel0::createExecItem(dim3 GirdDim,
   return ExecItem;
 };
 
-std::shared_ptr<chipstar::Event>
-CHIPBackendLevel0::createEventShared(chipstar::Context *ChipCtx,
-                                   chipstar::EventFlags Flags, bool UserEvent) {
+std::shared_ptr<chipstar::Event> CHIPBackendLevel0::createEventShared(
+    chipstar::Context *ChipCtx, chipstar::EventFlags Flags, bool UserEvent) {
   std::shared_ptr<chipstar::Event> Event;
   if (UserEvent) {
     Event = std::shared_ptr<chipstar::Event>(
@@ -1674,6 +1678,9 @@ CHIPBackendLevel0::createEventShared(chipstar::Context *ChipCtx,
            (void *)ChipCtx, (void *)Event.get());
   return Event;
 }
+
+chipstar::Event *CHIPBackendLevel0::createEvent(chipstar::Context *ChipCtx,
+                                                chipstar::EventFlags Flags) {}
 
 void CHIPBackendLevel0::uninitialize() {
   /**

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -383,7 +383,7 @@ void CHIPQueueLevel0::recordEvent(chipstar::Event *ChipEvent) {
 
   // create an Event for making a dependency chain
   std::shared_ptr<chipstar::Event> TimestampWriteComplete =
-      Backend->createCHIPEvent(this->ChipContext_);
+      Backend->createEventShared(this->ChipContext_);
   auto TimestampWriteCompleteLz =
       std::static_pointer_cast<CHIPEventLevel0>(TimestampWriteComplete);
   auto TimestampWriteCompleteLzHandle = TimestampWriteCompleteLz->peek();
@@ -555,7 +555,7 @@ CHIPCallbackDataLevel0::CHIPCallbackDataLevel0(hipStreamCallback_t CallbackF,
   auto ChipContextLz =
       static_cast<CHIPContextLevel0 *>(ChipQueue->getContext());
 
-  CpuCallbackComplete = BackendLz->createCHIPEvent(ChipContextLz);
+  CpuCallbackComplete = BackendLz->createEventShared(ChipContextLz);
   CpuCallbackComplete->Msg = "CpuCallbackComplete";
 
   GpuReady = ChipQueueLz->enqueueBarrierImplReg(
@@ -1100,7 +1100,7 @@ std::shared_ptr<chipstar::Event>
 CHIPQueueLevel0::launchImpl(chipstar::ExecItem *ExecItem) {
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
   std::shared_ptr<chipstar::Event> LaunchEvent =
-      static_cast<CHIPBackendLevel0 *>(Backend)->createCHIPEvent(ChipCtxZe);
+      static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(ChipCtxZe);
 
   CHIPKernelLevel0 *ChipKernel = (CHIPKernelLevel0 *)ExecItem->getKernel();
   LaunchEvent->Msg = "launch " + ChipKernel->getName();
@@ -1167,7 +1167,7 @@ CHIPQueueLevel0::memFillAsyncImpl(void *Dst, size_t Size, const void *Pattern,
                                   size_t PatternSize) {
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
   std::shared_ptr<chipstar::Event> MemFillEvent =
-      static_cast<CHIPBackendLevel0 *>(Backend)->createCHIPEvent(ChipCtxZe);
+      static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(ChipCtxZe);
   MemFillEvent->Msg = "memFill";
 
   // Check that requested pattern is a power of 2
@@ -1214,7 +1214,7 @@ std::shared_ptr<chipstar::Event> CHIPQueueLevel0::memCopy3DAsyncImpl(
     size_t Sspitch, size_t Width, size_t Height, size_t Depth) {
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
   std::shared_ptr<chipstar::Event> MemCopyRegionEvent =
-      static_cast<CHIPBackendLevel0 *>(Backend)->createCHIPEvent(ChipCtxZe);
+      static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(ChipCtxZe);
   MemCopyRegionEvent->Msg = "memCopy3DAsync";
 
   ze_copy_region_t DstRegion;
@@ -1256,7 +1256,7 @@ CHIPQueueLevel0::memCopyToImage(ze_image_handle_t Image, const void *Src,
   logTrace("CHIPQueueLevel0::memCopyToImage");
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
   std::shared_ptr<chipstar::Event> ImageCopyEvent =
-      static_cast<CHIPBackendLevel0 *>(Backend)->createCHIPEvent(ChipCtxZe);
+      static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(ChipCtxZe);
   ImageCopyEvent->Msg = "memCopyToImage";
 
   if (!SrcRegion.isPitched()) {
@@ -1335,7 +1335,7 @@ hipError_t CHIPQueueLevel0::getBackendHandles(uintptr_t *NativeInfo,
 std::shared_ptr<chipstar::Event> CHIPQueueLevel0::enqueueMarkerImpl() {
 
   std::shared_ptr<chipstar::Event> MarkerEvent =
-      static_cast<CHIPBackendLevel0 *>(Backend)->createCHIPEvent(ChipContext_);
+      static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(ChipContext_);
 
   MarkerEvent->Msg = "marker";
   LOCK(CommandListMtx);
@@ -1355,7 +1355,7 @@ std::shared_ptr<chipstar::Event> CHIPQueueLevel0::enqueueMarkerImpl() {
 std::shared_ptr<chipstar::Event> CHIPQueueLevel0::enqueueMarkerImplReg() {
   logError("CHIPQueueLevel0::enqueueMarkerImplReg");
   std::shared_ptr<chipstar::Event> MarkerEvent =
-      static_cast<CHIPBackendLevel0 *>(Backend)->createCHIPEvent(ChipContext_);
+      static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(ChipContext_);
 
   MarkerEvent->Msg = "marker";
 
@@ -1376,7 +1376,7 @@ std::shared_ptr<chipstar::Event> CHIPQueueLevel0::enqueueMarkerImplReg() {
 std::shared_ptr<chipstar::Event> CHIPQueueLevel0::enqueueBarrierImpl(
     const std::vector<std::shared_ptr<chipstar::Event>> &EventsToWaitFor) {
   std::shared_ptr<chipstar::Event> BarrierEvent =
-      static_cast<CHIPBackendLevel0 *>(Backend)->createCHIPEvent(ChipContext_);
+      static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(ChipContext_);
   BarrierEvent->Msg = "barrier";
   size_t NumEventsToWaitFor = 0;
 
@@ -1421,7 +1421,7 @@ std::shared_ptr<chipstar::Event> CHIPQueueLevel0::enqueueBarrierImplReg(
     const std::vector<std::shared_ptr<chipstar::Event>> &EventsToWaitFor) {
   logError("CHIPQueueLevel0::enqueueBarrierImplReg");
   std::shared_ptr<chipstar::Event> BarrierEvent =
-      static_cast<CHIPBackendLevel0 *>(Backend)->createCHIPEvent(ChipContext_);
+      static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(ChipContext_);
   BarrierEvent->Msg = "barrier";
   size_t NumEventsToWaitFor = 0;
 
@@ -1467,7 +1467,7 @@ CHIPQueueLevel0::memCopyAsyncImpl(void *Dst, const void *Src, size_t Size) {
   logTrace("CHIPQueueLevel0::memCopyAsync");
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
   std::shared_ptr<chipstar::Event> MemCopyEvent =
-      static_cast<CHIPBackendLevel0 *>(Backend)->createCHIPEvent(ChipCtxZe);
+      static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(ChipCtxZe);
   ze_result_t Status;
   LOCK(CommandListMtx);
   ze_command_list_handle_t CommandList = this->getCmdList();
@@ -1520,7 +1520,7 @@ void CHIPQueueLevel0::executeCommandList(
 void CHIPQueueLevel0::executeCommandListReg(
     ze_command_list_handle_t CommandList) {
   std::shared_ptr<chipstar::Event> LastCmdListEvent =
-      static_cast<CHIPBackendLevel0 *>(Backend)->createCHIPEvent(ChipContext_);
+      static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(ChipContext_);
   LastCmdListEvent->Msg = "CmdListFinishTracker";
 
   ze_result_t Status;
@@ -1656,7 +1656,7 @@ chipstar::ExecItem *CHIPBackendLevel0::createExecItem(dim3 GirdDim,
 };
 
 std::shared_ptr<chipstar::Event>
-CHIPBackendLevel0::createCHIPEvent(chipstar::Context *ChipCtx,
+CHIPBackendLevel0::createEventShared(chipstar::Context *ChipCtx,
                                    chipstar::EventFlags Flags, bool UserEvent) {
   std::shared_ptr<chipstar::Event> Event;
   if (UserEvent) {
@@ -1670,7 +1670,7 @@ CHIPBackendLevel0::createCHIPEvent(chipstar::Context *ChipCtx,
 
   std::static_pointer_cast<CHIPEventLevel0>(Event)->reset();
   assert(!std::static_pointer_cast<CHIPEventLevel0>(Event)->getAssocCmdList());
-  logDebug("CHIPBackendLevel0::createCHIPEvent: Context {} Event {}",
+  logDebug("CHIPBackendLevel0::createEventShared: Context {} Event {}",
            (void *)ChipCtx, (void *)Event.get());
   return Event;
 }

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -656,7 +656,7 @@ public:
   }
 
   virtual std::shared_ptr<chipstar::Event>
-  createCHIPEvent(chipstar::Context *ChipCtx,
+  createEventShared(chipstar::Context *ChipCtx,
                   chipstar::EventFlags Flags = chipstar::EventFlags(),
                   bool UserEvent = false) override;
 

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -655,10 +655,9 @@ public:
     return Q;
   }
 
-  virtual std::shared_ptr<chipstar::Event>
-  createEventShared(chipstar::Context *ChipCtx,
-                    chipstar::EventFlags Flags = chipstar::EventFlags(),
-                    bool UserEvent = false) override;
+  virtual std::shared_ptr<chipstar::Event> createEventShared(
+      chipstar::Context *ChipCtx,
+      chipstar::EventFlags Flags = chipstar::EventFlags()) override;
 
   virtual chipstar::Event *
   createEvent(chipstar::Context *ChipCtx,

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -657,8 +657,12 @@ public:
 
   virtual std::shared_ptr<chipstar::Event>
   createEventShared(chipstar::Context *ChipCtx,
-                  chipstar::EventFlags Flags = chipstar::EventFlags(),
-                  bool UserEvent = false) override;
+                    chipstar::EventFlags Flags = chipstar::EventFlags(),
+                    bool UserEvent = false) override;
+
+  virtual chipstar::Event *
+  createEvent(chipstar::Context *ChipCtx,
+              chipstar::EventFlags Flags = chipstar::EventFlags()) override;
 
   virtual chipstar::CallbackData *
   createCallbackData(hipStreamCallback_t Callback, void *UserData,

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -549,16 +549,13 @@ void CHIPDeviceOpenCL::resetImpl() { UNIMPLEMENTED(); }
 // ************************************************************************
 
 CHIPEventOpenCL::CHIPEventOpenCL(CHIPContextOpenCL *ChipContext,
-                                 cl_event ClEvent, chipstar::EventFlags Flags,
-                                 bool UserEvent)
+                                 cl_event ClEvent, chipstar::EventFlags Flags)
     : chipstar::Event((chipstar::Context *)(ChipContext), Flags),
-      ClEvent(ClEvent) {
-  UserEvent_ = UserEvent;
-}
+      ClEvent(ClEvent) {}
 
 CHIPEventOpenCL::CHIPEventOpenCL(CHIPContextOpenCL *ChipContext,
                                  chipstar::EventFlags Flags)
-    : CHIPEventOpenCL(ChipContext, nullptr, Flags, false) {}
+    : CHIPEventOpenCL(ChipContext, nullptr, Flags) {}
 
 uint64_t CHIPEventOpenCL::getFinishTime() {
   int Status;
@@ -593,7 +590,7 @@ std::shared_ptr<chipstar::Event>
 CHIPBackendOpenCL::createEventShared(chipstar::Context *ChipCtx,
                                      chipstar::EventFlags Flags) {
   CHIPEventOpenCL *Event =
-      new CHIPEventOpenCL((CHIPContextOpenCL *)ChipCtx, nullptr, Flags, false);
+      new CHIPEventOpenCL((CHIPContextOpenCL *)ChipCtx, nullptr, Flags);
 
   return std::shared_ptr<chipstar::Event>(Event);
 }
@@ -601,7 +598,8 @@ CHIPBackendOpenCL::createEventShared(chipstar::Context *ChipCtx,
 chipstar::Event *CHIPBackendOpenCL::createEvent(chipstar::Context *ChipCtx,
                                                 chipstar::EventFlags Flags) {
   CHIPEventOpenCL *Event =
-      new CHIPEventOpenCL((CHIPContextOpenCL *)ChipCtx, nullptr, Flags, true);
+      new CHIPEventOpenCL((CHIPContextOpenCL *)ChipCtx, nullptr, Flags);
+  Event->setUserEvent(true);
   return Event;
 }
 

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -589,10 +589,11 @@ CHIPEventOpenCL::~CHIPEventOpenCL() {
     clReleaseEvent(ClEvent);
 }
 
-std::shared_ptr<chipstar::Event> CHIPBackendOpenCL::createEventShared(
-    chipstar::Context *ChipCtx, chipstar::EventFlags Flags, bool UserEvent) {
-  CHIPEventOpenCL *Event = new CHIPEventOpenCL((CHIPContextOpenCL *)ChipCtx,
-                                               nullptr, Flags, UserEvent);
+std::shared_ptr<chipstar::Event>
+CHIPBackendOpenCL::createEventShared(chipstar::Context *ChipCtx,
+                                     chipstar::EventFlags Flags) {
+  CHIPEventOpenCL *Event =
+      new CHIPEventOpenCL((CHIPContextOpenCL *)ChipCtx, nullptr, Flags, false);
 
   return std::shared_ptr<chipstar::Event>(Event);
 }

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -595,7 +595,11 @@ std::shared_ptr<chipstar::Event> CHIPBackendOpenCL::createEventShared(
 }
 
 chipstar::Event *CHIPBackendOpenCL::createEvent(chipstar::Context *ChipCtx,
-                                                chipstar::EventFlags Flags) {}
+                                                chipstar::EventFlags Flags) {
+  CHIPEventOpenCL *Event =
+      new CHIPEventOpenCL((CHIPContextOpenCL *)ChipCtx, nullptr, Flags, true);
+  return Event;
+}
 
 void CHIPQueueOpenCL::recordEvent(chipstar::Event *ChipEvent) {
   logTrace("chipstar::Queue::recordEvent({})", (void *)ChipEvent);

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -587,7 +587,7 @@ size_t CHIPEventOpenCL::getRefCount() {
 CHIPEventOpenCL::~CHIPEventOpenCL() { ClEvent = nullptr; }
 
 std::shared_ptr<chipstar::Event>
-CHIPBackendOpenCL::createCHIPEvent(chipstar::Context *ChipCtx,
+CHIPBackendOpenCL::createEventShared(chipstar::Context *ChipCtx,
                                    chipstar::EventFlags Flags, bool UserEvent) {
   CHIPEventOpenCL *Event = new CHIPEventOpenCL((CHIPContextOpenCL *)ChipCtx,
                                                nullptr, Flags, UserEvent);
@@ -965,7 +965,7 @@ void CHIPQueueOpenCL::MemMap(const chipstar::AllocationInfo *AllocInfo,
   }
 
   auto MemMapEvent =
-      static_cast<CHIPBackendOpenCL *>(Backend)->createCHIPEvent(ChipContext_);
+      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(ChipContext_);
   auto MemMapEventNative =
       std::static_pointer_cast<CHIPEventOpenCL>(MemMapEvent)->getNativePtr();
 
@@ -998,7 +998,7 @@ void CHIPQueueOpenCL::MemMap(const chipstar::AllocationInfo *AllocInfo,
 
 void CHIPQueueOpenCL::MemUnmap(const chipstar::AllocationInfo *AllocInfo) {
   auto MemMapEvent =
-      static_cast<CHIPBackendOpenCL *>(Backend)->createCHIPEvent(ChipContext_);
+      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(ChipContext_);
   CHIPContextOpenCL *C = static_cast<CHIPContextOpenCL *>(ChipContext_);
   if (C->allDevicesSupportFineGrainSVMorUSM()) {
     logDebug("Device supports fine grain SVM or USM. Skipping MemMap/Unmap");
@@ -1024,7 +1024,7 @@ void CHIPQueueOpenCL::addCallback(hipStreamCallback_t Callback,
   cl_int Err;
 
   std::shared_ptr<chipstar::Event> HoldBackEvent =
-      static_cast<CHIPBackendOpenCL *>(Backend)->createCHIPEvent(ChipContext_);
+      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(ChipContext_);
 
   std::static_pointer_cast<CHIPEventOpenCL>(HoldBackEvent)->ClEvent =
       clCreateUserEvent(ClContext_->get(), &Err);
@@ -1045,7 +1045,7 @@ void CHIPQueueOpenCL::addCallback(hipStreamCallback_t Callback,
   // guarantees. We need to enforce CUDA ordering using user events.
 
   std::shared_ptr<chipstar::Event> CallbackEvent =
-      static_cast<CHIPBackendOpenCL *>(Backend)->createCHIPEvent(ChipContext_);
+      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(ChipContext_);
 
   std::static_pointer_cast<CHIPEventOpenCL>(CallbackEvent)->ClEvent =
       clCreateUserEvent(ClContext_->get(), &Err);
@@ -1083,7 +1083,7 @@ void CHIPQueueOpenCL::addCallback(hipStreamCallback_t Callback,
 
 std::shared_ptr<chipstar::Event> CHIPQueueOpenCL::enqueueMarkerImpl() {
   std::shared_ptr<chipstar::Event> MarkerEvent =
-      static_cast<CHIPBackendOpenCL *>(Backend)->createCHIPEvent(ChipContext_);
+      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(ChipContext_);
 
   auto SyncQueuesEventHandles = getSyncQueuesEventHandles();
   auto Status = clEnqueueMarkerWithWaitList(
@@ -1101,7 +1101,7 @@ CHIPQueueOpenCL::launchImpl(chipstar::ExecItem *ExecItem) {
   logTrace("CHIPQueueOpenCL->launch()");
   auto *OclContext = static_cast<CHIPContextOpenCL *>(ChipContext_);
   std::shared_ptr<chipstar::Event>(LaunchEvent) =
-      static_cast<CHIPBackendOpenCL *>(Backend)->createCHIPEvent(OclContext);
+      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(OclContext);
   CHIPExecItemOpenCL *ChipOclExecItem = (CHIPExecItemOpenCL *)ExecItem;
   CHIPKernelOpenCL *Kernel = (CHIPKernelOpenCL *)ChipOclExecItem->getKernel();
   assert(Kernel && "Kernel in chipstar::ExecItem is NULL!");
@@ -1220,7 +1220,7 @@ CHIPQueueOpenCL::~CHIPQueueOpenCL() {
 std::shared_ptr<chipstar::Event>
 CHIPQueueOpenCL::memCopyAsyncImpl(void *Dst, const void *Src, size_t Size) {
   std::shared_ptr<chipstar::Event> Event =
-      static_cast<CHIPBackendOpenCL *>(Backend)->createCHIPEvent(ChipContext_);
+      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(ChipContext_);
   logTrace("clSVMmemcpy {} -> {} / {} B\n", Src, Dst, Size);
   if (Dst == Src) {
     // Although ROCm API ref says that Dst and Src should not overlap,
@@ -1263,7 +1263,7 @@ std::shared_ptr<chipstar::Event>
 CHIPQueueOpenCL::memFillAsyncImpl(void *Dst, size_t Size, const void *Pattern,
                                   size_t PatternSize) {
   std::shared_ptr<chipstar::Event> Event =
-      static_cast<CHIPBackendOpenCL *>(Backend)->createCHIPEvent(ChipContext_);
+      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(ChipContext_);
   logTrace("clSVMmemfill {} / {} B\n", Dst, Size);
   auto SyncQueuesEventHandles = getSyncQueuesEventHandles();
   int Retval = ::clEnqueueSVMMemFill(
@@ -1338,7 +1338,7 @@ std::shared_ptr<chipstar::Event> CHIPQueueOpenCL::enqueueBarrierImpl(
   LOCK(Backend->DubiousLockOpenCL)
 #endif
   std::shared_ptr<chipstar::Event> Event =
-      static_cast<CHIPBackendOpenCL *>(Backend)->createCHIPEvent(
+      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(
           this->ChipContext_);
   cl_int RefCount;
   clGetEventInfo(

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -584,10 +584,10 @@ size_t CHIPEventOpenCL::getRefCount() {
   return RefCount;
 }
 
-CHIPEventOpenCL::~CHIPEventOpenCL() { 
-  if(ClEvent)
+CHIPEventOpenCL::~CHIPEventOpenCL() {
+  if (ClEvent)
     clReleaseEvent(ClEvent);
-  }
+}
 
 std::shared_ptr<chipstar::Event> CHIPBackendOpenCL::createEventShared(
     chipstar::Context *ChipCtx, chipstar::EventFlags Flags, bool UserEvent) {
@@ -609,20 +609,17 @@ void CHIPQueueOpenCL::recordEvent(chipstar::Event *ChipEvent) {
   auto ChipEventCL = static_cast<CHIPEventOpenCL *>(ChipEvent);
 
   std::shared_ptr<chipstar::Event> LastEvent = getLastEvent();
-  ChipEventCL->takeOver(LastEvent ? LastEvent : enqueueMarker());
+  ChipEventCL->recordEventCopy(LastEvent ? LastEvent : enqueueMarker());
   ChipEventCL->setRecording();
 }
 
-void CHIPEventOpenCL::takeOver(
+void CHIPEventOpenCL::recordEventCopy(
     const std::shared_ptr<chipstar::Event> &OtherIn) {
-  logTrace("CHIPEventOpenCL::takeOver");
-  {
-    std::shared_ptr<CHIPEventOpenCL> Other =
-        std::static_pointer_cast<CHIPEventOpenCL>(OtherIn);
-    LOCK(EventMtx); // chipstar::Event::Refc_
-    this->ClEvent = Other->ClEvent;
-    this->Msg = Other->Msg;
-  }
+  logTrace("CHIPEventOpenCL::recordEventCopy");
+  std::shared_ptr<CHIPEventOpenCL> Other =
+      std::static_pointer_cast<CHIPEventOpenCL>(OtherIn);
+  this->ClEvent = Other->ClEvent;
+  this->Msg = "recordEventCopy: " + Other->Msg;
 }
 
 bool CHIPEventOpenCL::wait() {

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -584,7 +584,10 @@ size_t CHIPEventOpenCL::getRefCount() {
   return RefCount;
 }
 
-CHIPEventOpenCL::~CHIPEventOpenCL() { ClEvent = nullptr; }
+CHIPEventOpenCL::~CHIPEventOpenCL() { 
+  if(ClEvent)
+    clReleaseEvent(ClEvent);
+  }
 
 std::shared_ptr<chipstar::Event> CHIPBackendOpenCL::createEventShared(
     chipstar::Context *ChipCtx, chipstar::EventFlags Flags, bool UserEvent) {

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -586,14 +586,16 @@ size_t CHIPEventOpenCL::getRefCount() {
 
 CHIPEventOpenCL::~CHIPEventOpenCL() { ClEvent = nullptr; }
 
-std::shared_ptr<chipstar::Event>
-CHIPBackendOpenCL::createEventShared(chipstar::Context *ChipCtx,
-                                   chipstar::EventFlags Flags, bool UserEvent) {
+std::shared_ptr<chipstar::Event> CHIPBackendOpenCL::createEventShared(
+    chipstar::Context *ChipCtx, chipstar::EventFlags Flags, bool UserEvent) {
   CHIPEventOpenCL *Event = new CHIPEventOpenCL((CHIPContextOpenCL *)ChipCtx,
                                                nullptr, Flags, UserEvent);
 
   return std::shared_ptr<chipstar::Event>(Event);
 }
+
+chipstar::Event *CHIPBackendOpenCL::createEvent(chipstar::Context *ChipCtx,
+                                                chipstar::EventFlags Flags) {}
 
 void CHIPQueueOpenCL::recordEvent(chipstar::Event *ChipEvent) {
   logTrace("chipstar::Queue::recordEvent({})", (void *)ChipEvent);
@@ -965,7 +967,8 @@ void CHIPQueueOpenCL::MemMap(const chipstar::AllocationInfo *AllocInfo,
   }
 
   auto MemMapEvent =
-      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(ChipContext_);
+      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(
+          ChipContext_);
   auto MemMapEventNative =
       std::static_pointer_cast<CHIPEventOpenCL>(MemMapEvent)->getNativePtr();
 
@@ -998,7 +1001,8 @@ void CHIPQueueOpenCL::MemMap(const chipstar::AllocationInfo *AllocInfo,
 
 void CHIPQueueOpenCL::MemUnmap(const chipstar::AllocationInfo *AllocInfo) {
   auto MemMapEvent =
-      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(ChipContext_);
+      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(
+          ChipContext_);
   CHIPContextOpenCL *C = static_cast<CHIPContextOpenCL *>(ChipContext_);
   if (C->allDevicesSupportFineGrainSVMorUSM()) {
     logDebug("Device supports fine grain SVM or USM. Skipping MemMap/Unmap");
@@ -1024,7 +1028,8 @@ void CHIPQueueOpenCL::addCallback(hipStreamCallback_t Callback,
   cl_int Err;
 
   std::shared_ptr<chipstar::Event> HoldBackEvent =
-      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(ChipContext_);
+      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(
+          ChipContext_);
 
   std::static_pointer_cast<CHIPEventOpenCL>(HoldBackEvent)->ClEvent =
       clCreateUserEvent(ClContext_->get(), &Err);
@@ -1045,7 +1050,8 @@ void CHIPQueueOpenCL::addCallback(hipStreamCallback_t Callback,
   // guarantees. We need to enforce CUDA ordering using user events.
 
   std::shared_ptr<chipstar::Event> CallbackEvent =
-      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(ChipContext_);
+      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(
+          ChipContext_);
 
   std::static_pointer_cast<CHIPEventOpenCL>(CallbackEvent)->ClEvent =
       clCreateUserEvent(ClContext_->get(), &Err);
@@ -1083,7 +1089,8 @@ void CHIPQueueOpenCL::addCallback(hipStreamCallback_t Callback,
 
 std::shared_ptr<chipstar::Event> CHIPQueueOpenCL::enqueueMarkerImpl() {
   std::shared_ptr<chipstar::Event> MarkerEvent =
-      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(ChipContext_);
+      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(
+          ChipContext_);
 
   auto SyncQueuesEventHandles = getSyncQueuesEventHandles();
   auto Status = clEnqueueMarkerWithWaitList(
@@ -1220,7 +1227,8 @@ CHIPQueueOpenCL::~CHIPQueueOpenCL() {
 std::shared_ptr<chipstar::Event>
 CHIPQueueOpenCL::memCopyAsyncImpl(void *Dst, const void *Src, size_t Size) {
   std::shared_ptr<chipstar::Event> Event =
-      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(ChipContext_);
+      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(
+          ChipContext_);
   logTrace("clSVMmemcpy {} -> {} / {} B\n", Src, Dst, Size);
   if (Dst == Src) {
     // Although ROCm API ref says that Dst and Src should not overlap,
@@ -1263,7 +1271,8 @@ std::shared_ptr<chipstar::Event>
 CHIPQueueOpenCL::memFillAsyncImpl(void *Dst, size_t Size, const void *Pattern,
                                   size_t PatternSize) {
   std::shared_ptr<chipstar::Event> Event =
-      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(ChipContext_);
+      static_cast<CHIPBackendOpenCL *>(Backend)->createEventShared(
+          ChipContext_);
   logTrace("clSVMmemfill {} / {} B\n", Dst, Size);
   auto SyncQueuesEventHandles = getSyncQueuesEventHandles();
   int Retval = ::clEnqueueSVMMemFill(

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -368,10 +368,9 @@ public:
   virtual int ReqNumHandles() override { return 4; }
 
   virtual chipstar::Queue *createCHIPQueue(chipstar::Device *ChipDev) override;
-  virtual std::shared_ptr<chipstar::Event>
-  createEventShared(chipstar::Context *ChipCtx,
-                    chipstar::EventFlags Flags = chipstar::EventFlags(),
-                    bool UserEvent = false) override;
+  virtual std::shared_ptr<chipstar::Event> createEventShared(
+      chipstar::Context *ChipCtx,
+      chipstar::EventFlags Flags = chipstar::EventFlags()) override;
   virtual chipstar::Event *
   createEvent(chipstar::Context *ChipCtx,
               chipstar::EventFlags Flags = chipstar::EventFlags()) override;

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -96,7 +96,7 @@ public:
                   chipstar::EventFlags Flags = chipstar::EventFlags());
   virtual ~CHIPEventOpenCL() override;
 
-  void takeOver(const std::shared_ptr<chipstar::Event> &Other);
+  void recordEventCopy(const std::shared_ptr<chipstar::Event> &Other);
   bool wait() override;
   float getElapsedTime(chipstar::Event *Other) override;
   virtual void hostSignal() override;

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -90,8 +90,7 @@ public:
 
 public:
   CHIPEventOpenCL(CHIPContextOpenCL *ChipContext, cl_event ClEvent,
-                  chipstar::EventFlags Flags = chipstar::EventFlags(),
-                  bool UserEvent = false);
+                  chipstar::EventFlags Flags = chipstar::EventFlags());
   CHIPEventOpenCL(CHIPContextOpenCL *ChipContext,
                   chipstar::EventFlags Flags = chipstar::EventFlags());
   virtual ~CHIPEventOpenCL() override;

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -369,7 +369,7 @@ public:
 
   virtual chipstar::Queue *createCHIPQueue(chipstar::Device *ChipDev) override;
   virtual std::shared_ptr<chipstar::Event>
-  createCHIPEvent(chipstar::Context *ChipCtx,
+  createEventShared(chipstar::Context *ChipCtx,
                   chipstar::EventFlags Flags = chipstar::EventFlags(),
                   bool UserEvent = false) override;
   virtual chipstar::CallbackData *

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -370,8 +370,11 @@ public:
   virtual chipstar::Queue *createCHIPQueue(chipstar::Device *ChipDev) override;
   virtual std::shared_ptr<chipstar::Event>
   createEventShared(chipstar::Context *ChipCtx,
-                  chipstar::EventFlags Flags = chipstar::EventFlags(),
-                  bool UserEvent = false) override;
+                    chipstar::EventFlags Flags = chipstar::EventFlags(),
+                    bool UserEvent = false) override;
+  virtual chipstar::Event *
+  createEvent(chipstar::Context *ChipCtx,
+              chipstar::EventFlags Flags = chipstar::EventFlags()) override;
   virtual chipstar::CallbackData *
   createCallbackData(hipStreamCallback_t Callback, void *UserData,
                      chipstar::Queue *ChipQueue) override;


### PR DESCRIPTION
* Add a new pure virtual function for event creation, separating into shared and non-shared events
* hip_async_binomial which uses `hipGetNativeEventFromHipEvent` still has events outstanding after completion as indicated by OpenCL object lifetime layer. 