### PR TITLE
Level-zero-premature-exit

### DIFF
--- a/samples/hipKernelLaunchIsNonBlocking/hipKernelLaunchIsNonBlocking.cc
+++ b/samples/hipKernelLaunchIsNonBlocking/hipKernelLaunchIsNonBlocking.cc
@@ -112,4 +112,8 @@ int main() {
   } else {
     std::cout << "FAILED!" << std::endl;
   }
+
+  CHECK(hipStreamDestroy(q));
+  CHECK(hipEventDestroy(start));
+  CHECK(hipEventDestroy(stop));
 }

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -670,7 +670,7 @@ void CHIPEventMonitorLevel0::checkEvents() {
   } // done collecting events to delete
 }
 
-void CHIPEventMonitorLevel0::exitChecks() {
+void CHIPEventMonitorLevel0::checkExit() {
   LOCK(EventMonitorMtx); // chipstar::EventMonitor::Stop
   /**
    * In the case that a user doesn't destroy all the
@@ -726,7 +726,7 @@ void CHIPEventMonitorLevel0::monitor() {
     usleep(200);
     checkCallbacks();
     checkEvents();
-    exitChecks();
+    checkExit();
   } // endless loop
 }
 // End EventMonitorLevel0

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -601,16 +601,6 @@ void CHIPEventMonitorLevel0::checkCallbacks() {
   CHIPCallbackDataLevel0 *CbData;
   LOCK(EventMonitorMtx); // chipstar::EventMonitor::Stop
   {
-
-    if (Stop) {
-      logTrace("checkCallbacks: out of callbacks. Exiting "
-               "thread");
-      if (Backend->CallbackQueue.size())
-        logError("Callback thread exiting while there are still active "
-                 "callbacks in the queue");
-      pthread_exit(0);
-    }
-
     LOCK(Backend->CallbackQueueMtx); // Backend::CallbackQueue
 
     if ((Backend->CallbackQueue.size() == 0))

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -182,7 +182,7 @@ class CHIPEventMonitorLevel0 : public chipstar::EventMonitor {
    * @brief Check if stop was requested for this monitor, if so handle all
    * outstanding events
    */
-  void exitChecks();
+  void checkExit();
 
   void checkCallbacks();
 


### PR DESCRIPTION
Remove redundant exit check from checkCallbacks