### PR TITLE
Update cpp-linter-action version

### DIFF
--- a/.github/workflows/clang-tidy-format.yml
+++ b/.github/workflows/clang-tidy-format.yml
@@ -17,7 +17,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install clang
         run: sudo apt install clang-11 --install-suggests
-      - uses: shenxianpeng/cpp-linter-action@master
+      - name: C/C++ Linter
+        uses: cpp-linter/cpp-linter-action@v2.9.0
         id: linter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Linter no longer recognized "main" as a proper version