### PR TITLE
Add __hmax().

### DIFF
--- a/include/hip/spirv_hip_fp16.h
+++ b/include/hip/spirv_hip_fp16.h
@@ -1565,6 +1565,13 @@ THE SOFTWARE.
             {
                 return __half_raw{-static_cast<__half_raw>(x).data};
             }
+            inline
+            __device__
+            __half __hmax(__half x, __half y)
+            {
+                return __half_raw{__ocml_fmax_f16(static_cast<__half_raw>(x).data,
+                    static_cast<__half_raw>(y).data)};
+            }
 
             inline
             __HOST_DEVICE__

--- a/include/hip/spirv_math_fwd.h
+++ b/include/hip/spirv_math_fwd.h
@@ -79,6 +79,7 @@ extern "C"
     __device__ _Float16 __ocml_sin_f16(_Float16);
     __device__ __attribute__((const)) _Float16 __ocml_sqrt_f16(_Float16);
     __device__ __attribute__((const)) _Float16 __ocml_trunc_f16(_Float16);
+    __device__ __attribute__((const)) _Float16 __ocml_fmax_f16(_Float16, _Float16);
 
     typedef _Float16 __2f16 __attribute__((ext_vector_type(2)));
     typedef short __2i16 __attribute__((ext_vector_type(2)));


### PR DESCRIPTION
This patch adds __hmax() wrapper using existing fmaxH() bytecode function. This is necessary to get things like openhermes to run on tinygrad.