### PR TITLE
SPIR-V portability fix for single element vectors

### DIFF
--- a/include/hip/spirv_hip_vector_types.h
+++ b/include/hip/spirv_hip_vector_types.h
@@ -149,7 +149,12 @@ inline constexpr unsigned int next_pot(unsigned int x) {
 template <typename T, unsigned int n> struct HIP_vector_base;
 
 template <typename T> struct HIP_vector_base<T, 1> {
-  using Native_vec_ = __NATIVE_VECTOR__(1, T);
+  // SPIR-V does not support one element vector types without
+  // extensions and the current Clang -> SPIR-V translator tool chain
+  // used by CHIP-SPV does not include a legalization phase to lower
+  // one element vectors to scalars. Therefore, define Native_vec_ to
+  // be a scalar here.
+  using Native_vec_ = T /*__NATIVE_VECTOR__(1, T) */;
 
   union {
     Native_vec_ data;


### PR DESCRIPTION
Adjust a HIP header for avoiding single element vectors to appear in LLVM IR. Single element vectors are not supported in SPIR-V without an extension (e.g. SPV_INTEL_vector_compute) which are enabled with hard coded --spirv-ext=+all option in clang. 

I'll make clang patch to disable all SPIR-V extension which will cause an assertion to be triggered in `llvm-spirv` if there are single element vectors in the input device code.

Related to issue #713.

(We had this patch previously but it got lost in #521)