### PR TITLE
Dynamic event pools

### DIFF
--- a/samples/hipMultiThreadAddCallback/hipMultiThreadAddCallback.cc
+++ b/samples/hipMultiThreadAddCallback/hipMultiThreadAddCallback.cc
@@ -158,7 +158,6 @@ int main() {
 
   // Wait until all the threads finish their execution
   for (int i = 0; i < numThreads; i++) {
-    std::cout << "Joining Tid#" << i << "\n";
     T[i].join();
   }
 

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -212,9 +212,20 @@ chipstar::Event::Event(chipstar::Context *Ctx, chipstar::EventFlags Flags)
     : EventStatus_(EVENT_STATUS_INIT), Flags_(Flags), ChipContext_(Ctx),
       Msg("") {}
 
+void chipstar::Event::addDependency(
+    const std::shared_ptr<chipstar::Event> &Event) {
+  assert(!Deleted_ && "Event use after delete!");
+  logDebug("Event {} Msg {} now depends on event {} msg:{}", (void *)this, Msg,
+           (void *)Event.get(), Event->Msg);
+  DependsOnList.push_back(Event);
+}
+
 void chipstar::Event::releaseDependencies() {
   assert(!Deleted_ && "chipstar::Event use after delete!");
   LOCK(EventMtx); // chipstar::Event::DependsOnList
+  for (auto &Dep : DependsOnList)
+    logDebug("Event {} msg: {} no longer depends on event {}", (void *)this,
+             Msg, (void *)Dep.get(), Dep->Msg);
   DependsOnList.clear();
 }
 

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1494,8 +1494,9 @@ chipstar::Queue::getSyncQueuesLastEvents() {
   LOCK(Dev->DeviceMtx); // chipstar::Device::ChipQueues_ via getQueuesNoLock()
 
   std::vector<std::shared_ptr<chipstar::Event>> EventsToWaitOn;
-  if (this->getLastEvent())
-    EventsToWaitOn.push_back(this->getLastEvent());
+  auto thisLastEvent = this->getLastEvent();
+  if (thisLastEvent)
+    EventsToWaitOn.push_back(thisLastEvent);
 
   // If this stream is default legacy stream, sync with all other streams on
   // this device

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1680,7 +1680,7 @@ void chipstar::Queue::memFillAsync3D(hipPitchedPtr PitchedDevPtr, int Value,
         ChipEvent->Msg = "memFillAsync3D";
         ::Backend->trackEvent(ChipEvent);
       } else
-        memFillAsync(DstP + Offset, SizeBytes, &Value, 1);
+        memFillAsyncImpl(DstP + Offset, SizeBytes, &Value, 1);
     }
 }
 

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1597,13 +1597,9 @@ void chipstar::Queue::memCopyAsync2D(void *Dst, size_t DPitch, const void *Src,
 
   // perform the copy
   for (size_t i = 0; i < Height; ++i) {
-    // capture the event on last iteration
-    if (i == Height - 1) {
-      ChipEvent = memCopyAsyncImpl(Dst, Src, Width);
-      ChipEvent->Msg = "memCopyAsync2D";
-    } else {
-      memCopyAsyncImpl(Dst, Src, Width);
-    }
+    ChipEvent = memCopyAsyncImpl(Dst, Src, Width);
+    ChipEvent->Msg = "memCopyAsync2D";
+    ::Backend->trackEvent(ChipEvent);
     Src = (char *)Src + SPitch;
     Dst = (char *)Dst + DPitch;
   }
@@ -1612,9 +1608,6 @@ void chipstar::Queue::memCopyAsync2D(void *Dst, size_t DPitch, const void *Src,
     this->MemMap(AllocInfoDst, chipstar::Queue::MEM_MAP_TYPE::HOST_READ_WRITE);
   if (AllocInfoSrc && AllocInfoSrc->MemoryType == hipMemoryTypeHost)
     this->MemMap(AllocInfoSrc, chipstar::Queue::MEM_MAP_TYPE::HOST_READ_WRITE);
-
-  if (ChipEvent)
-    ::Backend->trackEvent(ChipEvent);
 }
 
 void chipstar::Queue::memFill(void *Dst, size_t Size, const void *Pattern,
@@ -1649,13 +1642,9 @@ void chipstar::Queue::memFillAsync2D(void *Dst, size_t Pitch, int Value,
   for (size_t i = 0; i < Height; i++) {
     auto Offset = Pitch * i;
     char *DstP = (char *)Dst;
-    // capture the returned event on last iteration, otherwise don't
-    if (i == Height - 1) {
-      ChipEvent = memFillAsyncImpl(DstP + Offset, SizeBytes, &Value, 1);
-      ChipEvent->Msg = "memFillAsync2D";
-      ::Backend->trackEvent(ChipEvent);
-    } else
-      memFillAsyncImpl(DstP + Offset, SizeBytes, &Value, 1);
+    ChipEvent = memFillAsyncImpl(DstP + Offset, SizeBytes, &Value, 1);
+    ChipEvent->Msg = "memFillAsync2D";
+    ::Backend->trackEvent(ChipEvent);
   }
 }
 
@@ -1675,13 +1664,9 @@ void chipstar::Queue::memFillAsync3D(hipPitchedPtr PitchedDevPtr, int Value,
       size_t SizeBytes = Width;
       auto Offset = i * (Pitch * PitchedDevPtr.ysize) + j * Pitch;
       char *DstP = (char *)Dst;
-      // capture the returned event on last iteration, otherwise don't
-      if (i == Depth - 1 && j == Height - 1) {
-        ChipEvent = memFillAsyncImpl(DstP + Offset, SizeBytes, &Value, 1);
-        ChipEvent->Msg = "memFillAsync3D";
-        ::Backend->trackEvent(ChipEvent);
-      } else
-        memFillAsyncImpl(DstP + Offset, SizeBytes, &Value, 1);
+      ChipEvent = memFillAsyncImpl(DstP + Offset, SizeBytes, &Value, 1);
+      ChipEvent->Msg = "memFillAsync3D";
+      ::Backend->trackEvent(ChipEvent);
     }
 }
 

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -668,10 +668,11 @@ public:
   void setTrackCalled(bool Val) { TrackCalled_ = Val; }
   bool isUserEvent() { return UserEvent_; }
   void setUserEvent(bool Val) { UserEvent_ = Val; }
-  void addDependency(const std::shared_ptr<chipstar::Event> &Event) {
-    assert(!Deleted_ && "Event use after delete!");
-    DependsOnList.push_back(Event);
-  }
+  /// @brief Add an event on which this event depends, preventing that event
+  /// from getting recycled
+  /// @param Event
+  void addDependency(const std::shared_ptr<chipstar::Event> &Event);
+  /// @brief Release dependencies, allowing them to be recycled
   void releaseDependencies();
   chipstar::EventFlags getFlags() { return Flags_; }
   std::mutex EventMtx;

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1773,8 +1773,7 @@ public:
  */
 class Backend {
 protected:
-  chipstar::EventMonitor *CallbackEventMonitor_ = nullptr;
-  chipstar::EventMonitor *StaleEventMonitor_ = nullptr;
+  chipstar::EventMonitor *EventMonitor_ = nullptr;
 
   int MinQueuePriority_;
   int MaxQueuePriority_ = 0;
@@ -2024,8 +2023,7 @@ public:
   createCallbackData(hipStreamCallback_t Callback, void *UserData,
                      chipstar::Queue *ChipQ) = 0;
 
-  virtual chipstar::EventMonitor *createCallbackEventMonitor_() = 0;
-  virtual chipstar::EventMonitor *createStaleEventMonitor_() = 0;
+  virtual chipstar::EventMonitor *createEventMonitor_() = 0;
 
   /* event interop */
   virtual hipEvent_t getHipEvent(void *NativeEvent) = 0;

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -895,8 +895,8 @@ std::vector<ze_event_handle_t> CHIPQueueLevel0::addDependenciesQueueSync(
   // that they don't get destroyed before MemCopyEvent
   for (auto &Event : EventsToWaitOn) {
     LOCK(Event->EventMtx);
-    std::static_pointer_cast<CHIPEventLevel0>(Event)->addDependency(
-        TargetEvent);
+    std::static_pointer_cast<CHIPEventLevel0>(TargetEvent)
+        ->addDependency(Event);
   }
 
   std::vector<ze_event_handle_t> EventHandles =

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -721,9 +721,8 @@ void CHIPStaleEventMonitorLevel0::checkEvents() {
 
     ChipEventLz->isDeletedSanityCheck();
 
-    // delete the event if refcount reached 2
-    // this->ChipEvent and LZEventPool::Events_
-    if (ChipEventLz.use_count() == 2) {
+    // delete the event if refcount reached 1 (this->ChipEventLz)
+    if (ChipEventLz.use_count() == 1) {
       if (ChipEventLz->EventPool) {
         ChipEventLz->isDeletedSanityCheck();
         ChipEventLz->EventPool->returnEvent(ChipEventLz);
@@ -1682,8 +1681,7 @@ LZEventPool::LZEventPool(CHIPContextLevel0 *Ctx, unsigned int Size)
     chipstar::EventFlags Flags;
     auto NewEvent = std::shared_ptr<CHIPEventLevel0>(
         new CHIPEventLevel0(Ctx_, this, i, Flags));
-    Events_.push_back(NewEvent);
-    AvailableEvents_.push(NewEvent);
+    Events_.push(NewEvent);
   }
 };
 
@@ -1695,9 +1693,8 @@ LZEventPool::~LZEventPool() {
     logWarn("CHIPUserEventLevel0 objects still exist at the time of EventPool "
             "destruction");
 
-  while (AvailableEvents_.size())
-    AvailableEvents_.pop();
-  Events_.clear(); // shared_ptr's will be deleted
+  while (Events_.size())
+    Events_.pop();
   // The application must not call this function from
   // simultaneous threads with the same event pool handle.
   // Done via destructor should not be called from multiple threads
@@ -1708,11 +1705,11 @@ LZEventPool::~LZEventPool() {
 
 std::shared_ptr<CHIPEventLevel0> LZEventPool::getEvent() {
   std::shared_ptr<CHIPEventLevel0> Event;
-  if (!AvailableEvents_.size())
+  if (!Events_.size())
     return nullptr;
 
-  Event = AvailableEvents_.top();
-  AvailableEvents_.pop();
+  Event = Events_.top();
+  Events_.pop();
 
   return Event;
 };
@@ -1723,7 +1720,7 @@ void LZEventPool::returnEvent(std::shared_ptr<CHIPEventLevel0> Event) {
   LOCK(EventPoolMtx);
   logTrace("Returning event {} handle {}", (void *)Event.get(),
            (void *)Event.get()->get());
-  AvailableEvents_.push(Event);
+  Events_.push(Event);
 }
 
 // End EventPool

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1403,9 +1403,9 @@ std::shared_ptr<chipstar::Event> CHIPQueueLevel0::enqueueBarrierImpl(
       static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(
           ChipContext_);
   BarrierEvent->Msg = "barrier";
-  size_t NumEventsToWaitFor = 0;
 
-  NumEventsToWaitFor = EventsToWaitFor.size();
+  auto QueueSyncEvents = addDependenciesQueueSync(BarrierEvent);
+  size_t NumEventsToWaitFor = QueueSyncEvents.size() + EventsToWaitFor.size();
 
   ze_event_handle_t *EventHandles = nullptr;
   ze_event_handle_t SignalEventHandle = nullptr;
@@ -1415,13 +1415,17 @@ std::shared_ptr<chipstar::Event> CHIPQueueLevel0::enqueueBarrierImpl(
 
   if (NumEventsToWaitFor > 0) {
     EventHandles = new ze_event_handle_t[NumEventsToWaitFor];
-    for (size_t i = 0; i < NumEventsToWaitFor; i++) {
+    for (size_t i = 0; i < EventsToWaitFor.size(); i++) {
       std::shared_ptr<chipstar::Event> ChipEvent = EventsToWaitFor[i];
       std::shared_ptr<CHIPEventLevel0> ChipEventLz =
           std::static_pointer_cast<CHIPEventLevel0>(ChipEvent);
       CHIPASSERT(ChipEventLz);
       EventHandles[i] = ChipEventLz->peek();
       BarrierEvent->addDependency(ChipEventLz);
+    }
+
+    for (size_t i = 0; i < QueueSyncEvents.size(); i++) {
+      EventHandles[i + EventsToWaitFor.size()] = QueueSyncEvents[i];
     }
   } // done gather Event_ handles to wait on
 
@@ -1448,9 +1452,9 @@ std::shared_ptr<chipstar::Event> CHIPQueueLevel0::enqueueBarrierImplReg(
       static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(
           ChipContext_);
   BarrierEvent->Msg = "barrier";
-  size_t NumEventsToWaitFor = 0;
 
-  NumEventsToWaitFor = EventsToWaitFor.size();
+  auto QueueSyncEvents = addDependenciesQueueSync(BarrierEvent);
+  size_t NumEventsToWaitFor = QueueSyncEvents.size() + EventsToWaitFor.size();
 
   ze_event_handle_t *EventHandles = nullptr;
   ze_event_handle_t SignalEventHandle = nullptr;
@@ -1460,13 +1464,17 @@ std::shared_ptr<chipstar::Event> CHIPQueueLevel0::enqueueBarrierImplReg(
 
   if (NumEventsToWaitFor > 0) {
     EventHandles = new ze_event_handle_t[NumEventsToWaitFor];
-    for (size_t i = 0; i < NumEventsToWaitFor; i++) {
+    for (size_t i = 0; i < EventsToWaitFor.size(); i++) {
       std::shared_ptr<chipstar::Event> ChipEvent = EventsToWaitFor[i];
       std::shared_ptr<CHIPEventLevel0> ChipEventLz =
           std::static_pointer_cast<CHIPEventLevel0>(ChipEvent);
       CHIPASSERT(ChipEventLz);
       EventHandles[i] = ChipEventLz->peek();
       BarrierEvent->addDependency(ChipEventLz);
+    }
+
+    for (size_t i = 0; i < QueueSyncEvents.size(); i++) {
+      EventHandles[i + EventsToWaitFor.size()] = QueueSyncEvents[i];
     }
   } // done gather Event_ handles to wait on
 

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -662,8 +662,9 @@ void CHIPStaleEventMonitorLevel0::checkEvents() {
       ChipEventLz->doActions();
     }
 
-    // delete the event if refcount reached 1 (this->ChipEvent)
-    if (ChipEventLz.use_count() == 1) {
+    // delete the event if refcount reached 2
+    // this->ChipEvent and LZEventPool::Events_ 
+    if (ChipEventLz.use_count() == 2) {
       if (ChipEventLz->EventPool) {
         ChipEventLz->EventPool->returnEvent(ChipEventLz);
       }

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1645,6 +1645,8 @@ std::shared_ptr<CHIPEventLevel0> LZEventPool::getEvent() {
 
 void LZEventPool::returnEvent(std::shared_ptr<CHIPEventLevel0> Event) {
   LOCK(EventPoolMtx);
+  logTrace("Returning event {} handle {}", (void *)Event.get(),
+           (void *)Event.get()->get());
   AvailableEvents_.push(Event);
 }
 

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -728,7 +728,6 @@ void CHIPStaleEventMonitorLevel0::checkEvents() {
         ChipEventLz->isDeletedSanityCheck();
         ChipEventLz->EventPool->returnEvent(ChipEventLz);
       }
-      ChipEventLz->markDeleted();
     }
 
   } // done collecting events to delete

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -218,6 +218,7 @@ createSampler(CHIPDeviceLevel0 *ChipDev, const hipResourceDesc *PResDesc,
 
 void CHIPEventLevel0::assignCmdList(CHIPContextLevel0 *ChipContext,
                                     ze_command_list_handle_t CmdList) {
+  isDeletedSanityCheck();
   logTrace("CHIPEventLevel0({})::assignCmdList({})", (void *)this,
            (void *)CmdList);
   assert(AssignedCmdList_ == nullptr && "command list already assigned!");
@@ -244,8 +245,6 @@ void CHIPEventLevel0::reset() {
   if (DependsOnList.size() > 0)
     logWarn("CHIPEventLevel0::reset() called while event has dependencies");
   DependsOnList.clear();
-  // assert(DependsOnList.empty() && "CHIPEventLevel0::reset() called while "
-  //                                 "event has dependencies");
   auto Status = zeEventHostReset(Event_);
   CHIPERR_CHECK_LOG_AND_THROW(Status, ZE_RESULT_SUCCESS, hipErrorTbd);
   {
@@ -259,14 +258,12 @@ void CHIPEventLevel0::reset() {
     Timestamp_ = 0;
     HostTimestamp_ = 0;
     DeviceTimestamp_ = 0;
-#ifndef NDEBUG
-    Deleted_ = false;
-#endif
+    markDeleted(false);
   }
 }
 
 ze_event_handle_t CHIPEventLevel0::peek() {
-  assert(!Deleted_ && "chipstar::Event use after delete!");
+  isDeletedSanityCheck();
   return Event_;
 }
 
@@ -425,7 +422,7 @@ void CHIPQueueLevel0::recordEvent(chipstar::Event *ChipEvent) {
 }
 
 bool CHIPEventLevel0::wait() {
-  assert(!Deleted_ && "chipstar::Event use after delete!");
+  isDeletedSanityCheck();
   logTrace("CHIPEventLevel0::wait(timeout: {}) {} Msg: {} Handle: {}",
            ChipEnvVars.getL0EventTimeout(), (void *)this, Msg, (void *)Event_);
 
@@ -447,7 +444,7 @@ bool CHIPEventLevel0::wait() {
 }
 
 bool CHIPEventLevel0::updateFinishStatus(bool ThrowErrorIfNotReady) {
-  assert(!Deleted_ && "chipstar::Event use after delete!");
+  isDeletedSanityCheck();
   std::string EventStatusOld, EventStatusNew;
   {
     LOCK(EventMtx); // chipstar::Event::EventStatus_
@@ -472,6 +469,7 @@ bool CHIPEventLevel0::updateFinishStatus(bool ThrowErrorIfNotReady) {
 }
 
 uint32_t CHIPEventLevel0::getValidTimestampBits() {
+  isDeletedSanityCheck();
   CHIPContextLevel0 *ChipCtxLz = (CHIPContextLevel0 *)ChipContext_;
   CHIPDeviceLevel0 *ChipDevLz = (CHIPDeviceLevel0 *)ChipCtxLz->getDevice();
   auto Props = ChipDevLz->getDeviceProps();
@@ -479,6 +477,7 @@ uint32_t CHIPEventLevel0::getValidTimestampBits() {
 }
 
 unsigned long CHIPEventLevel0::getFinishTime() {
+  isDeletedSanityCheck();
   CHIPContextLevel0 *ChipCtxLz = (CHIPContextLevel0 *)ChipContext_;
   CHIPDeviceLevel0 *ChipDevLz = (CHIPDeviceLevel0 *)ChipCtxLz->getDevice();
   auto Props = ChipDevLz->getDeviceProps();
@@ -551,7 +550,7 @@ float CHIPEventLevel0::getElapsedTime(chipstar::Event *OtherIn) {
 }
 
 void CHIPEventLevel0::hostSignal() {
-  assert(!Deleted_ && "chipstar::Event use after delete!");
+  isDeletedSanityCheck();
   logTrace("CHIPEventLevel0::hostSignal() {} Msg: {} Handle: {}", (void *)this,
            Msg, (void *)Event_);
   auto Status = zeEventHostSignal(Event_);
@@ -705,6 +704,7 @@ void CHIPStaleEventMonitorLevel0::checkEvents() {
   for (size_t EventIdx = 0; EventIdx < Backend->Events.size(); EventIdx++) {
     std::shared_ptr<CHIPEventLevel0> ChipEventLz =
         std::static_pointer_cast<CHIPEventLevel0>(Backend->Events[EventIdx]);
+    ChipEventLz->isDeletedSanityCheck();
 
     assert(ChipEventLz);
     assert(!ChipEventLz->isUserEvent() &&
@@ -719,15 +719,16 @@ void CHIPStaleEventMonitorLevel0::checkEvents() {
       ChipEventLz->doActions();
     }
 
+    ChipEventLz->isDeletedSanityCheck();
+
     // delete the event if refcount reached 2
     // this->ChipEvent and LZEventPool::Events_
     if (ChipEventLz.use_count() == 2) {
       if (ChipEventLz->EventPool) {
+        ChipEventLz->isDeletedSanityCheck();
         ChipEventLz->EventPool->returnEvent(ChipEventLz);
       }
-#ifndef NDEBUG
       ChipEventLz->markDeleted();
-#endif
     }
 
   } // done collecting events to delete
@@ -891,12 +892,19 @@ CHIPQueueLevel0::~CHIPQueueLevel0() {
 std::vector<ze_event_handle_t> CHIPQueueLevel0::addDependenciesQueueSync(
     std::shared_ptr<chipstar::Event> TargetEvent) {
   auto EventsToWaitOn = getSyncQueuesLastEvents();
+  for (auto &Event : EventsToWaitOn)
+    Event->isDeletedSanityCheck();
+
   // Every event in EventsToWaitOn should have a dependency on MemCopyEvent so
   // that they don't get destroyed before MemCopyEvent
   for (auto &Event : EventsToWaitOn) {
     LOCK(Event->EventMtx);
     std::static_pointer_cast<CHIPEventLevel0>(TargetEvent)
         ->addDependency(Event);
+  }
+
+  for (auto &Event : EventsToWaitOn) {
+    Event->isDeletedSanityCheck();
   }
 
   std::vector<ze_event_handle_t> EventHandles =
@@ -1711,6 +1719,8 @@ std::shared_ptr<CHIPEventLevel0> LZEventPool::getEvent() {
 };
 
 void LZEventPool::returnEvent(std::shared_ptr<CHIPEventLevel0> Event) {
+  Event->isDeletedSanityCheck();
+  Event->markDeleted();
   LOCK(EventPoolMtx);
   logTrace("Returning event {} handle {}", (void *)Event.get(),
            (void *)Event.get()->get());
@@ -1743,6 +1753,7 @@ CHIPBackendLevel0::createEventShared(chipstar::Context *ChipCtx,
   assert(!std::static_pointer_cast<CHIPEventLevel0>(Event)->getAssignedCmdList());
   logDebug("CHIPBackendLevel0::createEventShared: Context {} Event {}",
            (void *)ChipCtx, (void *)Event.get());
+  Event->isDeletedSanityCheck();
   return Event;
 }
 

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -239,6 +239,8 @@ void CHIPEventLevel0::unassignCmdList() {
 }
 
 void CHIPEventLevel0::reset() {
+  logTrace("CHIPEventLevel0::reset() {} msg: {} handle: {}", (void *)this, Msg,
+           (void *)Event_);
   auto Status = zeEventHostReset(Event_);
   CHIPERR_CHECK_LOG_AND_THROW(Status, ZE_RESULT_SUCCESS, hipErrorTbd);
   {
@@ -264,7 +266,8 @@ ze_event_handle_t CHIPEventLevel0::peek() {
 }
 
 CHIPEventLevel0::~CHIPEventLevel0() {
-  logTrace("~CHIPEventLevel0({})", (void *)this);
+  logTrace("~CHIPEventLevel0() {} msg: {} handle: {}", (void *)this, Msg,
+           (void *)Event_);
   // if in RECORDING state, wait to finish
   if (EventStatus_ == EVENT_STATUS_RECORDING) {
     logTrace("~CHIPEventLevel0({}) waiting for event to finish", (void *)this);
@@ -279,10 +282,8 @@ CHIPEventLevel0::~CHIPEventLevel0() {
     // assert(false);
   }
 
-  if (Event_) {
-    auto Status = zeEventDestroy(Event_);
-    assert(Status == ZE_RESULT_SUCCESS);
-  }
+  auto Status = zeEventDestroy(Event_);
+  assert(Status == ZE_RESULT_SUCCESS);
 
   if (isUserEvent()) {
     assert(!TrackCalled_ &&
@@ -454,10 +455,7 @@ bool CHIPEventLevel0::updateFinishStatus(bool ThrowErrorIfNotReady) {
 
     EventStatusNew = getEventStatusStr();
   }
-  // logTrace("CHIPEventLevel0::updateFinishStatus() {} Refc: {} {}: {} ->
-  // {}",
-  //          (void *)this, getCHIPRefc(), Msg, EventStatusOld,
-  //          EventStatusNew);
+
   if (EventStatusNew != EventStatusOld) {
     return true;
   }
@@ -546,7 +544,8 @@ float CHIPEventLevel0::getElapsedTime(chipstar::Event *OtherIn) {
 
 void CHIPEventLevel0::hostSignal() {
   assert(!Deleted_ && "chipstar::Event use after delete!");
-  logTrace("CHIPEventLevel0::hostSignal()");
+  logTrace("CHIPEventLevel0::hostSignal() {} Msg: {} Handle: {}", (void *)this,
+           Msg, (void *)Event_);
   auto Status = zeEventHostSignal(Event_);
   CHIPERR_CHECK_LOG_AND_THROW(Status, ZE_RESULT_SUCCESS, hipErrorTbd);
 
@@ -1669,6 +1668,7 @@ CHIPBackendLevel0::createEventShared(chipstar::Context *ChipCtx,
 
   auto ZeCtx = (CHIPContextLevel0 *)ChipCtx;
   Event = ZeCtx->getEventFromPool();
+  assert(Event && "LZEventPool returned a null event");
 
   std::static_pointer_cast<CHIPEventLevel0>(Event)->reset();
   assert(!std::static_pointer_cast<CHIPEventLevel0>(Event)->getAssignedCmdList());
@@ -1681,7 +1681,7 @@ chipstar::Event *CHIPBackendLevel0::createEvent(chipstar::Context *ChipCtx,
                                                 chipstar::EventFlags Flags) {
   auto Event = new CHIPEventLevel0((CHIPContextLevel0 *)ChipCtx, Flags);
   Event->setUserEvent(true);
-  logDebug("CHIPBackendLevel0::createEventd: Context {} Event {}",
+  logDebug("CHIPBackendLevel0::createEvent: Context {} Event {}",
            (void *)ChipCtx, (void *)Event);
   return Event;
 }

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -79,8 +79,8 @@ public:
   using ActionFn = std::function<void()>;
 
 private:
-  ze_command_list_handle_t AssocCmdList_ = nullptr;
-  CHIPContextLevel0 *AssocContext_ = nullptr;
+  ze_command_list_handle_t AssignedCmdList_ = nullptr;
+  CHIPContextLevel0 *AssignedContext_ = nullptr;
   /// Device timestamp gets ultimately stored here
   uint64_t Timestamp_ = 0;
   /// Since device counters can overflow resulting in a negative time between
@@ -98,23 +98,23 @@ public:
   uint64_t &getTimestamp() { return Timestamp_; }
   uint64_t &getDeviceTimestamp() { return DeviceTimestamp_; }
   uint64_t &getHostTimestamp() { return HostTimestamp_; }
-  ze_command_list_handle_t getAssocCmdList() { return AssocCmdList_; }
+  ze_command_list_handle_t getAssignedCmdList() { return AssignedCmdList_; }
 
   /**
-   * @brief Associate a command list with this event. When this event completes,
+   * @brief Assign a command list with this event. When this event completes,
    * the EventMonitor thread will return the command list handle back to the
    * queue stack where it came from.
    *
    * @param ChipQueue queue where the event was created (and where the command
    * list stack resides)
-   * @param CmdList command list to associate with this event
+   * @param CmdList command list to Assign with this event
    */
   void assignCmdList(CHIPContextLevel0 *ChipContext,
                         ze_command_list_handle_t CmdList);
 
   /**
    * @brief Reset and then return the command list handle back to the context
-   * pointed by AssocContext_
+   * pointed by AssignedContext_
    */
   void unassignCmdList();
 

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -23,8 +23,6 @@
 #ifndef CHIP_BACKEND_LEVEL0_H
 #define CHIP_BACKEND_LEVEL0_H
 
-// TODO: Should this be a cmake parameter? env? What is max size?
-#define EVENT_POOL_SIZE 1000
 #define L0_DEFAULT_QUEUE_PRIORITY ZE_COMMAND_QUEUE_PRIORITY_NORMAL
 
 #include "../../CHIPBackend.hh"
@@ -364,6 +362,7 @@ class CHIPContextLevel0 : public chipstar::Context {
   size_t EventsRequested_ = 0;
   size_t EventsReused_ = 0;
   std::stack<ze_command_list_handle_t> ZeCmdListRegPool_;
+  size_t EventPoolSize_ = 1;
 
 public:
   /**
@@ -398,7 +397,8 @@ public:
     logTrace("No available events found in {} event pools. Creating a new "
              "event pool",
              EventPools_.size());
-    auto NewEventPool = new LZEventPool(this, EVENT_POOL_SIZE);
+    auto NewEventPool = new LZEventPool(this, EventPoolSize_);
+    EventPoolSize_ *= 2;
     Event = NewEventPool->getEvent();
     EventPools_.push_back(NewEventPool);
     return Event;

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -108,7 +108,7 @@ public:
    * @param CmdList command list to Assign with this event
    */
   void assignCmdList(CHIPContextLevel0 *ChipContext,
-                        ze_command_list_handle_t CmdList);
+                     ze_command_list_handle_t CmdList);
 
   /**
    * @brief Reset and then return the command list handle back to the context
@@ -167,16 +167,7 @@ public:
   virtual ~CHIPCallbackDataLevel0() override {}
 };
 
-class CHIPCallbackEventMonitorLevel0 : public chipstar::EventMonitor {
-public:
-  ~CHIPCallbackEventMonitorLevel0() {
-    logTrace("CHIPCallbackEventMonitorLevel0 DEST");
-    join();
-  };
-  virtual void monitor() override;
-};
-
-class CHIPStaleEventMonitorLevel0 : public chipstar::EventMonitor {
+class CHIPEventMonitorLevel0 : public chipstar::EventMonitor {
   // variable for storing the how much time has passed since trying to exit
   // the monitor loop
   int TimeSinceStopRequested_ = 0;
@@ -196,8 +187,8 @@ class CHIPStaleEventMonitorLevel0 : public chipstar::EventMonitor {
   void checkCallbacks();
 
 public:
-  ~CHIPStaleEventMonitorLevel0() {
-    logTrace("CHIPStaleEventMonitorLevel0 DEST");
+  ~CHIPEventMonitorLevel0() {
+    logTrace("CHIPEventMonitorLevel0 DEST");
     join();
   };
   virtual void monitor() override;
@@ -688,14 +679,8 @@ public:
     return new CHIPCallbackDataLevel0(Callback, UserData, ChipQueue);
   }
 
-  virtual chipstar::EventMonitor *createCallbackEventMonitor_() override {
-    auto Evm = new CHIPCallbackEventMonitorLevel0();
-    Evm->start();
-    return Evm;
-  }
-
-  virtual chipstar::EventMonitor *createStaleEventMonitor_() override {
-    auto Evm = new CHIPStaleEventMonitorLevel0();
+  virtual chipstar::EventMonitor *createEventMonitor_() override {
+    auto Evm = new CHIPEventMonitorLevel0();
     Evm->start();
     return Evm;
   }

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -195,6 +195,8 @@ class CHIPStaleEventMonitorLevel0 : public chipstar::EventMonitor {
    */
   void exitChecks();
 
+  void checkCallbacks();
+
 public:
   ~CHIPStaleEventMonitorLevel0() {
     logTrace("CHIPStaleEventMonitorLevel0 DEST");

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -208,14 +208,13 @@ private:
   CHIPContextLevel0 *Ctx_;
   ze_event_pool_handle_t EventPool_;
   unsigned int Size_;
-  std::vector<std::shared_ptr<CHIPEventLevel0>> Events_;
-  std::stack<std::shared_ptr<CHIPEventLevel0>> AvailableEvents_;
+  std::stack<std::shared_ptr<CHIPEventLevel0>> Events_;
 
 public:
   std::mutex EventPoolMtx;
   LZEventPool(CHIPContextLevel0 *Ctx, unsigned int Size);
   ~LZEventPool();
-  bool EventAvailable() { return AvailableEvents_.size() > 0; }
+  bool EventAvailable() { return Events_.size() > 0; }
   ze_event_pool_handle_t get() { return EventPool_; }
 
   void returnEvent(std::shared_ptr<CHIPEventLevel0> Event);

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -208,19 +208,17 @@ private:
   CHIPContextLevel0 *Ctx_;
   ze_event_pool_handle_t EventPool_;
   unsigned int Size_;
-  std::stack<int> FreeSlots_;
   std::vector<std::shared_ptr<CHIPEventLevel0>> Events_;
-
-  int getFreeSlot();
+  std::stack<std::shared_ptr<CHIPEventLevel0>> AvailableEvents_;
 
 public:
   std::mutex EventPoolMtx;
   LZEventPool(CHIPContextLevel0 *Ctx, unsigned int Size);
   ~LZEventPool();
-  bool EventAvailable() { return FreeSlots_.size() > 0; }
+  bool EventAvailable() { return AvailableEvents_.size() > 0; }
   ze_event_pool_handle_t get() { return EventPool_; }
 
-  void returnSlot(int Slot);
+  void returnEvent(std::shared_ptr<CHIPEventLevel0> Event);
 
   std::shared_ptr<CHIPEventLevel0> getEvent();
 };

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -1628,13 +1628,7 @@ chipstar::CallbackData *CHIPBackendOpenCL::createCallbackData(
   UNIMPLEMENTED(nullptr);
 }
 
-chipstar::EventMonitor *CHIPBackendOpenCL::createCallbackEventMonitor_() {
-  auto Evm = new EventMonitorOpenCL();
-  Evm->start();
-  return Evm;
-}
-
-chipstar::EventMonitor *CHIPBackendOpenCL::createStaleEventMonitor_() {
+chipstar::EventMonitor *CHIPBackendOpenCL::createEventMonitor_() {
   UNIMPLEMENTED(nullptr);
 }
 

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -405,8 +405,7 @@ public:
   virtual chipstar::CallbackData *
   createCallbackData(hipStreamCallback_t Callback, void *UserData,
                      chipstar::Queue *ChipQueue) override;
-  virtual chipstar::EventMonitor *createCallbackEventMonitor_() override;
-  virtual chipstar::EventMonitor *createStaleEventMonitor_() override;
+  virtual chipstar::EventMonitor *createEventMonitor_() override;
 
   virtual hipEvent_t getHipEvent(void *NativeEvent) override;
   virtual void *getNativeEvent(hipEvent_t HipEvent) override;


### PR DESCRIPTION
* Fix event refcounts
* Switch to using an event stack for handling events inside an event pool
* Event pools now start small and double as needed to prevent generation of many events for small test cases
* Get rid of `CallbackEventMonitor` and use a single thread to handle all other activities such as event monitoring, callbacks, event pool management (if needed in the future)
* replace all "Event use after delete" asserts with a new function `isDeletedSanityCheck()` which does nothing in `Release`. Call this function at every event member function. 

* check.py add `--total-runtime=x` option. Given a number of minutes, run tests once to estimate the runtime and then calculate the `--num-tries` to fill the time allotted. 