### PR TITLE
SYCL-HIP Interop - Drop RCL/ICL Quer

### DIFF
--- a/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
@@ -114,14 +114,7 @@ int oneMKLGemmTest(uintptr_t* nativeHandlers, const char* hip_backend, float* A,
     sycl_devices[0] = sycl_device;
     sycl::context sycl_context = sycl::ext::oneapi::level_zero::make_context(sycl_devices, (pi_native_handle)hContext, 1);
 
-    bool isImmCmdList = true;
-    // query the environemtn for CHIP_L0_IMM_CMD_LIST flag, if it's OFF, off or 0, then set isImmCmdList to false
-    char* env = getenv("CHIP_L0_IMM_CMD_LIST");
-    if (env != NULL) {
-      if (!strcmp(env, "OFF") || !strcmp(env, "off") || !strcmp(env, "0")) {
-        isImmCmdList = false;
-      }
-    }
+    bool isImmCmdList = false;
 #if __INTEL_LLVM_COMPILER >= 20240000
     sycl_queue = sycl::ext::oneapi::level_zero::make_queue(sycl_context, sycl_device, (pi_native_handle)hQueue, isImmCmdList, 1, sycl::property::queue::in_order());
 #else

--- a/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
@@ -112,15 +112,7 @@ int oneMKLGemmTest(uintptr_t* nativeHandlers, const char* hip_backend, float* A,
     sycl_devices[0] = sycl_device;
     sycl::context sycl_context = sycl::ext::oneapi::level_zero::make_context(sycl_devices, (pi_native_handle)hContext, 1);
 
-    bool isImmCmdList = true;
-    // query the environemtn for CHIP_L0_IMM_CMD_LIST flag, if it's OFF, off or 0, then set isImmCmdList to false
-    char* env = getenv("CHIP_L0_IMM_CMD_LIST");
-    if (env != NULL) {
-      if (!strcmp(env, "OFF") || !strcmp(env, "off") || !strcmp(env, "0")) {
-        isImmCmdList = false;
-      }
-    }
-
+    bool isImmCmdList = false;
 #if __INTEL_LLVM_COMPILER >= 20240000
     sycl_queue = sycl::ext::oneapi::level_zero::make_queue(sycl_context, sycl_device, (pi_native_handle)hQueue,
                                                            isImmCmdList, 1, sycl::property::queue::in_order());

--- a/scripts/unit_tests.sh
+++ b/scripts/unit_tests.sh
@@ -107,7 +107,7 @@ export POCL_KERNEL_CACHE=0
 
 # Use OpenCL for building/test discovery to prevent Level Zero from being used in multi-thread/multi-process environment
 module use ~/modulefiles
-module load $CLANG opencl/dgpu
+module load mkl/2024.0 compiler/2024.0.2 $CLANG opencl/dgpu 
 
 output=$(clinfo -l 2>&1 | grep "Platform #0")
 echo $output
@@ -151,7 +151,7 @@ else
   # ../scripts/compile_libceed.sh ${CHIPSTAR_INSTALL_DIR}
 fi
 
-module unload opencl/dgpu oneapi/compiler/2023.2.3
+module unload opencl/dgpu
 
 # module load HIP/hipBLAS/main/release # for libCEED NOTE: Must be after build step otherwise it will cause link issues.
 


### PR DESCRIPTION
Since we never return an immediate command list even when they are used internally we can just drop the check. 

There was a bug in the initial implementation where `isImmCmdList = true` but it seems that we don't really need to check if ICL is used since we never return a command list.