### PR TITLE
level0: resolve #735

### DIFF
--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -655,6 +655,8 @@ public:
   virtual void uninitialize() override;
   std::mutex CommandListsMtx;
 
+  void initializeCommon(ze_driver_handle_t ZeDriver);
+
   virtual void initializeImpl() override;
 
   virtual void initializeFromNative(const uintptr_t *NativeHandles,


### PR DESCRIPTION
Fix hipInitFromNativeHandles() resetted properties in the backend which caused a linking issue seen in #735.

Resolves #735.