### PR TITLE
Fix bogus sizeof(sizeof(string)) expression in gcnArchName()

### DIFF
--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -2238,7 +2238,7 @@ void CHIPDeviceLevel0::populateDevicePropertiesImpl() {
   constexpr char ArchName[] = "unavailable";
   static_assert(sizeof(ArchName) <= sizeof(HipDeviceProps_.gcnArchName),
                 "Buffer overflow!");
-  std::strncpy(HipDeviceProps_.gcnArchName, ArchName, sizeof(sizeof(ArchName)));
+  std::strncpy(HipDeviceProps_.gcnArchName, ArchName, sizeof(ArchName));
 }
 
 chipstar::Queue *CHIPDeviceLevel0::createQueue(chipstar::QueueFlags Flags,

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -584,7 +584,7 @@ void CHIPDeviceOpenCL::populateDevicePropertiesImpl() {
   constexpr char ArchName[] = "unavailable";
   static_assert(sizeof(ArchName) <= sizeof(HipDeviceProps_.gcnArchName),
                 "Buffer overflow!");
-  std::strncpy(HipDeviceProps_.gcnArchName, ArchName, sizeof(sizeof(ArchName)));
+  std::strncpy(HipDeviceProps_.gcnArchName, ArchName, sizeof(ArchName));
 }
 
 void CHIPDeviceOpenCL::resetImpl() { UNIMPLEMENTED(); }


### PR DESCRIPTION
Fix bogus sizeof(sizeof(string)) expression, which results in gcnArchName() returning "unavailable" truncated to 8 characters, which is "unavaila".