### PR TITLE
Map device built-ins to compiler built-ins

### DIFF
--- a/bitcode/CMakeLists.txt
+++ b/bitcode/CMakeLists.txt
@@ -34,10 +34,6 @@ if(NOT CLANG_VERSION_LESS_15 AND CLANG_VERSION_LESS_16)
   list(APPEND EXTRA_FLAGS ${DISABLE_OPAQUE_PTRS_OPT})
 endif()
 
-if(CHIP_ENABLE_NON_COMPLIANT_DEVICELIB_CODE)
-  list(APPEND EXTRA_FLAGS "-DCHIP_ENABLE_NON_COMPLIANT_DEVICELIB_CODE=1")
-endif()
-
 if("${LLVM_VERSION}" VERSION_LESS 14.0)
   # Definitions for pre-upstreamed HIP-Clang.
   set(BC_TRIPLE "spirv64")
@@ -109,18 +105,15 @@ set(OCML_LIB_PATHS
   ${CMAKE_BINARY_DIR}/bitcode/ROCm-Device-Libs/oclc/oclc_isa_version_803.lib.bc
 )
 
-if(CHIP_ENABLE_NON_COMPLIANT_DEVICELIB_CODE)
-    # add support for calling certain LLVM builtins that are not supported by HIP/CUDA
-    add_custom_command(
-    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/BC/c_to_opencl.bc"
-    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/c_to_opencl.c"
-    COMMAND "${CMAKE_CXX_COMPILER}" ${BITCODE_C_COMPILE_FLAGS}
-    -o "${CMAKE_CURRENT_BINARY_DIR}/BC/c_to_opencl.bc"
-    -c "${CMAKE_CURRENT_SOURCE_DIR}/c_to_opencl.c"
-    COMMENT "Building c_to_opencl.bc"
-    VERBATIM)
-    list(APPEND DEPEND_LIST "${CMAKE_CURRENT_BINARY_DIR}/BC/c_to_opencl.bc")
-endif()
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/BC/c_to_opencl.bc"
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/c_to_opencl.c"
+  COMMAND "${CMAKE_CXX_COMPILER}" ${BITCODE_C_COMPILE_FLAGS}
+  -o "${CMAKE_CURRENT_BINARY_DIR}/BC/c_to_opencl.bc"
+  -c "${CMAKE_CURRENT_SOURCE_DIR}/c_to_opencl.c"
+  COMMENT "Building c_to_opencl.bc"
+  VERBATIM)
+list(APPEND DEPEND_LIST "${CMAKE_CURRENT_BINARY_DIR}/BC/c_to_opencl.bc")
 
 # devicelib
 add_custom_command(

--- a/bitcode/c_to_opencl.c
+++ b/bitcode/c_to_opencl.c
@@ -22,12 +22,15 @@
 
 // See c_to_opencl.def for details.
 
-#define DEF_UNARY_FN_MAP(NAME_, TYPE_)                                         \
-  extern TYPE_ MAP_PREFIX##NAME_(TYPE_);                                       \
-  TYPE_ NAME_(TYPE_ x) { return MAP_PREFIX##NAME_(x); }
-#define DEF_BINARY_FN_MAP(NAME_, TYPE_)                                        \
-  extern TYPE_ MAP_PREFIX##NAME_(TYPE_, TYPE_);                                \
-  TYPE_ NAME_(TYPE_ x, TYPE_ y) { return MAP_PREFIX##NAME_(x, y); }
+#define DEF_UNARY_FN_MAP(FROM_FN_, TO_FN_, TYPE_)                              \
+  extern TYPE_ __chip_c2ocl_##FROM_FN_(TYPE_);                                 \
+  TYPE_ FROM_FN_(TYPE_ x) { return __chip_c2ocl_##FROM_FN_(x); }
+
+#define DEF_BINARY_FN_MAP(FROM_FN_, TO_FN_, TYPE_)                             \
+  extern TYPE_ __chip_c2ocl_##FROM_FN_(TYPE_, TYPE_);                          \
+  TYPE_ FROM_FN_(TYPE_ x, TYPE_ y) { return __chip_c2ocl_##FROM_FN_(x, y); }
+
 #include "c_to_opencl.def"
+
 #undef UNARY_FN
 #undef BINARY_FN

--- a/bitcode/c_to_opencl.def
+++ b/bitcode/c_to_opencl.def
@@ -20,9 +20,11 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-// Some libstd++ math calls results in non-overloaded (and non-mangled)
-// C math function calls that do not link with the overloaded (and
-// mangled) math builtin functions in OpenCL.
+// A subset of HIP device built-ins are mapped to compiler built-ins
+// for getting benefits from LLVM optimizers. The compiler built-ins
+// either map to LLVM intrinsics or C math calls. This file has
+// definitions for mapping the C math calls to corresponding OpenCL
+// built-ins.
 //
 // We can't define non-overloaded function that would call the builtin
 // by the same in OpenCL in the same translation unit. To get around
@@ -38,30 +40,78 @@
 
 // Note: Include guards are not desired here.
 
-#define MAP_PREFIX _chip_spv_c_to_opencl_
-
-// DEF_UNARY_FN_MAP(NAME, TYPE)
+// DEF_UNARY_FN_MAP(FROM_FN, TO_FN, TYPE)
 #ifndef DEF_UNARY_FN_MAP
 #define DEF_UNARY_FN_MAP
 #endif
 
-// DEF_BINARY_FN_MAP(NAME, TYPE)
+// DEF_BINARY_FN_MAP(FROM_FN, TO_FN, TYPE)
 #ifndef DEF_BINARY_FN_MAP
 #define DEF_BINARY_FN_MAP
 #endif
 
-DEF_UNARY_FN_MAP(lgamma, double)
-DEF_UNARY_FN_MAP(tan, double)
-DEF_UNARY_FN_MAP(asin, double)
-DEF_UNARY_FN_MAP(acos, double)
-DEF_UNARY_FN_MAP(atan, double)
-DEF_UNARY_FN_MAP(sinh, double)
-DEF_UNARY_FN_MAP(cosh, double)
-DEF_UNARY_FN_MAP(tanh, double)
-DEF_UNARY_FN_MAP(erf, double)
-DEF_UNARY_FN_MAP(erfc, double)
+DEF_UNARY_FN_MAP(acos, acos, double)
+DEF_UNARY_FN_MAP(acosf, acos, float)
+DEF_UNARY_FN_MAP(asin, asin, double)
+DEF_UNARY_FN_MAP(asinf, asin, float)
+DEF_UNARY_FN_MAP(atan, atan, double)
+DEF_UNARY_FN_MAP(atanf, atan, float)
+DEF_UNARY_FN_MAP(cbrt, cbrt, double)
+DEF_UNARY_FN_MAP(cbrtf, cbrt, float)
+DEF_UNARY_FN_MAP(ceil, ceil, double)
+DEF_UNARY_FN_MAP(ceilf, ceil, float)
+DEF_UNARY_FN_MAP(cos, cos, double)
+DEF_UNARY_FN_MAP(cosf, cos, float)
+DEF_UNARY_FN_MAP(cosh, cosh, double)
+DEF_UNARY_FN_MAP(coshf, cosh, float)
+DEF_UNARY_FN_MAP(erf, erf, double)
+DEF_UNARY_FN_MAP(erff, erf, float)
+DEF_UNARY_FN_MAP(erfc, erfc, double)
+DEF_UNARY_FN_MAP(erfcf, erfc, float)
+DEF_UNARY_FN_MAP(exp, exp, double)
+DEF_UNARY_FN_MAP(expf, exp, float)
+DEF_UNARY_FN_MAP(expm1, expm1, double)
+DEF_UNARY_FN_MAP(expm1f, expm1, float)
+DEF_UNARY_FN_MAP(exp2, exp2, double)
+DEF_UNARY_FN_MAP(exp2f, exp2, float)
+DEF_UNARY_FN_MAP(fabs, fabs, double)
+DEF_UNARY_FN_MAP(fabsf, fabs, float)
+DEF_UNARY_FN_MAP(floor, floor, double)
+DEF_UNARY_FN_MAP(floorf, floor, float)
+DEF_UNARY_FN_MAP(lgamma, lgamma, double)
+DEF_UNARY_FN_MAP(lgammaf, lgamma, float)
+DEF_UNARY_FN_MAP(log, log, double)
+DEF_UNARY_FN_MAP(logf, log, float)
+DEF_UNARY_FN_MAP(log10, log10, double)
+DEF_UNARY_FN_MAP(log10f, log10, float)
+DEF_UNARY_FN_MAP(rint, rint, double)
+DEF_UNARY_FN_MAP(rintf, rint, float)
+DEF_UNARY_FN_MAP(round, round, double)
+DEF_UNARY_FN_MAP(roundf, round, float)
+DEF_UNARY_FN_MAP(signbit, signbit, double)
+DEF_UNARY_FN_MAP(signbitf, signbit, float)
+DEF_UNARY_FN_MAP(sin, sin, double)
+DEF_UNARY_FN_MAP(sinf, sin, float)
+DEF_UNARY_FN_MAP(sinh, sinh, double)
+DEF_UNARY_FN_MAP(sinhf, sinh, float)
+DEF_UNARY_FN_MAP(sqrt, sqrt, double)
+DEF_UNARY_FN_MAP(sqrtf, sqrt, float)
+DEF_UNARY_FN_MAP(tan, tan, double)
+DEF_UNARY_FN_MAP(tanf, tan, float)
+DEF_UNARY_FN_MAP(tanh, tanh, double)
+DEF_UNARY_FN_MAP(tanhf, tanh, float)
+DEF_UNARY_FN_MAP(trunc, trunc, double)
+DEF_UNARY_FN_MAP(truncf, trunc, float)
 
-DEF_BINARY_FN_MAP(copysign, double)
-DEF_BINARY_FN_MAP(nextafter, double)
+DEF_BINARY_FN_MAP(copysign, copysign, double)
+DEF_BINARY_FN_MAP(fmax, fmax, double)
+DEF_BINARY_FN_MAP(fmaxf, fmax, float)
+DEF_BINARY_FN_MAP(fmin, fmin, double)
+DEF_BINARY_FN_MAP(fminf, fmin, float)
+DEF_BINARY_FN_MAP(fmod, fmod, double)
+DEF_BINARY_FN_MAP(fmodf, fmod, float)
+DEF_BINARY_FN_MAP(hypot, hypot, double)
+DEF_BINARY_FN_MAP(hypotf, hypot, float)
+DEF_BINARY_FN_MAP(nextafter, nextafter, double)
 
 #undef MAPPING_PREFIX

--- a/bitcode/c_to_opencl.def
+++ b/bitcode/c_to_opencl.def
@@ -30,11 +30,11 @@
 // by the same in OpenCL in the same translation unit. To get around
 // it we define the former in C source file, for example:
 //
-//   double lgamma(double) { return <MAP_PREFIX>lgamma(x); }
+//   double lgamma(double) { return __chip_c2ocl_lgamma(x); }
 //
 // And on the OpenCL side we call the corresponding OpenCL builtin:
 //
-//   double <MAP_PREFIX>lgamma(double x) { return tan(x); }
+//   double __chip_c2ocl_lgamma(double x) { return lgamma(x); }
 //
 // In this file we define the functions which receive this treatment.
 
@@ -113,5 +113,3 @@ DEF_BINARY_FN_MAP(fmodf, fmod, float)
 DEF_BINARY_FN_MAP(hypot, hypot, double)
 DEF_BINARY_FN_MAP(hypotf, hypot, float)
 DEF_BINARY_FN_MAP(nextafter, nextafter, double)
-
-#undef MAPPING_PREFIX

--- a/bitcode/devicelib.cl
+++ b/bitcode/devicelib.cl
@@ -848,7 +848,6 @@ EXPORT long __chip_double_as_longlong(double x) { return as_long(x); }
 EXPORT double __chip_longlong_as_double(long int x) { return as_double(x); }
 
 // See c_to_opencl.def for details.
-#define MAP_PREFIX __chip_c2ocl_
 #define DEF_UNARY_FN_MAP(FROM_FN_, TO_FN_, TYPE_)                              \
   TYPE_ __chip_c2ocl_##FROM_FN_(TYPE_ x) { return TO_FN_(x); }
 #define DEF_BINARY_FN_MAP(FROM_FN_, TO_FN_, TYPE_)                             \

--- a/bitcode/devicelib.cl
+++ b/bitcode/devicelib.cl
@@ -847,14 +847,12 @@ EXPORT uint __chip_float_as_uint(float x) { return as_uint(x); }
 EXPORT long __chip_double_as_longlong(double x) { return as_long(x); }
 EXPORT double __chip_longlong_as_double(long int x) { return as_double(x); }
 
-#ifdef CHIP_ENABLE_NON_COMPLIANT_DEVICELIB_CODE
-
 // See c_to_opencl.def for details.
-#define DEF_UNARY_FN_MAP(NAME_, TYPE_)                                         \
-  TYPE_ MAP_PREFIX##NAME_(TYPE_ x) { return NAME_(x); }
-#define DEF_BINARY_FN_MAP(NAME_, TYPE_)                                        \
-  TYPE_ MAP_PREFIX##NAME_(TYPE_ x, TYPE_ y) { return NAME_(x, y); }
+#define MAP_PREFIX __chip_c2ocl_
+#define DEF_UNARY_FN_MAP(FROM_FN_, TO_FN_, TYPE_)                              \
+  TYPE_ __chip_c2ocl_##FROM_FN_(TYPE_ x) { return TO_FN_(x); }
+#define DEF_BINARY_FN_MAP(FROM_FN_, TO_FN_, TYPE_)                             \
+  TYPE_ __chip_c2ocl_##FROM_FN_(TYPE_ x, TYPE_ y) { return TO_FN_(x, y); }
 #include "c_to_opencl.def"
 #undef UNARY_FN
 #undef BINARY_FN
-#endif

--- a/include/hip/devicelib/double_precision/dp_math.hh
+++ b/include/hip/devicelib/double_precision/dp_math.hh
@@ -25,28 +25,86 @@
 
 #include <hip/devicelib/macros.hh>
 
+#if defined __has_builtin && __has_builtin(__builtin_acos)
+// Must use 'static' here for the HIP built-ins mapped to compiler
+// built-ins where the HIP built-ins' signature coincides with OpenCL
+// built-ins.
+//
+// The compiler built-ins may be lowered to C math calls which are
+// remapped to OpenCL built-ins. Because the OpenCL built-ins'
+// signature matches to the HIP built-ins, the cmath->OpenCL mapping
+// ends up calling the HIP built-in definitions here leading to
+// infinite call recursion unless the definitions here are marked
+// 'static'.
+//
+// 'static' breaks the recursion because the HIP->compiler built-in
+// mappings and cmath->OpenCL built-in mappings live in separate TUs
+// (the latter reside in device bitcode library) and static functions
+// are not involved in linking.
+static inline __device__ double acos(double x) {
+  return __builtin_acos(x);
+}
+#else
 extern "C++" __device__ double acos(double x); // OpenCL
+#endif
 
 extern "C++" __device__ double acosh(double x); // OpenCL
 extern "C++" __device__ double acosh ( double  x ); // OpenCL
+
+#if defined __has_builtin && __has_builtin(__builtin_asin)
+static inline __device__ double asin(double x) {
+  return __builtin_asin(x);
+}
+#else
 extern "C++" __device__ double asin(double x); // OpenCL
+#endif
 
 extern "C++" __device__ double asinh(double x); // OpenCL
+
+#if defined __has_builtin && __has_builtin(__builtin_atan)
+static inline __device__ double atan(double x) {
+  return __builtin_atan(x);
+}
+#else
 extern "C++" __device__ double atan(double x); // OpenCL
+#endif
+
 extern "C++" __device__ double atan2(double y, double x); // OpenCL
 extern "C++" __device__ double atanh(double x); // OpenCL
+
+#if defined __has_builtin && __has_builtin(__builtin_cbrt)
+static inline __device__ double cbrt(double x) {
+  return __builtin_cbrt(x);
+}
+#else
 extern "C++" __device__ double cbrt(double x); // OpenCL
+#endif
+
+#if defined __has_builtin && __has_builtin(__builtin_ceil)
+static inline __device__ double ceil(double x) {
+  return __builtin_ceil(x);
+}
+#else
 extern "C++" __device__ double ceil(double x); // OpenCL
+#endif
+
 extern "C++" __device__ double copysign(double x, double y); // OpenCL
 
-#ifdef __FAST_MATH__
+#if defined __has_builtin && __has_builtin(__builtin_cos)
+static inline __device__ double cos(double x) { return __builtin_cos(x); }
+#elif defined __FAST_MATH__
 extern "C++" __device__ double native_cos(double x); // OpenCL
 extern "C++" inline __device__ double cos(double x) { return ::native_cos(x); }
 #else
 extern "C++" __device__ double cos(double x); // OpenCL
 #endif
 
+#if defined __has_builtin && __has_builtin(__builtin_cosh)
+static inline __device__ double cosh(double x) { return __builtin_cosh(x); }
+#else
 extern "C++" __device__ double cosh(double x); // OpenCL
+#endif
+
 extern "C++" __device__ double cospi(double x); // OpenCL
 
 extern "C" __device__  double __ocml_i0_f64(double x);
@@ -59,7 +117,12 @@ extern "C++" inline __device__ double cyl_bessel_i1 ( double  x ) {
 }
 
 extern "C++" __device__ double erf(double x);
+
+#if defined __has_builtin && __has_builtin(__builtin_erfc)
+static inline __device__ double erfc(double x) { return __builtin_erfc(x); }
+#else
 extern "C++" __device__ double erfc(double x);
+#endif
 
 extern "C" __device__  double __ocml_erfcinv_f64(double x); // OCML
 extern "C++" inline __device__ double erfcinv(double x) {
@@ -76,7 +139,9 @@ extern "C++" inline __device__ double erfinv(double x) {
   return ::__ocml_erfinv_f64(x);
 }
 
-#ifdef __FAST_MATH__
+#if defined __has_builtin && __has_builtin(__builtin_exp)
+static inline __device__ double exp(double x) { return __builtin_exp(x); }
+#elif defined __FAST_MATH__
 extern "C++" __device__ double native_exp(double x); // OpenCL
 extern "C++" inline __device__ double exp(double x) { return ::native_exp(x); }
 #else
@@ -92,7 +157,9 @@ extern "C++" inline __device__ double exp10(double x) {
 extern "C++" __device__ double exp10(double x); // OpenCL
 #endif
 
-#ifdef __FAST_MATH__
+#if defined __has_builtin && __has_builtin(__builtin_exp2)
+static inline __device__ double exp2(double x) { return __builtin_exp2(x); }
+#elif defined __FAST_MATH__
 extern "C++" __device__ double native_exp2(double x); // OpenCL
 extern "C++" inline __device__ double exp2(double x) {
   return ::native_exp2(x);
@@ -101,16 +168,61 @@ extern "C++" inline __device__ double exp2(double x) {
 extern "C++" __device__ double exp2(double x);  // OpenCL
 #endif
 
+#if defined __has_builtin && __has_builtin(__builtin_expm1)
+static inline __device__ double expm1(double x) { return __builtin_expm1(x); }
+#else
 extern "C++" __device__ double expm1(double x); // OpenCL
+#endif
+
+#if defined __has_builtin && __has_builtin(__builtin_fabs)
+static inline __device__ double fabs(double x) { return __builtin_fabs(x); }
+#else
 extern "C++" __device__ double fabs(double x); // OpenCL
+#endif
+
 extern "C++" __device__ double fdim(double x, double y); // OpenCL
+
+#if defined __has_builtin && __has_builtin(__builtin_floor)
+static inline __device__ double floor(double x) { return __builtin_floor(x); }
+#else
 extern "C++" __device__ double floor(double x); // OpenCL
+#endif
+
 extern "C++" __device__ double fma(double x, double y, double z); // OpenCL
+
+#if defined __has_builtin && __has_builtin(__builtin_fmax)
+static inline __device__ double fmax(double x, double y) {
+  return __builtin_fmax(x, y);
+}
+#else
 extern "C++" __device__ double fmax(double, double); // OpenCL
+#endif
+
+#if defined __has_builtin && __has_builtin(__builtin_fmin)
+static inline __device__ double fmin(double x, double y) {
+  return __builtin_fmin(x, y);
+}
+#else
 extern "C++" __device__ double fmin(double x, double y); // OpenCL
+#endif
+
+#if defined __has_builtin && __has_builtin(__builtin_fmod)
+static inline __device__ double fmod(double x, double y) {
+  return __builtin_fmod(x, y);
+}
+#else
 extern "C++" __device__ double fmod(double x, double y); // OpenCL
+#endif
+
 extern "C++" __device__ double frexp(double x, int *nptr); // OpenCL
+
+#if defined __has_builtin && __has_builtin(__builtin_hypot)
+static __device__ double hypot(double x, double y) {
+  return __builtin_hypot(x, y);
+}
+#else
 extern "C++" __device__ double hypot(double x, double y); // OpenCL
+#endif
 extern "C++" __device__  int ilogb(double x); // OpenCL
 
 extern "C++" __device__  int 	isfinite ( double  a ); // OpenCL
@@ -133,7 +245,12 @@ extern "C++" inline __device__ double jn(int n, double x) {
 }
 
 extern "C++" __device__ double ldexp(double x, int exp); // OpenCL
+
+#if defined __has_builtin && __has_builtin(__builtin_lgamma)
+static inline __device__ double lgamma(double x) { return __builtin_lgamma(x); }
+#else
 extern "C++" __device__ double lgamma(double x); // OpenCL
+#endif
 
 extern "C" __device__  long long int __chip_llrint_f64(double x); // Custom
 extern "C++" inline __device__ long long int llrint(double x) {
@@ -145,14 +262,18 @@ extern "C++" inline __device__ long long int llround(double x) {
   return ::__chip_llround_f64(x);
 }
 
-#ifdef __FAST_MATH__
+#if defined __has_builtin && __has_builtin(__builtin_log)
+static inline __device__ double log(double x) { return __builtin_log(x); }
+#elif defined __FAST_MATH__
 extern "C++" __device__ double native_log(double x); // OpenCL
 extern "C++" inline __device__ double log(double x) { return ::native_log(x); }
 #else
 extern "C++" __device__ double log(double x);   // OpenCL
 #endif
 
-#ifdef __FAST_MATH__
+#if defined __has_builtin && __has_builtin(__builtin_log10)
+static inline __device__ double log10(double x) { return __builtin_log10(x); }
+#elif defined __FAST_MATH__
 extern "C++" __device__ double native_log10(double x); // OpenCL
 extern "C++" inline __device__ double log10(double x) {
   return ::native_log10(x);
@@ -199,7 +320,7 @@ extern "C++" inline __device__ double nan(const char *tagp) {
   return ::nan(nancode);
 }
 
-extern "C++" inline __device__ double nearbyint(double x) {
+static inline __device__ double nearbyint(double x) {
   return __builtin_nearbyint(x);
 }
 
@@ -231,7 +352,13 @@ extern "C++" inline __device__ double normcdfinv(double x) {
   return ::__ocml_ncdfinv_f64(x);
 }
 
+#if defined __has_builtin && __has_builtin(__builtin_pow)
+static inline __device__ double pow(double x, double y) {
+  return __builtin_pow(x, y);
+}
+#else
 extern "C++" __device__ double pow(double x, double y); // OpenCL
+#endif
 
 extern "C" __device__  double __ocml_rcbrt_f64(double x); // OCML
 extern "C++" inline __device__ double rcbrt(double x) {
@@ -246,7 +373,11 @@ extern "C++" inline __device__ double rhypot(double x, double y) {
   return ::__ocml_rhypot_f64(x, y);
 }
 
+#if defined __has_builtin && __has_builtin(__builtin_rint)
+static inline __device__ double rint(double x) { return __builtin_rint(x); }
+#else
 extern "C++" __device__ double rint(double x); // OpenCL
+#endif
 
 extern "C" __device__  double __chip_rnorm_f64(int dim, const double *p); // Custom
 extern "C++" inline __device__ double rnorm(int dim, const double *p) {
@@ -265,7 +396,11 @@ extern "C++" inline __device__ double rnorm4d(double a, double b, double c,
   return ::__ocml_rlen4_f64(a, b, c, d);
 }
 
+#if defined __has_builtin && __has_builtin(__builtin_round)
+static inline __device__ double round(double x) { return __builtin_round(x); }
+#else
 extern "C++" __device__ double round(double x); // OpenCL
+#endif
 
 #ifdef __FAST_MATH__
 extern "C++" __device__ double native_rsqrt(double x); // OpenCL
@@ -288,9 +423,16 @@ extern "C++" inline __device__ double scalbn(double x, int n)  {
   return ::__ocml_scalbn_f64(x, n);
 }
 
-extern "C++" __device__ int 	signbit ( double  a ); // OpenCL
 
-#ifdef __FAST_MATH__
+#if defined __has_builtin && __has_builtin(__builtin_signbit)
+static inline __device__ int signbit(double a) { return __builtin_signbit(a); }
+#else
+extern "C++" __device__ int signbit(double a); // OpenCL
+#endif
+
+#if defined __has_builtin && __has_builtin(__builtin_sin)
+static inline __device__ double sin(double x) { return __builtin_sin(x); }
+#elif defined __FAST_MATH__
 extern "C++" __device__ double native_sin(double x); // OpenCL
 extern "C++" inline __device__ double sin(double x) {
   return ::native_sin(x);
@@ -314,10 +456,17 @@ extern "C++" inline __device__ void sincospi(double x, double *sptr,
  return ::__chip_sincospi_f64(x, sptr, cptr);
 }
 
+#if defined __has_builtin && __has_builtin(__builtin_sinh)
+static inline __device__ double sinh(double x) { return __builtin_sinh(x); }
+#else
 extern "C++" __device__ double sinh(double x); // OpenCL
+#endif
+
 extern "C++" __device__ double sinpi(double x); // OpenCL
 
-#ifdef __FAST_MATH__
+#if defined __has_builtin && __has_builtin(__builtin_sqrt)
+static inline __device__ double sqrt(double x) { return __builtin_sqrt(x); }
+#elif defined __FAST_MATH__
 extern "C++" __device__ double native_sqrt(double x); // OpenCL
 extern "C++" inline __device__ double sqrt(double x) {
   return ::native_sqrt(x);
@@ -326,16 +475,28 @@ extern "C++" inline __device__ double sqrt(double x) {
 extern "C++" __device__ double sqrt(double x); // OpenCL
 #endif
 
-#ifdef __FAST_MATH__
+#if defined __has_builtin && __has_builtin(__builtin_tan)
+static inline __device__ double tan(double x) { return __builtin_tan(x); }
+#elif defined __FAST_MATH__
 extern "C++" __device__ double native_tan(double x); // OpenCL
 extern "C++" inline __device__ double tan(double x) { return ::native_tan(x); }
 #else
 extern "C++" __device__ double tan(double x);  // OpenCL
 #endif
 
+#if defined __has_builtin && __has_builtin(__builtin_tanh)
+static inline __device__ double tanh(double x) { return __builtin_tanh(x); }
+#else
 extern "C++" __device__ double tanh(double x); // OpenCL
+#endif
+
 extern "C++" __device__ double tgamma(double x); // OpenCL
+
+#if defined __has_builtin && __has_builtin(__builtin_trunc)
+static inline __device__ double trunc(double x) { return __builtin_trunc(x); }
+#else
 extern "C++" __device__ double trunc(double x); // OpenCL
+#endif
 
 extern "C" __device__  double __ocml_y0_f64(double x); // OCML
 extern "C++" inline __device__ double y0(double x) {

--- a/include/hip/devicelib/double_precision/dp_math.hh
+++ b/include/hip/devicelib/double_precision/dp_math.hh
@@ -217,7 +217,7 @@ extern "C++" __device__ double fmod(double x, double y); // OpenCL
 extern "C++" __device__ double frexp(double x, int *nptr); // OpenCL
 
 #if defined __has_builtin && __has_builtin(__builtin_hypot)
-static __device__ double hypot(double x, double y) {
+static inline __device__ double hypot(double x, double y) {
   return __builtin_hypot(x, y);
 }
 #else

--- a/include/hip/devicelib/single_precision/sp_math.hh
+++ b/include/hip/devicelib/single_precision/sp_math.hh
@@ -38,9 +38,7 @@
  * function declared in 1. cosf(x) -> cos(x)
  */
 #if defined __has_builtin && __has_builtin(__builtin_acosf)
-extern "C++" inline __device__ float acosf(float x) {
-  return __builtin_acos(x);
-}
+static inline __device__ float acosf(float x) { return __builtin_acos(x); }
 #else
 extern "C++" __device__ float acos(float x); // OpenCL
 extern "C++" inline __device__ float acosf(float x) { return ::acos(x); }
@@ -50,9 +48,7 @@ extern "C++" __device__ float acosh(float x); // OpenCL
 extern "C++" inline __device__ float acoshf(float x) { return ::acosh(x); }
 
 #if defined __has_builtin && __has_builtin(__builtin_asinf)
-extern "C++" inline __device__ float asinf(float x) {
-  return __builtin_asinf(x);
-}
+static inline __device__ float asinf(float x) { return __builtin_asinf(x); }
 #else
 extern "C++" __device__ float asin(float x); // OpenCL
 extern "C++" inline __device__ float asinf(float x) { return ::asin(x); }
@@ -67,9 +63,7 @@ extern "C++" inline __device__ float atan2f(float y, float x) {
 }
 
 #if defined __has_builtin && __has_builtin(__builtin_atanf)
-extern "C++" inline __device__ float atanf(float x) {
-  return __builtin_atanf(x);
-}
+static inline __device__ float atanf(float x) { return __builtin_atanf(x); }
 #else
 extern "C++" __device__ float atan(float x); // OpenCL
 extern "C++" inline __device__ float atanf(float x) { return ::atan(x); }
@@ -79,18 +73,14 @@ extern "C++" __device__ float atanh(float x); // OpenCL
 extern "C++" inline __device__ float atanhf(float x) { return ::atanh(x); }
 
 #if defined __has_builtin && __has_builtin(__builtin_cbrtf)
-extern "C++" inline __device__ float cbrtf(float x) {
-  return __builtin_cbrtf(x);
-}
+static inline __device__ float cbrtf(float x) { return __builtin_cbrtf(x); }
 #else
 extern "C++" __device__ float cbrt(float x); // OpenCL
 extern "C++" inline __device__ float cbrtf(float x) { return ::cbrt(x); }
 #endif
 
 #if defined __has_builtin && __has_builtin(__builtin_ceilf)
-extern "C++" inline __device__ float ceilf(float x) {
-  return __builtin_ceilf(x);
-}
+static inline __device__ float ceilf(float x) { return __builtin_ceilf(x); }
 #else
 extern "C++" __device__ float ceil(float x); // OpenCL
 extern "C++" inline __device__ float ceilf(float x) { return ::ceil(x); }
@@ -102,9 +92,7 @@ extern "C++" inline __device__ float copysignf(float x, float y) {
 }
 
 #if defined __has_builtin && __has_builtin(__builtin_cosf)
-extern "C++" inline __device__ float cosf(float x) {
-  return __builtin_cosf(x);
-}
+static inline __device__ float cosf(float x) { return __builtin_cosf(x); }
 #elif defined __FAST_MATH__
 extern "C++" __device__ float native_cos(float x); // OpenCL
 extern "C++" inline __device__ float cosf(float x) {
@@ -118,9 +106,7 @@ extern "C++" inline __device__ float cosf(float x) {
 #endif
 
 #if defined __has_builtin && __has_builtin(__builtin_coshf)
-extern "C++" inline __device__ float coshf(float x) {
-  return __builtin_coshf(x);
-}
+static inline __device__ float coshf(float x) { return __builtin_coshf(x); }
 #else
 extern "C++" __device__ float cosh(float x); // OpenCL
 extern "C++" inline __device__ float coshf(float x) { return ::cosh(x); }
@@ -136,9 +122,7 @@ extern "C" __device__  float __ocml_i1_f32(float x); // OCML
 extern "C++" inline __device__ float cyl_bessel_i1f(float x) { return ::__ocml_i1_f32(x); }
 
 #if defined __has_builtin && __has_builtin(__builtin_erfcf)
-extern "C++" inline __device__ float erfcf(float x) {
-  return __builtin_erfcf(x);
-}
+static inline __device__ float erfcf(float x) { return __builtin_erfcf(x); }
 #else
 extern "C++" __device__ float erfc(float x); // OpenCL
 extern "C++" inline __device__ float erfcf(float x) { return ::erfc(x); }
@@ -167,9 +151,7 @@ extern "C++" inline __device__ float exp10f(float x) {
 }
 
 #if defined __has_builtin && __has_builtin(__builtin_exp2f)
-extern "C++" inline __device__ float exp2f(float x) {
-  return __builtin_exp2f(x);
-}
+static inline __device__ float exp2f(float x) { return __builtin_exp2f(x); }
 #elif defined __FAST_MATH__
 extern "C++" __device__ float exp2(float x); // OpenCL
 extern "C++" inline __device__ float exp2f(float x) { return ::native_exp2(x); }
@@ -179,7 +161,7 @@ extern "C++" inline __device__ float exp2f(float x) { return ::exp2(x); }
 #endif
 
 #if defined __has_builtin && __has_builtin(__builtin_expf)
-extern "C++" inline __device__ float expf(float x) { return __builtin_expf(x); }
+static inline __device__ float expf(float x) { return __builtin_expf(x); }
 #elif defined __FAST_MATH__
 extern "C++" __device__ float native_exp(float x); // OpenCL
 extern "C++" inline __device__ float expf(float x) { return ::native_exp(x); }
@@ -190,18 +172,14 @@ extern "C++" inline __device__ float expf(float x) { return ::exp(x); }
 
 
 #if defined __has_builtin && __has_builtin(__builtin_expm1f)
-extern "C++" inline __device__ float expm1f(float x) {
-  return __builtin_expm1f(x);
-}
+static inline __device__ float expm1f(float x) { return __builtin_expm1f(x); }
 #else
 extern "C++" __device__ float expm1(float x); // OpenCL
 extern "C++" inline __device__ float expm1f(float x) { return ::expm1(x); }
 #endif
 
 #if defined __has_builtin && __has_builtin(__builtin_fabsf)
-extern "C++" inline __device__ float fabsf(float x) {
-  return __builtin_fabsf(x);
-}
+static inline __device__ float fabsf(float x) { return __builtin_fabsf(x); }
 #else
 extern "C++" __device__ float fabs(float x); // OpenCL
 extern "C++" inline __device__ float fabsf(float x) { return ::fabs(x); }
@@ -222,9 +200,7 @@ extern "C++" inline __device__ float fdividef(float x, float y) {
 }
 
 #if defined __has_builtin && __has_builtin(__builtin_floorf)
-extern "C++" inline __device__ float floorf(float x) {
-  return __builtin_floorf(x);
-}
+static inline __device__ float floorf(float x) { return __builtin_floorf(x); }
 #else
 extern "C++" __device__ float floor(float x); // OpenCL
 extern "C++" inline __device__ float floorf(float x) { return ::floor(x); }
@@ -236,7 +212,7 @@ extern "C++" inline __device__ float fmaf(float x, float y, float z) {
 }
 
 #if defined __has_builtin && __has_builtin(__builtin_fmaxf)
-extern "C++" inline __device__ float fmaxf(float x, float y) {
+static inline __device__ float fmaxf(float x, float y) {
   return __builtin_fmaxf(x, y);
 }
 #else
@@ -247,7 +223,7 @@ extern "C++" inline __device__ float fmaxf(float x, float y) {
 #endif
 
 #if defined __has_builtin && __has_builtin(__builtin_fminf)
-extern "C++" inline __device__ float fminf(float x, float y) {
+static inline __device__ float fminf(float x, float y) {
   return __builtin_fminf(x, y);
 }
 #else
@@ -258,7 +234,7 @@ extern "C++" inline __device__ float fminf(float x, float y) {
 #endif
 
 #if defined __has_builtin && __has_builtin(__builtin_fmodf)
-extern "C++" inline __device__ float fmodf(float x, float y) {
+static inline __device__ float fmodf(float x, float y) {
   return __builtin_fmodf(x, y);
 }
 #else
@@ -274,7 +250,7 @@ extern "C++" inline __device__ float frexpf(float x, int *nptr) {
 }
 
 #if defined __has_builtin && __has_builtin(__builtin_hypotf)
-extern "C++" inline __device__ float hypotf(float x, float y) {
+static inline __device__ float hypotf(float x, float y) {
   return __builtin_hypotf(x, y);
 }
 #else
@@ -313,10 +289,8 @@ extern "C++" inline __device__ float ldexpf(float x, int exp) {
 }
 
 #if defined __has_builtin && __has_builtin(__builtin_lgammaf)
-extern "C++" inline __device__ float lgammaf(float x) {
-  return __builtin_lgammaf(x);
-}
-extern "C++" inline __device__ float lgamma(float x) {
+static inline __device__ float lgammaf(float x) { return __builtin_lgammaf(x); }
+static inline __device__ float lgamma(float x) {
   return __builtin_lgammaf(x);
 }
 #else
@@ -338,9 +312,7 @@ extern "C++" inline __device__ long long int llroundf(float x) {
 }
 
 #if defined __has_builtin && __has_builtin(__builtin_log10f)
-extern "C++" inline __device__ float log10f(float x) {
-  return __builtin_log10(x);
-}
+static inline __device__ float log10f(float x) { return __builtin_log10(x); }
 #elif defined __FAST_MATH__
 extern "C++" __device__ float native_log10(float x); // OpenCL
 extern "C++" inline __device__ float log10f(float x) {
@@ -370,7 +342,7 @@ extern "C++" __device__ float logb(float x); // OpenCL
 extern "C++" inline __device__ float logbf(float x) { return ::logb(x); }
 
 #if defined __has_builtin && __has_builtin(__builtin_logf)
-extern "C++" inline __device__ float logf(float x) { return __builtin_log(x); }
+static inline __device__ float logf(float x) { return __builtin_log(x); }
 #elif defined __FAST_MATH__
 extern "C++" __device__ float native_log(float x); // OpenCL
 extern "C++" inline __device__ float logf(float x) {
@@ -465,7 +437,7 @@ extern "C++" inline __device__ float norm(int dim, const float *p) {
 }
 
 #if defined __has_builtin && __has_builtin(__builtin_powf)
-extern "C++" inline __device__ float powf(float x, float y) {
+static inline __device__ float powf(float x, float y) {
   return __builtin_powf(x, y);
 }
 #else
@@ -495,9 +467,7 @@ extern "C++" inline __device__ float rhypotf(float x, float y) {
 }
 
 #if defined __has_builtin && __has_builtin(__builtin_rintf)
-extern "C++" inline __device__ float rintf(float x) {
-  return __builtin_rintf(x);
-}
+static inline __device__ float rintf(float x) { return __builtin_rintf(x); }
 #else
 extern "C++" __device__ float rint(float x); // OpenCL
 extern "C++" inline __device__ float rintf(float x) { return ::rint(x); }
@@ -527,9 +497,7 @@ extern "C++" inline __device__ float rnorm(int dim, const float *p) {
 }
 
 #if defined __has_builtin && __has_builtin(__builtin_roundf)
-extern "C++" inline __device__ float roundf(float x) {
-  return __builtin_roundf(x);
-}
+static inline __device__ float roundf(float x) { return __builtin_roundf(x); }
 #else
 extern "C++" __device__ float round(float x); // OpenCL
 extern "C++" inline __device__ float roundf(float x) {
@@ -558,9 +526,7 @@ extern "C++" inline __device__ float scalblnf(float x, long int n) {
 }
 
 #if defined __has_builtin && __has_builtin(__builtin_signbitf)
-extern "C++" inline __device__ int signbitf(float a) {
-  return __builtin_signbitf(a);
-}
+static inline __device__ int signbitf(float a) { return __builtin_signbitf(a); }
 #else
 extern "C" __device__  int __ocml_signbit_f32(float a); // OCML
 extern "C++" inline __device__ int signbitf(float a) {
@@ -582,7 +548,7 @@ extern "C++" inline __device__ void sincospif(float x, float *sptr,
 }
 
 #if defined __has_builtin && __has_builtin(__builtin_sinf)
-extern "C++" inline __device__ float sinf(float x) { return __builtin_sinf(x); }
+static inline __device__ float sinf(float x) { return __builtin_sinf(x); }
 #elif defined __FAST_MATH__
 extern "C++" __device__ float native_sin(float x); // OpenCL
 extern "C++" inline __device__ float sinf(float x) { return ::native_sin(x); }
@@ -592,9 +558,7 @@ extern "C++" inline __device__ float sinf(float x) { return ::sin(x); }
 #endif
 
 #if defined __has_builtin && __has_builtin(__builtin_sinhf)
-extern "C++" inline __device__ float sinhf(float x) {
-  return __builtin_sinhf(x);
-}
+static inline __device__ float sinhf(float x) { return __builtin_sinhf(x); }
 #else
 extern "C++" __device__ float sinh(float x); // OpenCL
 extern "C++" inline __device__ float sinhf(float x) { return ::sinh(x); }
@@ -604,9 +568,7 @@ extern "C++" __device__ float sinpi(float x); // OpenCL
 extern "C++" inline __device__ float sinpif(float x) { return ::sinpi(x); }
 
 #if defined __has_builtin && __has_builtin(__builtin_sqrtf)
-extern "C++" inline __device__ float sqrtf(float x) {
-  return __builtin_sqrtf(x);
-}
+static inline __device__ float sqrtf(float x) { return __builtin_sqrtf(x); }
 #elif defined __FAST_MATH__
 extern "C++" __device__ float native_sqrt(float x); // OpenCL
 extern "C++" inline __device__ float sqrtf(float x) {
@@ -620,7 +582,7 @@ extern "C++" inline __device__ float sqrtf(float x) {
 #endif
 
 #if defined __has_builtin && __has_builtin(__builtin_tanf)
-extern "C++" inline __device__ float tanf(float x) { return __builtin_tanf(x); }
+static inline __device__ float tanf(float x) { return __builtin_tanf(x); }
 #elif defined __FAST_MATH__
 extern "C++" __device__ float native_tan(float x); // OpenCL
 extern "C++" inline __device__ float tanf(float x) { return ::native_tan(x); }
@@ -630,9 +592,7 @@ extern "C++" inline __device__ float tanf(float x) { return ::tan(x); }
 #endif
 
 #if defined __has_builtin && __has_builtin(__builtin_tanhf)
-extern "C++" inline __device__ float tanhf(float x) {
-  return __builtin_tanhf(x);
-}
+static inline __device__ float tanhf(float x) { return __builtin_tanhf(x); }
 #else
 extern "C++" __device__ float tanh(float x); // OpenCL
 extern "C++" inline __device__ float tanhf(float x) { return ::tanh(x); }
@@ -642,9 +602,7 @@ extern "C++" __device__ float tgamma(float x); // OpenCL
 extern "C++" inline __device__ float tgammaf(float x) { return ::tgamma(x); }
 
 #if defined __has_builtin && __has_builtin(__builtin_truncf)
-extern "C++" inline __device__ float truncf(float x) {
-  return __builtin_truncf(x);
-}
+static inline __device__ float truncf(float x) { return __builtin_truncf(x); }
 #else
 extern "C++" __device__ float trunc(float x); // OpenCL
 extern "C++" inline __device__ float truncf(float x) { return ::trunc(x); }

--- a/include/hip/devicelib/single_precision/sp_math.hh
+++ b/include/hip/devicelib/single_precision/sp_math.hh
@@ -37,14 +37,26 @@
  * 2. If necessary, define the type specific function and bind it to the
  * function declared in 1. cosf(x) -> cos(x)
  */
+#if defined __has_builtin && __has_builtin(__builtin_acosf)
+extern "C++" inline __device__ float acosf(float x) {
+  return __builtin_acos(x);
+}
+#else
 extern "C++" __device__ float acos(float x); // OpenCL
 extern "C++" inline __device__ float acosf(float x) { return ::acos(x); }
+#endif
 
 extern "C++" __device__ float acosh(float x); // OpenCL
 extern "C++" inline __device__ float acoshf(float x) { return ::acosh(x); }
 
+#if defined __has_builtin && __has_builtin(__builtin_asinf)
+extern "C++" inline __device__ float asinf(float x) {
+  return __builtin_asinf(x);
+}
+#else
 extern "C++" __device__ float asin(float x); // OpenCL
 extern "C++" inline __device__ float asinf(float x) { return ::asin(x); }
+#endif
 
 extern "C++" __device__ float asinh(float x); // OpenCL
 extern "C++" inline __device__ float asinhf(float x) { return ::asinh(x); }
@@ -54,35 +66,65 @@ extern "C++" inline __device__ float atan2f(float y, float x) {
   return ::atan2(y, x);
 }
 
+#if defined __has_builtin && __has_builtin(__builtin_atanf)
+extern "C++" inline __device__ float atanf(float x) {
+  return __builtin_atanf(x);
+}
+#else
 extern "C++" __device__ float atan(float x); // OpenCL
 extern "C++" inline __device__ float atanf(float x) { return ::atan(x); }
+#endif
 
 extern "C++" __device__ float atanh(float x); // OpenCL
 extern "C++" inline __device__ float atanhf(float x) { return ::atanh(x); }
 
+#if defined __has_builtin && __has_builtin(__builtin_cbrtf)
+extern "C++" inline __device__ float cbrtf(float x) {
+  return __builtin_cbrtf(x);
+}
+#else
 extern "C++" __device__ float cbrt(float x); // OpenCL
 extern "C++" inline __device__ float cbrtf(float x) { return ::cbrt(x); }
+#endif
 
+#if defined __has_builtin && __has_builtin(__builtin_ceilf)
+extern "C++" inline __device__ float ceilf(float x) {
+  return __builtin_ceilf(x);
+}
+#else
 extern "C++" __device__ float ceil(float x); // OpenCL
 extern "C++" inline __device__ float ceilf(float x) { return ::ceil(x); }
+#endif
 
 extern "C++" __device__ float copysign(float x, float y); // OpenCL
 extern "C++" inline __device__ float copysignf(float x, float y) {
   return ::copysign(x, y);
 }
 
-extern "C++" __device__ float cos(float x); // OpenCL
+#if defined __has_builtin && __has_builtin(__builtin_cosf)
+extern "C++" inline __device__ float cosf(float x) {
+  return __builtin_cosf(x);
+}
+#elif defined __FAST_MATH__
 extern "C++" __device__ float native_cos(float x); // OpenCL
 extern "C++" inline __device__ float cosf(float x) {
-#ifdef __FAST_MATH__
   return ::native_cos(x);
-#else
-  return ::cos(x);
-#endif
 }
+#else
+extern "C++" __device__ float cos(float x); // OpenCL
+extern "C++" inline __device__ float cosf(float x) {
+  return ::cos(x);
+}
+#endif
 
+#if defined __has_builtin && __has_builtin(__builtin_coshf)
+extern "C++" inline __device__ float coshf(float x) {
+  return __builtin_coshf(x);
+}
+#else
 extern "C++" __device__ float cosh(float x); // OpenCL
 extern "C++" inline __device__ float coshf(float x) { return ::cosh(x); }
+#endif
 
 extern "C++" __device__ float cospi(float x); // OpenCL
 extern "C++" inline __device__ float cospif(float x) { return ::cospi(x); }
@@ -93,8 +135,14 @@ extern "C++" inline __device__ float cyl_bessel_i0f(float x) { return ::__ocml_i
 extern "C" __device__  float __ocml_i1_f32(float x); // OCML
 extern "C++" inline __device__ float cyl_bessel_i1f(float x) { return ::__ocml_i1_f32(x); }
 
+#if defined __has_builtin && __has_builtin(__builtin_erfcf)
+extern "C++" inline __device__ float erfcf(float x) {
+  return __builtin_erfcf(x);
+}
+#else
 extern "C++" __device__ float erfc(float x); // OpenCL
 extern "C++" inline __device__ float erfcf(float x) { return ::erfc(x); }
+#endif
 
 extern "C" __device__  float __ocml_erfcinv_f32(float x); // OCML
 extern "C++" inline __device__ float erfcinvf(float x) { return ::__ocml_erfcinv_f32(x); }
@@ -118,31 +166,46 @@ extern "C++" inline __device__ float exp10f(float x) {
 #endif
 }
 
-extern "C++" __device__ float exp2(float x); // OpenCL
-extern "C++" __device__ float native_exp2(float x); // OpenCL
+#if defined __has_builtin && __has_builtin(__builtin_exp2f)
 extern "C++" inline __device__ float exp2f(float x) {
-#ifdef __FAST_MATH__
-  return ::native_exp2(x);
-#else
-  return ::exp2(x);
-#endif
+  return __builtin_exp2f(x);
 }
+#elif defined __FAST_MATH__
+extern "C++" __device__ float exp2(float x); // OpenCL
+extern "C++" inline __device__ float exp2f(float x) { return ::native_exp2(x); }
+#else
+extern "C++" __device__ float native_exp2(float x); // OpenCL
+extern "C++" inline __device__ float exp2f(float x) { return ::exp2(x); }
+#endif
 
-extern "C++" __device__ float exp(float x); // OpenCL
+#if defined __has_builtin && __has_builtin(__builtin_expf)
+extern "C++" inline __device__ float expf(float x) { return __builtin_expf(x); }
+#elif defined __FAST_MATH__
 extern "C++" __device__ float native_exp(float x); // OpenCL
-extern "C++" inline __device__ float expf(float x) {
-#ifdef __FAST_MATH__
-  return ::native_exp(x);
+extern "C++" inline __device__ float expf(float x) { return ::native_exp(x); }
 #else
-  return ::exp(x);
+extern "C++" __device__ float exp(float x); // OpenCL
+extern "C++" inline __device__ float expf(float x) { return ::exp(x); }
 #endif
-}
 
+
+#if defined __has_builtin && __has_builtin(__builtin_expm1f)
+extern "C++" inline __device__ float expm1f(float x) {
+  return __builtin_expm1f(x);
+}
+#else
 extern "C++" __device__ float expm1(float x); // OpenCL
 extern "C++" inline __device__ float expm1f(float x) { return ::expm1(x); }
+#endif
 
+#if defined __has_builtin && __has_builtin(__builtin_fabsf)
+extern "C++" inline __device__ float fabsf(float x) {
+  return __builtin_fabsf(x);
+}
+#else
 extern "C++" __device__ float fabs(float x); // OpenCL
 extern "C++" inline __device__ float fabsf(float x) { return ::fabs(x); }
+#endif
 
 extern "C++" __device__ float fdim(float x, float y); // OpenCL
 extern "C++" inline __device__ float fdimf(float x, float y) {
@@ -158,38 +221,68 @@ extern "C++" inline __device__ float fdividef(float x, float y) {
 #endif
 }
 
+#if defined __has_builtin && __has_builtin(__builtin_floorf)
+extern "C++" inline __device__ float floorf(float x) {
+  return __builtin_floorf(x);
+}
+#else
 extern "C++" __device__ float floor(float x); // OpenCL
 extern "C++" inline __device__ float floorf(float x) { return ::floor(x); }
+#endif
 
 extern "C++" __device__ float fma(float x, float y, float z); // OpenCL
 extern "C++" inline __device__ float fmaf(float x, float y, float z) {
   return ::fma(x, y, z);
 }
 
+#if defined __has_builtin && __has_builtin(__builtin_fmaxf)
+extern "C++" inline __device__ float fmaxf(float x, float y) {
+  return __builtin_fmaxf(x, y);
+}
+#else
 extern "C++" __device__ float fmax(float x, float y); // OpenCL
 extern "C++" inline __device__ float fmaxf(float x, float y) {
   return ::fmax(x, y);
 }
+#endif
 
+#if defined __has_builtin && __has_builtin(__builtin_fminf)
+extern "C++" inline __device__ float fminf(float x, float y) {
+  return __builtin_fminf(x, y);
+}
+#else
 extern "C++" __device__ float fmin(float x, float y); // OpenCL
 extern "C++" inline __device__ float fminf(float x, float y) {
   return ::fmin(x, y);
 }
+#endif
 
+#if defined __has_builtin && __has_builtin(__builtin_fmodf)
+extern "C++" inline __device__ float fmodf(float x, float y) {
+  return __builtin_fmodf(x, y);
+}
+#else
 extern "C++" __device__ float fmod(float x, float y); // OpenCL
 extern "C++" inline __device__ float fmodf(float x, float y) {
   return ::fmod(x, y);
 }
+#endif
 
 extern "C++" __device__ float frexp(float x, int *nptr); // OpenCL
 extern "C++" inline __device__ float frexpf(float x, int *nptr) {
   return ::frexp(x, nptr);
 }
 
+#if defined __has_builtin && __has_builtin(__builtin_hypotf)
+extern "C++" inline __device__ float hypotf(float x, float y) {
+  return __builtin_hypotf(x, y);
+}
+#else
 extern "C++" __device__ float hypot(float x, float y); // OpenCL
 extern "C++" inline __device__ float hypotf(float x, float y) {
   return ::hypot(x, y);
 }
+#endif
 
 extern "C++" __device__ int ilogb(float x); // OpenCL
 extern "C++" inline __device__ int ilogbf(float x) { return ::ilogb(x); }
@@ -219,9 +312,20 @@ extern "C++" inline __device__ float ldexpf(float x, int exp) {
   return ::ldexp(x, exp);
 }
 
+#if defined __has_builtin && __has_builtin(__builtin_lgammaf)
+extern "C++" inline __device__ float lgammaf(float x) {
+  return __builtin_lgammaf(x);
+}
+extern "C++" inline __device__ float lgamma(float x) {
+  return __builtin_lgammaf(x);
+}
+#else
 extern "C" __device__  float __ocml_lgamma_f32(float x); // OCML
-extern "C++" inline __device__ float lgammaf(float x) { return ::__ocml_lgamma_f32(x); };
+extern "C++" inline __device__ float lgammaf(float x) {
+  return ::__ocml_lgamma_f32(x);
+};
 extern "C++" inline __device__ float lgamma(float x) { return ::lgammaf(x); }
+#endif
 
 extern "C" __device__  long long int __chip_llrint_f32(float x); // Custom
 extern "C++" inline __device__ long long int llrintf(float x) {
@@ -233,15 +337,21 @@ extern "C++" inline __device__ long long int llroundf(float x) {
   return __chip_llround_f32(x);
 }
 
-extern "C++" __device__ float log10(float x); // OpenCL
+#if defined __has_builtin && __has_builtin(__builtin_log10f)
+extern "C++" inline __device__ float log10f(float x) {
+  return __builtin_log10(x);
+}
+#elif defined __FAST_MATH__
 extern "C++" __device__ float native_log10(float x); // OpenCL
 extern "C++" inline __device__ float log10f(float x) {
-#ifdef __FAST_MATH__
   return ::native_log10(x);
-#else
-  return ::log10(x);
-#endif
 }
+#else
+extern "C++" __device__ float log10(float x); // OpenCL
+extern "C++" inline __device__ float log10f(float x) {
+  return ::log10(x);
+}
+#endif
 
 extern "C++" __device__ float log1p(float x); // OpenCL
 extern "C++" inline __device__ float log1pf(float x) { return ::log1p(x); }
@@ -259,15 +369,19 @@ extern "C++" inline __device__ float log2f(float x) {
 extern "C++" __device__ float logb(float x); // OpenCL
 extern "C++" inline __device__ float logbf(float x) { return ::logb(x); }
 
-extern "C++" __device__ float log(float x); // OpenCL
+#if defined __has_builtin && __has_builtin(__builtin_logf)
+extern "C++" inline __device__ float logf(float x) { return __builtin_log(x); }
+#elif defined __FAST_MATH__
 extern "C++" __device__ float native_log(float x); // OpenCL
 extern "C++" inline __device__ float logf(float x) {
-#ifdef __FAST_MATH__
   return ::native_log(x);
-#else
-  return ::log(x);
-#endif
 }
+#else
+extern "C++" __device__ float log(float x); // OpenCL
+extern "C++" inline __device__ float logf(float x) {
+  return ::log(x);
+}
+#endif
 
 extern "C" __device__  long int __chip_lrint_f32(float x); // Custom
 extern "C++" inline __device__ long int lrintf(float x) {
@@ -350,11 +464,17 @@ extern "C++" inline __device__ float norm(int dim, const float *p) {
   return ::__chip_norm_f32(dim, p);
 }
 
+#if defined __has_builtin && __has_builtin(__builtin_powf)
+extern "C++" inline __device__ float powf(float x, float y) {
+  return __builtin_powf(x, y);
+}
+#else
 extern "C++" __device__ float pow(float x, float y); // OpenCL
 extern "C++" inline __device__ float powf(float x, float y) {
   // TODO This function is affected by the --use_fast_math compiler flag
   return ::pow(x, y);
 }
+#endif
 
 extern "C" __device__  float __ocml_rcbrt_f32(float x); // OCML
 extern "C++" inline __device__ float rcbrtf(float x) { return ::__ocml_rcbrt_f32(x); }
@@ -374,8 +494,14 @@ extern "C++" inline __device__ float rhypotf(float x, float y) {
   return ::__ocml_rhypot_f32(x, y);
 }
 
+#if defined __has_builtin && __has_builtin(__builtin_rintf)
+extern "C++" inline __device__ float rintf(float x) {
+  return __builtin_rintf(x);
+}
+#else
 extern "C++" __device__ float rint(float x); // OpenCL
 extern "C++" inline __device__ float rintf(float x) { return ::rint(x); }
+#endif
 
 extern "C" __device__ float __ocml_rlen3_f32(float a, float b,
                                               float c); // OCML
@@ -400,10 +526,16 @@ extern "C++" inline __device__ float rnorm(int dim, const float *p) {
   return ::rnormf(dim, p);
 }
 
+#if defined __has_builtin && __has_builtin(__builtin_roundf)
+extern "C++" inline __device__ float roundf(float x) {
+  return __builtin_roundf(x);
+}
+#else
 extern "C++" __device__ float round(float x); // OpenCL
 extern "C++" inline __device__ float roundf(float x) {
   return static_cast<float>(::round(x));
 }
+#endif
 
 extern "C++" __device__ float rsqrt(float x);        // OpenCL
 extern "C++" __device__ float native_rsqrt(float x); // OpenCL
@@ -425,7 +557,16 @@ extern "C++" inline __device__ float scalblnf(float x, long int n) {
   return (n < INT_MAX) ? ::__ocml_scalbn_f32(x, (int)n) : ::__ocml_scalb_f32(x, (float)n);
 }
 
+#if defined __has_builtin && __has_builtin(__builtin_signbitf)
+extern "C++" inline __device__ int signbitf(float a) {
+  return __builtin_signbitf(a);
+}
+#else
 extern "C" __device__  int __ocml_signbit_f32(float a); // OCML
+extern "C++" inline __device__ int signbitf(float a) {
+  return __ocml_signbit_f32(a);
+}
+#endif
 
 extern "C++" __device__ float sincos(float x, float *sptr); // OpenCL
 extern "C++" inline __device__ void sincosf(float x, float *sptr, float *cptr) {
@@ -440,50 +581,74 @@ extern "C++" inline __device__ void sincospif(float x, float *sptr,
   return __chip_sincospi_f32(x, sptr, cptr);
 }
 
-extern "C++" __device__ float sin(float x); // OpenCL
+#if defined __has_builtin && __has_builtin(__builtin_sinf)
+extern "C++" inline __device__ float sinf(float x) { return __builtin_sinf(x); }
+#elif defined __FAST_MATH__
 extern "C++" __device__ float native_sin(float x); // OpenCL
-extern "C++" inline __device__ float sinf(float x) {
-#ifdef __FAST_MATH__
-  return ::native_sin(x);
+extern "C++" inline __device__ float sinf(float x) { return ::native_sin(x); }
 #else
-  return ::sin(x);
+extern "C++" __device__ float sin(float x); // OpenCL
+extern "C++" inline __device__ float sinf(float x) { return ::sin(x); }
 #endif
-}
 
+#if defined __has_builtin && __has_builtin(__builtin_sinhf)
+extern "C++" inline __device__ float sinhf(float x) {
+  return __builtin_sinhf(x);
+}
+#else
 extern "C++" __device__ float sinh(float x); // OpenCL
 extern "C++" inline __device__ float sinhf(float x) { return ::sinh(x); }
+#endif
 
 extern "C++" __device__ float sinpi(float x); // OpenCL
 extern "C++" inline __device__ float sinpif(float x) { return ::sinpi(x); }
 
-extern "C++" __device__ float sqrt(float x); // OpenCL
+#if defined __has_builtin && __has_builtin(__builtin_sqrtf)
+extern "C++" inline __device__ float sqrtf(float x) {
+  return __builtin_sqrtf(x);
+}
+#elif defined __FAST_MATH__
 extern "C++" __device__ float native_sqrt(float x); // OpenCL
 extern "C++" inline __device__ float sqrtf(float x) {
-#ifdef __FAST_MATH__
   return ::native_sqrt(x);
+}
 #else
+extern "C++" __device__ float sqrt(float x); // OpenCL
+extern "C++" inline __device__ float sqrtf(float x) {
   return ::sqrt(x);
-#endif
 }
+#endif
 
-extern "C++" __device__ float tan(float x); // OpenCL
+#if defined __has_builtin && __has_builtin(__builtin_tanf)
+extern "C++" inline __device__ float tanf(float x) { return __builtin_tanf(x); }
+#elif defined __FAST_MATH__
 extern "C++" __device__ float native_tan(float x); // OpenCL
-extern "C++" inline __device__ float tanf(float x) {
-#ifdef __FAST_MATH__
-  return ::native_tan(x);
+extern "C++" inline __device__ float tanf(float x) { return ::native_tan(x); }
 #else
-  return ::tan(x);
+extern "C++" __device__ float tan(float x); // OpenCL
+extern "C++" inline __device__ float tanf(float x) { return ::tan(x); }
 #endif
-}
 
+#if defined __has_builtin && __has_builtin(__builtin_tanhf)
+extern "C++" inline __device__ float tanhf(float x) {
+  return __builtin_tanhf(x);
+}
+#else
 extern "C++" __device__ float tanh(float x); // OpenCL
 extern "C++" inline __device__ float tanhf(float x) { return ::tanh(x); }
+#endif
 
 extern "C++" __device__ float tgamma(float x); // OpenCL
 extern "C++" inline __device__ float tgammaf(float x) { return ::tgamma(x); }
 
+#if defined __has_builtin && __has_builtin(__builtin_truncf)
+extern "C++" inline __device__ float truncf(float x) {
+  return __builtin_truncf(x);
+}
+#else
 extern "C++" __device__ float trunc(float x); // OpenCL
 extern "C++" inline __device__ float truncf(float x) { return ::trunc(x); }
+#endif
 
 extern "C" __device__  float __ocml_y0_f32(float x); // OCML
 extern "C++" inline __device__ float y0f(float x) { return ::__ocml_y0_f32(x); }


### PR DESCRIPTION
Map a set of HIP built-ins referenced by HeCBench benchmarks to compiler built-ins. The myocyte-hip benchmark seems to benefit from this the most - most likely due to:

* HIP built-in calls with compile time values which are constant-folded.

* HIP built-in calls which are simplified such as `pow(x, 2) --> x*x`.
