### PR TITLE
Add CHIP_LAZY_JIT environment option to control JIT timing

### DIFF
--- a/docs/Using.md
+++ b/docs/Using.md
@@ -34,6 +34,12 @@ If you do not provide this value, `hipcc` will check for existance of the follow
 
 Preserves runtime temporary compilation files when this variable is set to `1`.
 
+#### CHIP\_LAZY\_JIT
+
+When set to `0`, chipStar will compile all device modules at the runtime
+initialization. Default setting is `1` meaning the device modules are
+compiled just before kernel launches.
+
 ### Disabling GPU hangcheck
 
 Note that long-running GPU compute kernels can trigger hang detection mechanism in the GPU driver, which will cause the kernel execution to be terminated and the runtime will report an error. Consult the documentation of your GPU driver on how to disable this hangcheck.

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -4434,7 +4434,7 @@ extern "C" void **__hipRegisterFatBinary(const void *Data) {
   SPVRegister::Handle ModHandle =
       getSPVRegister().registerSource(SPIRVModuleSpan);
 
-  if (ChipEnvVars.getLazyJit() == false) {
+  if (!ChipEnvVars.getLazyJit()) {
     logDebug("Lazy JIT disabled, compiling module now");
     const SPVModule *SMod = getSPVRegister().getSource(ModHandle);
     Backend->getActiveDevice()->getOrCreateModule(*SMod);

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -4431,7 +4431,15 @@ extern "C" void **__hipRegisterFatBinary(const void *Data) {
   if (SPIRVModuleSpan.empty())
     CHIPERR_LOG_AND_THROW(ErrorMsg, hipErrorInitializationError);
 
-  auto ModHandle = getSPVRegister().registerSource(SPIRVModuleSpan);
+  SPVRegister::Handle ModHandle =
+      getSPVRegister().registerSource(SPIRVModuleSpan);
+
+  if (ChipEnvVars.getLazyJit() == false) {
+    logDebug("Lazy JIT disabled, compiling module now");
+    const SPVModule *SMod = getSPVRegister().getSource(ModHandle);
+    Backend->getActiveDevice()->getOrCreateModule(*SMod);
+  }
+
   logDebug("Registered SPIR-V module {}, source-binary={}",
            static_cast<const void *>(ModHandle.Module),
            static_cast<const void *>(SPIRVModuleSpan.data()));

--- a/src/CHIPDriver.hh
+++ b/src/CHIPDriver.hh
@@ -228,6 +228,7 @@ private:
   BackendType Backend_;
   bool DumpSpirv_ = false;
   bool SkipUninit_ = false;
+  bool LazyJit_ = true;
   std::string JitFlags_ = CHIP_DEFAULT_JIT_FLAGS;
   bool L0ImmCmdLists_ = true;
   unsigned long L0EventTimeout_ = 0;
@@ -246,6 +247,7 @@ public:
   bool getDumpSpirv() const { return DumpSpirv_; }
   bool getSkipUninit() const { return SkipUninit_; }
   const std::string &getJitFlags() const { return JitFlags_; }
+  bool getLazyJit() const { return LazyJit_; }
   bool getL0ImmCmdLists() const { return L0ImmCmdLists_; }
   int getL0CollectEventsTimeout() const { return L0CollectEventsTimeout_; }
   unsigned long getL0EventTimeout() const {
@@ -273,6 +275,9 @@ private:
 
     if (!readEnvVar("CHIP_SKIP_UNINIT").empty())
       SkipUninit_ = parseBoolean("CHIP_SKIP_UNINIT");
+
+    if (!readEnvVar("CHIP_LAZY_JIT").empty())
+      LazyJit_ = parseBoolean("CHIP_LAZY_JIT");
 
     JitFlags_ = parseJitFlags("CHIP_JIT_FLAGS_OVERRIDE");
 

--- a/tests/runtime/TestLazyModuleInit.cpp
+++ b/tests/runtime/TestLazyModuleInit.cpp
@@ -11,6 +11,12 @@ __device__ int Foo = 123;
 __global__ void bar(int *Dst) { *Dst = Foo; }
 
 int main() {
+  const char *LazyJit = std::getenv("CHIP_LAZY_JIT");
+  if (LazyJit && std::string_view(LazyJit) == "0") {
+    printf("CHIP_LAZY_JIT is set to 0. Skip testing.\n");
+    return CHIP_SKIP_TEST;
+  }
+
   // Check the source binary is registered.
   assert(getSPVRegister().getNumSources() == 1);
 


### PR DESCRIPTION
With CHIP_LAZY_JIT=0 setting, all device modules will be compiled at chipStar runtime initialization. We have used this in benchmarking to exclude device compilation time in kernel execution time measurements.