### PR TITLE
Fix tests were unintentinally skipped

### DIFF
--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -23,6 +23,8 @@
 #
 #=============================================================================
 
+set(CHIP_SKIP_TEST 77)
+
 function(add_hip_runtime_test MAIN_SOURCE)
   get_filename_component(EXEC_NAME ${MAIN_SOURCE} NAME_WLE)
   set_source_files_properties(${MAIN_SOURCE} PROPERTIES LANGUAGE CXX)
@@ -35,10 +37,13 @@ function(add_hip_runtime_test MAIN_SOURCE)
   target_include_directories("${EXEC_NAME}"
     PRIVATE $<TARGET_PROPERTY:CHIP,INCLUDE_DIRECTORIES>)
 
+  target_compile_definitions("${EXEC_NAME}"
+    PRIVATE CHIP_SKIP_TEST=${CHIP_SKIP_TEST})
+
   add_test(NAME ${EXEC_NAME} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${EXEC_NAME})
 
   set_tests_properties("${EXEC_NAME}" PROPERTIES
-    SKIP_REGULAR_EXPRESSION "SKIP")
+    SKIP_RETURN_CODE ${CHIP_SKIP_TEST})
 
 endfunction()
 

--- a/tests/runtime/TestBallot.hip
+++ b/tests/runtime/TestBallot.hip
@@ -34,7 +34,7 @@ int main() {
   (void)hipGetDeviceProperties(&Props, 0);
   if (!Props.arch.hasWarpBallot) {
     printf("SKIP: device does not support __ballot()\n");
-    return 2;
+    return CHIP_SKIP_TEST;
   }
 
   checkBallot(32, 0xBADF00D1, Props);

--- a/tests/runtime/TestIndirectMappedHostAlloc.hip
+++ b/tests/runtime/TestIndirectMappedHostAlloc.hip
@@ -23,7 +23,7 @@ int main() {
   HIP_CHECK(hipGetDeviceProperties(&Prop, Device));
   if (!Prop.canMapHostMemory) {
     printf("SKIP: Test requires canMapHostMemory == 1\n");
-    return 2;
+    return CHIP_SKIP_TEST;
   }
 
   int *InH, *OutH;


### PR DESCRIPTION
Fix tests under `tests/runtime/` were unintentinally skipped in debug builds due to word "SKIP" appearing in the chipStar's debug prints. More specifically, the tests were skipped due to `CHIP debug ... : CHIP_SKIP_UNINIT=...` messages.

Fixed the issue by changing the skipping logic to be exit code based.