### PR TITLE
Backend handles refactor

### DIFF
--- a/include/hip/hip_interop.h
+++ b/include/hip/hip_interop.h
@@ -41,7 +41,6 @@ void* hipGetNativeEventFromHipEvent(void* HipEvent);
 
 void* hipGetHipEventFromNativeEvent(void* NativeEvent);
 
-const char* hipGetBackendName();
 #ifdef __cplusplus
 }
 #endif

--- a/samples/hip_async_interop/BinomialOption.cpp
+++ b/samples/hip_async_interop/BinomialOption.cpp
@@ -340,10 +340,8 @@ void *BinomialOption::runNativeKernel(void *NativeEventDep,
                                       uintptr_t *NativeHandles, int NumHandles,
                                       unsigned Blocks, unsigned Threads,
                                       unsigned Arg1, void *Arg2, void *Arg3) {
-  const char *EnvBe = std::getenv("CHIP_BE");
-  if (EnvBe == nullptr)
-    EnvBe = "opencl";
-  std::string Backend{EnvBe};
+  std::string Backend((char*)NativeHandles[0]);
+
   if (Backend.compare("opencl") == 0) {
 #ifdef HAVE_OPENCL
     return runOpenCLKernel(NativeEventDep, NativeHandles, NumHandles, Blocks,

--- a/samples/hip_async_interop/BinomialOption.cpp
+++ b/samples/hip_async_interop/BinomialOption.cpp
@@ -37,8 +37,12 @@ THE SOFTWARE.
 #include "hip/hip_interop.h"
 
 extern "C" {
-  void* runOpenCLKernel(void *NativeEventDep, uintptr_t *NativeHandles, int NumHandles, unsigned Blocks, unsigned Threads, unsigned Arg1, void *Arg2, void *Arg3);
-  void* runLevel0Kernel(void *NativeEventDep, uintptr_t *NativeHandles, int NumHandles, unsigned Blocks, unsigned Threads, unsigned Arg1, void *Arg2, void *Arg3);
+void *runOpenCLKernel(void *NativeEventDep, uintptr_t *NativeHandles,
+                      int NumHandles, unsigned Blocks, unsigned Threads,
+                      unsigned Arg1, void *Arg2, void *Arg3);
+void *runLevel0Kernel(void *NativeEventDep, uintptr_t *NativeHandles,
+                      int NumHandles, unsigned Blocks, unsigned Threads,
+                      unsigned Arg1, void *Arg2, void *Arg3);
 }
 
 using namespace appsdk;
@@ -56,308 +60,294 @@ using namespace std;
  */
 #define VOLATILITY 0.30f
 
+class BinomialOption {
+  double setupTime;  /**< Time taken to setup resources and building kernel */
+  double kernelTime; /**< Time taken to run kernel and read result back */
+  int numSamples;    /**< No. of  samples*/
+  unsigned int samplesPerVectorWidth; /**< No. of samples per vector width */
+  unsigned int numSteps;              /**< No. of time steps*/
+  float *randArray;                   /**< Array of float random numbers */
+  float *output;                      /**< Output result */
+  float *refOutput;                   /**< Reference result */
+  float4 *randBuffer;                 /**< memory buffer for random numbers */
+  float4 *outBuffer;                  /**< memory buffer for output*/
+  int iterations;        /**< Number of iterations for kernel execution */
+  SDKTimer *sampleTimer; /**< SDKTimer object */
+  float *din, *dout;
 
-class BinomialOption
-{
-        double setupTime;                     /**< Time taken to setup resources and building kernel */
-        double kernelTime;                    /**< Time taken to run kernel and read result back */
-        int numSamples;                       /**< No. of  samples*/
-        unsigned int samplesPerVectorWidth;   /**< No. of samples per vector width */
-        unsigned int numSteps;                /**< No. of time steps*/
-        float* randArray;                     /**< Array of float random numbers */
-        float* output;                        /**< Output result */
-        float* refOutput;                     /**< Reference result */
-        float4* randBuffer;                   /**< memory buffer for random numbers */
-        float4* outBuffer;                    /**< memory buffer for output*/
-        int iterations;                       /**< Number of iterations for kernel execution */
-        SDKTimer    *sampleTimer;             /**< SDKTimer object */
-        float *din, *dout;
+private:
+  float random(float randMax, float randMin);
 
-    private:
+public:
+  HIPCommandArgs *sampleArgs;
+  /**
+   * Constructor
+   * Initialize member variables
+   */
+  BinomialOption()
+      : setupTime(0), kernelTime(0), randArray(NULL), output(NULL),
+        refOutput(NULL), iterations(1) {
+    numSamples = 256;
+    numSteps = 254;
+    sampleArgs = new HIPCommandArgs();
+    sampleTimer = new SDKTimer();
+    sampleArgs->sampleVerStr = SAMPLE_VERSION;
+  }
 
-        float random(float randMax, float randMin);
+  inline long long get_time() {
+    struct timeval tv;
+    gettimeofday(&tv, 0);
+    return (tv.tv_sec * 1000000) + tv.tv_usec;
+  }
 
-    public:
-        HIPCommandArgs   *sampleArgs;
-        /**
-         * Constructor
-         * Initialize member variables
-         */
-        BinomialOption()
-          : setupTime(0),
-            kernelTime(0),
-            randArray(NULL),
-            output(NULL),
-            refOutput(NULL),
-            iterations(1)
-        {
-            numSamples = 256;
-            numSteps = 254;
-            sampleArgs = new HIPCommandArgs() ;
-            sampleTimer = new SDKTimer();
-            sampleArgs->sampleVerStr = SAMPLE_VERSION;
-        }
+  ~BinomialOption();
 
-        inline long long get_time()
-        {
-          struct timeval tv;
-          gettimeofday(&tv, 0);
-          return (tv.tv_sec * 1000000) + tv.tv_usec;
-        }
+  /**
+   * Allocate and initialize host memory array with random values
+   * @return SDK_SUCCESS on success and SDK_FAILURE on failure
+   */
+  int setupBinomialOption();
 
-        ~BinomialOption();
+  /**
+   * HIP related initialisations.
+   * @return SDK_SUCCESS on success and SDK_FAILURE on failure
+   */
+  int setupHIP();
 
-        /**
-         * Allocate and initialize host memory array with random values
-         * @return SDK_SUCCESS on success and SDK_FAILURE on failure
-         */
-        int setupBinomialOption();
+  /**
+   * Set values for kernels' arguments, enqueue calls to the kernels
+   * on to the command queue, wait till end of kernel execution.
+   * Get kernel start and end time if timing is enabled
+   * @return SDK_SUCCESS on success and SDK_FAILURE on failure
+   */
+  int runKernels(unsigned iterations);
 
-        /**
-         * HIP related initialisations.
-         * @return SDK_SUCCESS on success and SDK_FAILURE on failure
-         */
-        int setupHIP();
+  void *runNativeKernel(void *NativeEventDep, uintptr_t *NativeHandles,
+                        int NumHandles, unsigned Blocks, unsigned Threads,
+                        unsigned Arg1, void *Arg2, void *Arg3);
 
-        /**
-         * Set values for kernels' arguments, enqueue calls to the kernels
-         * on to the command queue, wait till end of kernel execution.
-         * Get kernel start and end time if timing is enabled
-         * @return SDK_SUCCESS on success and SDK_FAILURE on failure
-         */
-        int runKernels(unsigned iterations);
+  /**
+   * Reference CPU implementation of Binomial Option
+   * for performance comparison
+   * @return SDK_SUCCESS on success and SDK_FAILURE on failure
+   */
+  int binomialOptionCPUReference();
 
-        void* runNativeKernel(void *NativeEventDep, uintptr_t *NativeHandles, int NumHandles, unsigned Blocks, unsigned Threads, unsigned Arg1, void *Arg2, void *Arg3);
+  /**
+   * Override from SDKSample. Print sample stats.
+   */
+  void printStats();
 
-        /**
-         * Reference CPU implementation of Binomial Option
-         * for performance comparison
-         * @return SDK_SUCCESS on success and SDK_FAILURE on failure
-         */
-        int binomialOptionCPUReference();
+  /**
+   * Override from SDKSample. Initialize
+   * command line parser, add custom options
+   * @return SDK_SUCCESS on success and SDK_FAILURE on failure
+   */
+  int initialize();
 
-        /**
-         * Override from SDKSample. Print sample stats.
-         */
-        void printStats();
+  /**
+   * Override from SDKSample, adjust width and height
+   * of execution domain, perform all sample setup
+   * @return SDK_SUCCESS on success and SDK_FAILURE on failure
+   */
+  int setup();
 
-        /**
-         * Override from SDKSample. Initialize
-         * command line parser, add custom options
-         * @return SDK_SUCCESS on success and SDK_FAILURE on failure
-         */
-        int initialize();
+  /**
+   * Override from SDKSample
+   * Run HIP BinomialOption
+   * @return SDK_SUCCESS on success and SDK_FAILURE on failure
+   */
+  int run();
 
-        /**
-         * Override from SDKSample, adjust width and height
-         * of execution domain, perform all sample setup
-         * @return SDK_SUCCESS on success and SDK_FAILURE on failure
-         */
-        int setup();
+  /**
+   * Override from SDKSample
+   * Cleanup memory allocations
+   * @return SDK_SUCCESS on success and SDK_FAILURE on failure
+   */
+  int cleanup();
 
-        /**
-         * Override from SDKSample
-         * Run HIP BinomialOption
-         * @return SDK_SUCCESS on success and SDK_FAILURE on failure
-         */
-        int run();
-
-        /**
-         * Override from SDKSample
-         * Cleanup memory allocations
-         * @return SDK_SUCCESS on success and SDK_FAILURE on failure
-         */
-        int cleanup();
-
-        /**
-         * Override from SDKSample
-         * Verify against reference implementation
-         * @return SDK_SUCCESS on success and SDK_FAILURE on failure
-         */
-        int verifyResults();
+  /**
+   * Override from SDKSample
+   * Verify against reference implementation
+   * @return SDK_SUCCESS on success and SDK_FAILURE on failure
+   */
+  int verifyResults();
 };
 
+__global__ void binomial_options(int numSteps, const float4 *randArray,
+                                 float4 *out) {
+  // load shared mem
+  unsigned int tid = hipThreadIdx_x;
+  unsigned int bid = hipBlockIdx_x;
 
-__global__ void binomial_options(
-                                 int numSteps,
-                                 const float4* randArray,
-                                 float4* out)
-{
-    // load shared mem
-    unsigned int tid = hipThreadIdx_x;
-    unsigned int bid = hipBlockIdx_x;
+  __shared__ float4 callA[254 + 1]; // numSteps+1 elements
+  __shared__ float4 callB[254 + 1]; // numSteps+1 elements
 
-    __shared__ float4 callA[254+1];//numSteps+1 elements
-    __shared__ float4 callB[254+1];//numSteps+1 elements
+  float4 inRand = randArray[bid];
+  float4 s, x, optionYears, dt, vsdt, rdt, r, rInv, u, d, pu, pd, puByr, pdByr,
+      profit;
 
-    float4 inRand = randArray[bid];
-    float4 s, x, optionYears, dt, vsdt, rdt, r, rInv, u, d, pu, pd, puByr, pdByr, profit;
+  s.x = (1.0f - inRand.x) * 5.0f + inRand.x * 30.f;
+  s.y = (1.0f - inRand.y) * 5.0f + inRand.y * 30.f;
+  s.z = (1.0f - inRand.z) * 5.0f + inRand.z * 30.f;
+  s.w = (1.0f - inRand.w) * 5.0f + inRand.w * 30.f;
 
-    s.x = (1.0f - inRand.x) * 5.0f + inRand.x * 30.f;
-    s.y = (1.0f - inRand.y) * 5.0f + inRand.y * 30.f;
-    s.z = (1.0f - inRand.z) * 5.0f + inRand.z * 30.f;
-    s.w = (1.0f - inRand.w) * 5.0f + inRand.w * 30.f;
+  x.x = (1.0f - inRand.x) * 1.0f + inRand.x * 100.f;
+  x.y = (1.0f - inRand.y) * 1.0f + inRand.y * 100.f;
+  x.z = (1.0f - inRand.z) * 1.0f + inRand.z * 100.f;
+  x.w = (1.0f - inRand.w) * 1.0f + inRand.w * 100.f;
 
-    x.x = (1.0f - inRand.x) * 1.0f + inRand.x * 100.f;
-    x.y = (1.0f - inRand.y) * 1.0f + inRand.y * 100.f;
-    x.z = (1.0f - inRand.z) * 1.0f + inRand.z * 100.f;
-    x.w = (1.0f - inRand.w) * 1.0f + inRand.w * 100.f;
+  optionYears.x = (1.0f - inRand.x) * 0.25f + inRand.x * 10.f;
+  optionYears.y = (1.0f - inRand.y) * 0.25f + inRand.y * 10.f;
+  optionYears.z = (1.0f - inRand.z) * 0.25f + inRand.z * 10.f;
+  optionYears.w = (1.0f - inRand.w) * 0.25f + inRand.w * 10.f;
 
-    optionYears.x = (1.0f - inRand.x) * 0.25f + inRand.x * 10.f;
-    optionYears.y = (1.0f - inRand.y) * 0.25f + inRand.y * 10.f;
-    optionYears.z = (1.0f - inRand.z) * 0.25f + inRand.z * 10.f;
-    optionYears.w = (1.0f - inRand.w) * 0.25f + inRand.w * 10.f;
+  dt.x = optionYears.x * (1.0f / (float)numSteps);
+  dt.y = optionYears.y * (1.0f / (float)numSteps);
+  dt.z = optionYears.z * (1.0f / (float)numSteps);
+  dt.w = optionYears.w * (1.0f / (float)numSteps);
 
-    dt.x = optionYears.x * (1.0f / (float)numSteps);
-    dt.y = optionYears.y * (1.0f / (float)numSteps);
-    dt.z = optionYears.z * (1.0f / (float)numSteps);
-    dt.w = optionYears.w * (1.0f / (float)numSteps);
+  vsdt.x = VOLATILITY * sqrtf(dt.x);
+  vsdt.y = VOLATILITY * sqrtf(dt.y);
+  vsdt.z = VOLATILITY * sqrtf(dt.z);
+  vsdt.w = VOLATILITY * sqrtf(dt.w);
 
-    vsdt.x = VOLATILITY * sqrtf(dt.x);
-    vsdt.y = VOLATILITY * sqrtf(dt.y);
-    vsdt.z = VOLATILITY * sqrtf(dt.z);
-    vsdt.w = VOLATILITY * sqrtf(dt.w);
+  rdt.x = RISKFREE * dt.x;
+  rdt.y = RISKFREE * dt.y;
+  rdt.z = RISKFREE * dt.z;
+  rdt.w = RISKFREE * dt.w;
 
-    rdt.x = RISKFREE * dt.x;
-    rdt.y = RISKFREE * dt.y;
-    rdt.z = RISKFREE * dt.z;
-    rdt.w = RISKFREE * dt.w;
+  r.x = expf(rdt.x);
+  r.y = expf(rdt.y);
+  r.z = expf(rdt.z);
+  r.w = expf(rdt.w);
 
-    r.x = expf(rdt.x);
-    r.y = expf(rdt.y);
-    r.z = expf(rdt.z);
-    r.w = expf(rdt.w);
+  rInv.x = 1.0f / r.x;
+  rInv.y = 1.0f / r.y;
+  rInv.z = 1.0f / r.z;
+  rInv.w = 1.0f / r.w;
 
-    rInv.x = 1.0f / r.x;
-    rInv.y = 1.0f / r.y;
-    rInv.z = 1.0f / r.z;
-    rInv.w = 1.0f / r.w;
+  u.x = expf(vsdt.x);
+  u.y = expf(vsdt.y);
+  u.z = expf(vsdt.z);
+  u.w = expf(vsdt.w);
 
-    u.x  = expf(vsdt.x);
-    u.y  = expf(vsdt.y);
-    u.z  = expf(vsdt.z);
-    u.w  = expf(vsdt.w);
+  d.x = 1.0f / u.x;
+  d.y = 1.0f / u.y;
+  d.z = 1.0f / u.z;
+  d.w = 1.0f / u.w;
 
-    d.x = 1.0f / u.x;
-    d.y = 1.0f / u.y;
-    d.z = 1.0f / u.z;
-    d.w = 1.0f / u.w;
+  pu.x = (r.x - d.x) / (u.x - d.x);
+  pu.y = (r.y - d.y) / (u.y - d.y);
+  pu.z = (r.z - d.z) / (u.z - d.z);
+  pu.w = (r.w - d.w) / (u.w - d.w);
 
-    pu.x= (r.x - d.x)/(u.x - d.x);
-    pu.y= (r.y - d.y)/(u.y - d.y);
-    pu.z= (r.z - d.z)/(u.z - d.z);
-    pu.w= (r.w - d.w)/(u.w - d.w);
+  pd.x = 1.0f - pu.x;
+  pd.y = 1.0f - pu.y;
+  pd.z = 1.0f - pu.z;
+  pd.w = 1.0f - pu.w;
 
-    pd.x = 1.0f - pu.x;
-    pd.y = 1.0f - pu.y;
-    pd.z = 1.0f - pu.z;
-    pd.w = 1.0f - pu.w;
+  puByr.x = pu.x * rInv.x;
+  puByr.y = pu.y * rInv.y;
+  puByr.z = pu.z * rInv.z;
+  puByr.w = pu.w * rInv.w;
 
-    puByr.x = pu.x * rInv.x;
-    puByr.y = pu.y * rInv.y;
-    puByr.z = pu.z * rInv.z;
-    puByr.w = pu.w * rInv.w;
+  pdByr.x = pd.x * rInv.x;
+  pdByr.y = pd.y * rInv.y;
+  pdByr.z = pd.z * rInv.z;
+  pdByr.w = pd.w * rInv.w;
 
-    pdByr.x= pd.x * rInv.x;
-    pdByr.y= pd.y * rInv.y;
-    pdByr.z= pd.z * rInv.z;
-    pdByr.w= pd.w * rInv.w;
+  profit.x = s.x * expf(vsdt.x * (2.0f * tid - (float)numSteps)) - x.x;
+  profit.y = s.y * expf(vsdt.y * (2.0f * tid - (float)numSteps)) - x.y;
+  profit.z = s.z * expf(vsdt.z * (2.0f * tid - (float)numSteps)) - x.z;
+  profit.w = s.w * expf(vsdt.w * (2.0f * tid - (float)numSteps)) - x.w;
 
-    profit.x = s.x * expf(vsdt.x * (2.0f * tid - (float)numSteps)) - x.x;
-    profit.y = s.y * expf(vsdt.y * (2.0f * tid - (float)numSteps)) - x.y;
-    profit.z = s.z * expf(vsdt.z * (2.0f * tid - (float)numSteps)) - x.z;
-    profit.w = s.w * expf(vsdt.w * (2.0f * tid - (float)numSteps)) - x.w;
+  callA[tid].x = profit.x > 0 ? profit.x : 0.0f;
+  callA[tid].y = profit.y > 0 ? profit.y : 0.0f;
+  callA[tid].z = profit.z > 0 ? profit.z : 0.0f;
+  callA[tid].w = profit.w > 0 ? profit.w : 0.0f;
 
-    callA[tid].x = profit.x > 0 ? profit.x : 0.0f;
-    callA[tid].y = profit.y > 0 ? profit.y : 0.0f;
-    callA[tid].z = profit.z > 0 ? profit.z: 0.0f;
-    callA[tid].w = profit.w > 0 ? profit.w: 0.0f;
+  __syncthreads();
 
+  for (int j = numSteps; j > 0; j -= 2) {
+    if (tid < j) {
+      callB[tid].x = puByr.x * callA[tid].x + pdByr.x * callA[tid + 1].x;
+      callB[tid].y = puByr.y * callA[tid].y + pdByr.y * callA[tid + 1].y;
+      callB[tid].z = puByr.z * callA[tid].z + pdByr.z * callA[tid + 1].z;
+      callB[tid].w = puByr.w * callA[tid].w + pdByr.w * callA[tid + 1].w;
+    }
     __syncthreads();
 
-    for(int j = numSteps; j > 0; j -= 2)
-    {
-        if(tid < j)
-        {
-            callB[tid].x = puByr.x * callA[tid].x + pdByr.x * callA[tid + 1].x;
-            callB[tid].y = puByr.y * callA[tid].y + pdByr.y * callA[tid + 1].y;
-            callB[tid].z = puByr.z * callA[tid].z + pdByr.z * callA[tid + 1].z;
-            callB[tid].w = puByr.w * callA[tid].w + pdByr.w * callA[tid + 1].w;
-        }
-        __syncthreads();
-
-        if(tid < j - 1)
-        {
-            callA[tid].x = puByr.x * callB[tid].x + pdByr.x * callB[tid + 1].x;
-            callA[tid].y = puByr.y * callB[tid].y + pdByr.y * callB[tid + 1].y;
-            callA[tid].z = puByr.z * callB[tid].z + pdByr.z * callB[tid + 1].z;
-            callA[tid].w = puByr.w * callB[tid].w + pdByr.w * callB[tid + 1].w;
-        }
-        __syncthreads();
+    if (tid < j - 1) {
+      callA[tid].x = puByr.x * callB[tid].x + pdByr.x * callB[tid + 1].x;
+      callA[tid].y = puByr.y * callB[tid].y + pdByr.y * callB[tid + 1].y;
+      callA[tid].z = puByr.z * callB[tid].z + pdByr.z * callB[tid + 1].z;
+      callA[tid].w = puByr.w * callB[tid].w + pdByr.w * callB[tid + 1].w;
     }
+    __syncthreads();
+  }
 
-    // write result for this block to global mem
-    if(tid == 0) out[bid] = callA[0];
-
+  // write result for this block to global mem
+  if (tid == 0)
+    out[bid] = callA[0];
 }
 
-int
-BinomialOption::setupBinomialOption()
-{
-    // Make numSamples multiple of 4
-    numSamples = (numSamples / 4)? (numSamples / 4) * 4: 4;
+int BinomialOption::setupBinomialOption() {
+  // Make numSamples multiple of 4
+  numSamples = (numSamples / 4) ? (numSamples / 4) * 4 : 4;
 
-    samplesPerVectorWidth = numSamples / 4;
+  samplesPerVectorWidth = numSamples / 4;
 
-    randArray = (float*)memalign(16, samplesPerVectorWidth * sizeof(float4));
+  randArray = (float *)memalign(16, samplesPerVectorWidth * sizeof(float4));
 
-    CHECK_ALLOCATION(randArray, "Failed to allocate host memory. (randArray)");
+  CHECK_ALLOCATION(randArray, "Failed to allocate host memory. (randArray)");
 
-    for(int i = 0; i < numSamples; i++)
-    {
-        randArray[i] = (float)rand() / (float)RAND_MAX;
-    }
+  for (int i = 0; i < numSamples; i++) {
+    randArray[i] = (float)rand() / (float)RAND_MAX;
+  }
 
-    output = (float*)malloc(samplesPerVectorWidth * sizeof(float4));
+  output = (float *)malloc(samplesPerVectorWidth * sizeof(float4));
 
-    CHECK_ALLOCATION(output, "Failed to allocate host memory. (output)");
-    memset(output, 0, samplesPerVectorWidth * sizeof(float4));
+  CHECK_ALLOCATION(output, "Failed to allocate host memory. (output)");
+  memset(output, 0, samplesPerVectorWidth * sizeof(float4));
 
-    return SDK_SUCCESS;
+  return SDK_SUCCESS;
 }
 
-int
-BinomialOption::setupHIP()
-{
+int BinomialOption::setupHIP() {
 
-    hipDeviceProp_t devProp;
-    hipGetDeviceProperties(&devProp, 0);
-    cout << " System minor " << devProp.minor << endl;
-    cout << " System major " << devProp.major << endl;
-    cout << " agent prop name " << devProp.name << endl;
+  hipDeviceProp_t devProp;
+  hipGetDeviceProperties(&devProp, 0);
+  cout << " System minor " << devProp.minor << endl;
+  cout << " System major " << devProp.major << endl;
+  cout << " agent prop name " << devProp.name << endl;
 
-    hipHostMalloc((void**)&randBuffer, samplesPerVectorWidth * sizeof(float4),hipHostMallocDefault);
-    hipHostMalloc((void**)&outBuffer, samplesPerVectorWidth * sizeof(float4),hipHostMallocDefault);
+  hipHostMalloc((void **)&randBuffer, samplesPerVectorWidth * sizeof(float4),
+                hipHostMallocDefault);
+  hipHostMalloc((void **)&outBuffer, samplesPerVectorWidth * sizeof(float4),
+                hipHostMallocDefault);
 
-    hipHostGetDevicePointer((void**)&din, randBuffer,0);
-    hipHostGetDevicePointer((void**)&dout, outBuffer,0);
+  hipHostGetDevicePointer((void **)&din, randBuffer, 0);
+  hipHostGetDevicePointer((void **)&dout, outBuffer, 0);
 
-    hipMemcpy(din, randArray, samplesPerVectorWidth * sizeof(float4), hipMemcpyHostToDevice);
+  hipMemcpy(din, randArray, samplesPerVectorWidth * sizeof(float4),
+            hipMemcpyHostToDevice);
 
-    return SDK_SUCCESS;
+  return SDK_SUCCESS;
 }
 
-void*
-BinomialOption::runNativeKernel(void *NativeEventDep, uintptr_t *NativeHandles, int NumHandles,
-                                unsigned Blocks, unsigned Threads,
-                                unsigned Arg1, void* Arg2, void* Arg3) {
-  const char* EnvBe = std::getenv("CHIP_BE");
+void *BinomialOption::runNativeKernel(void *NativeEventDep,
+                                      uintptr_t *NativeHandles, int NumHandles,
+                                      unsigned Blocks, unsigned Threads,
+                                      unsigned Arg1, void *Arg2, void *Arg3) {
+  const char *EnvBe = std::getenv("CHIP_BE");
   if (EnvBe == nullptr)
     EnvBe = "opencl";
   std::string Backend{EnvBe};
   if (Backend.compare("opencl") == 0) {
 #ifdef HAVE_OPENCL
-    return runOpenCLKernel(NativeEventDep, NativeHandles, NumHandles, Blocks, Threads, Arg1, Arg2, Arg3);
+    return runOpenCLKernel(NativeEventDep, NativeHandles, NumHandles, Blocks,
+                           Threads, Arg1, Arg2, Arg3);
 #else
     std::cerr
         << "Cannot execute native kernel with OpenCL Backend unavailable\n";
@@ -365,7 +355,8 @@ BinomialOption::runNativeKernel(void *NativeEventDep, uintptr_t *NativeHandles, 
 #endif
   } else if (Backend.compare("level0") == 0) {
 #ifdef HAVE_LEVEL0
-    return runLevel0Kernel(NativeEventDep, NativeHandles, NumHandles, Blocks, Threads, Arg1, Arg2, Arg3);
+    return runLevel0Kernel(NativeEventDep, NativeHandles, NumHandles, Blocks,
+                           Threads, Arg1, Arg2, Arg3);
 #else
     std::cerr
         << "Cannot execute native kernel with Level0 Backend unavailable\n";
@@ -377,39 +368,37 @@ BinomialOption::runNativeKernel(void *NativeEventDep, uintptr_t *NativeHandles, 
   }
 }
 
-
-int
-BinomialOption::runKernels(unsigned iterations)
-{
+int BinomialOption::runKernels(unsigned iterations) {
   hipEvent_t Start, Stop;
 
-  uintptr_t NativeHandles[4];
-  int NumHandles = 4;
-  int Err = hipGetBackendNativeHandles((uintptr_t)0, NativeHandles, &NumHandles);
+  int NumHandles;
+  int Err = hipGetBackendNativeHandles(0, 0, &NumHandles);
+  assert(Err == 0);
+  uintptr_t NativeHandles[NumHandles];
+  Err = hipGetBackendNativeHandles((uintptr_t)0, NativeHandles, 0);
   assert(Err == 0);
 
   unsigned int LocalThreads = {numSteps + 1};
 
-  for (unsigned i = 0; i < iterations/2; ++i) {
+  for (unsigned i = 0; i < iterations / 2; ++i) {
     hipEventCreate(&Start);
     hipEventCreate(&Stop);
     hipEventRecord(Start, NULL);
 
-    hipLaunchKernelGGL(binomial_options,
-                dim3(samplesPerVectorWidth),
-                dim3(LocalThreads),
-                0, 0,
-                numSteps, (float4*)din, (float4*)dout);
+    hipLaunchKernelGGL(binomial_options, dim3(samplesPerVectorWidth),
+                       dim3(LocalThreads), 0, 0, numSteps, (float4 *)din,
+                       (float4 *)dout);
 
     hipEventRecord(Stop, NULL);
 
     void *NativeEventDep = hipGetNativeEventFromHipEvent(Stop);
-    assert (NativeEventDep != nullptr);
-    void *NativeEvtRun = runNativeKernel(NativeEventDep, NativeHandles, NumHandles,
-                                       samplesPerVectorWidth, LocalThreads,
-                                       numSteps, (void*)din, (void*)dout);
-    hipEvent_t EventRun = (hipEvent_t)hipGetHipEventFromNativeEvent(NativeEvtRun);
-    assert (EventRun);
+    assert(NativeEventDep != nullptr);
+    void *NativeEvtRun = runNativeKernel(
+        NativeEventDep, NativeHandles, NumHandles, samplesPerVectorWidth,
+        LocalThreads, numSteps, (void *)din, (void *)dout);
+    hipEvent_t EventRun =
+        (hipEvent_t)hipGetHipEventFromNativeEvent(NativeEvtRun);
+    assert(EventRun);
     hipStreamWaitEvent(NULL, EventRun, 0);
 
     hipEventDestroy(Start);
@@ -419,16 +408,15 @@ BinomialOption::runKernels(unsigned iterations)
   }
 
   if (iterations & 1) {
-      hipLaunchKernelGGL(binomial_options,
-                  dim3(samplesPerVectorWidth),
-                  dim3(LocalThreads),
-                  0, 0,
-                  numSteps, (float4*)din, (float4*)dout);
+    hipLaunchKernelGGL(binomial_options, dim3(samplesPerVectorWidth),
+                       dim3(LocalThreads), 0, 0, numSteps, (float4 *)din,
+                       (float4 *)dout);
   }
 
   hipStreamSynchronize(NULL);
 
-  hipMemcpy(output, dout, samplesPerVectorWidth * sizeof(float4), hipMemcpyDeviceToHost);
+  hipMemcpy(output, dout, samplesPerVectorWidth * sizeof(float4),
+            hipMemcpyDeviceToHost);
 
   return SDK_SUCCESS;
 }
@@ -437,291 +425,251 @@ BinomialOption::runKernels(unsigned iterations)
  * Reduces the input array (in place)
  * length specifies the length of the array
  */
-int
-BinomialOption::binomialOptionCPUReference()
-{
-    refOutput = (float*)malloc(samplesPerVectorWidth * sizeof(float4));
-    CHECK_ALLOCATION(refOutput, "Failed to allocate host memory. (refOutput)");
+int BinomialOption::binomialOptionCPUReference() {
+  refOutput = (float *)malloc(samplesPerVectorWidth * sizeof(float4));
+  CHECK_ALLOCATION(refOutput, "Failed to allocate host memory. (refOutput)");
 
-    float* stepsArray = (float*)malloc((numSteps + 1) * sizeof(float4));
-    CHECK_ALLOCATION(stepsArray, "Failed to allocate host memory. (stepsArray)");
+  float *stepsArray = (float *)malloc((numSteps + 1) * sizeof(float4));
+  CHECK_ALLOCATION(stepsArray, "Failed to allocate host memory. (stepsArray)");
 
-    // Iterate for all samples
-    for(int bid = 0; bid < numSamples; ++bid)
-    {
-        float s[4];
-        float x[4];
-        float vsdt[4];
-        float puByr[4];
-        float pdByr[4];
-        float optionYears[4];
+  // Iterate for all samples
+  for (int bid = 0; bid < numSamples; ++bid) {
+    float s[4];
+    float x[4];
+    float vsdt[4];
+    float puByr[4];
+    float pdByr[4];
+    float optionYears[4];
 
-        float inRand[4];
+    float inRand[4];
 
-        for(int i = 0; i < 4; ++i)
-        {
-            inRand[i] = randArray[bid + i];
-            s[i] = (1.0f - inRand[i]) * 5.0f + inRand[i] * 30.f;
-            x[i] = (1.0f - inRand[i]) * 1.0f + inRand[i] * 100.f;
-            optionYears[i] = (1.0f - inRand[i]) * 0.25f + inRand[i] * 10.f;
-            float dt = optionYears[i] * (1.0f / (float)numSteps);
-            vsdt[i] = VOLATILITY * sqrtf(dt);
-            float rdt = RISKFREE * dt;
-            float r = expf(rdt);
-            float rInv = 1.0f / r;
-            float u = expf(vsdt[i]);
-            float d = 1.0f / u;
-            float pu = (r - d)/(u - d);
-            float pd = 1.0f - pu;
-            puByr[i] = pu * rInv;
-            pdByr[i] = pd * rInv;
+    for (int i = 0; i < 4; ++i) {
+      inRand[i] = randArray[bid + i];
+      s[i] = (1.0f - inRand[i]) * 5.0f + inRand[i] * 30.f;
+      x[i] = (1.0f - inRand[i]) * 1.0f + inRand[i] * 100.f;
+      optionYears[i] = (1.0f - inRand[i]) * 0.25f + inRand[i] * 10.f;
+      float dt = optionYears[i] * (1.0f / (float)numSteps);
+      vsdt[i] = VOLATILITY * sqrtf(dt);
+      float rdt = RISKFREE * dt;
+      float r = expf(rdt);
+      float rInv = 1.0f / r;
+      float u = expf(vsdt[i]);
+      float d = 1.0f / u;
+      float pu = (r - d) / (u - d);
+      float pd = 1.0f - pu;
+      puByr[i] = pu * rInv;
+      pdByr[i] = pd * rInv;
+    }
+
+    for (int j = 0; j <= numSteps; j++) {
+      for (int i = 0; i < 4; ++i) {
+        float profit =
+            s[i] * expf(vsdt[i] * (2.0f * (float)j - (float)numSteps)) - x[i];
+        stepsArray[j * 4 + i] = profit > 0.0f ? profit : 0.0f;
+      }
+    }
+
+    for (int j = numSteps; j > 0; --j) {
+      for (int k = 0; k <= j - 1; ++k) {
+        for (int i = 0; i < 4; ++i) {
+          int index_k = k * 4 + i;
+          int index_k_1 = (k + 1) * 4 + i;
+          stepsArray[index_k] =
+              pdByr[i] * stepsArray[index_k_1] + puByr[i] * stepsArray[index_k];
         }
+      }
+    }
 
-        for(int j = 0; j <= numSteps; j++)
-        {
-            for(int i = 0; i < 4; ++i)
-            {
-                float profit = s[i] * expf(vsdt[i] * (2.0f * (float)j - (float)numSteps)) - x[i];
-                stepsArray[j * 4 + i] = profit > 0.0f ? profit : 0.0f;
-            }
+    // Copy the root to result
+    refOutput[bid] = stepsArray[0];
+  }
+
+  free(stepsArray);
+
+  return SDK_SUCCESS;
+}
+
+int BinomialOption::initialize() {
+  // Call base class Initialize to get default configuration
+  CHECK_ERROR(sampleArgs->initialize(), SDK_SUCCESS,
+              " Resource Intilization failed");
+
+  Option *num_samples = new Option;
+  CHECK_ALLOCATION(num_samples,
+                   "Error. Failed to allocate memory (num_samples)\n");
+
+  num_samples->_sVersion = "x";
+  num_samples->_lVersion = "samples";
+  num_samples->_description = "Number of samples to be calculated";
+  num_samples->_type = CA_ARG_INT;
+  num_samples->_value = &numSamples;
+
+  sampleArgs->AddOption(num_samples);
+
+  delete num_samples;
+
+  Option *num_iterations = new Option;
+  CHECK_ALLOCATION(num_iterations,
+                   "Error. Failed to allocate memory (num_iterations)\n");
+
+  num_iterations->_sVersion = "i";
+  num_iterations->_lVersion = "iterations";
+  num_iterations->_description = "Number of iterations for kernel execution";
+  num_iterations->_type = CA_ARG_INT;
+  num_iterations->_value = &iterations;
+
+  sampleArgs->AddOption(num_iterations);
+
+  delete num_iterations;
+
+  return SDK_SUCCESS;
+}
+
+int BinomialOption::setup() {
+  if (setupBinomialOption()) {
+    return SDK_FAILURE;
+  }
+
+  int timer = sampleTimer->createTimer();
+  sampleTimer->resetTimer(timer);
+  sampleTimer->startTimer(timer);
+  if (setupHIP()) {
+    return SDK_FAILURE;
+  }
+  sampleTimer->stopTimer(timer);
+  // Compute setup time
+  setupTime = (double)(sampleTimer->readTimer(timer));
+
+  return SDK_SUCCESS;
+}
+
+int BinomialOption::run() {
+  // Warm up
+  if (iterations > 1) {
+    if (runKernels(2))
+      return SDK_FAILURE;
+  }
+
+  std::cout << "Executing kernel for " << iterations << " iterations"
+            << std::endl;
+  std::cout << "-------------------------------------------" << std::endl;
+
+  int timer = sampleTimer->createTimer();
+  sampleTimer->resetTimer(timer);
+  sampleTimer->startTimer(timer);
+
+  if (runKernels(iterations))
+    return SDK_FAILURE;
+  sampleTimer->stopTimer(timer);
+
+  // Compute average kernel time
+  kernelTime = (double)(sampleTimer->readTimer(timer)) / iterations;
+
+  if (!sampleArgs->quiet) {
+    printArray<float>("input", randArray, numSamples, 1);
+    printArray<float>("Output", output, numSamples, 1);
+  }
+
+  return SDK_SUCCESS;
+}
+
+int BinomialOption::verifyResults() {
+  if (sampleArgs->verify) {
+    /**
+     * reference implementation
+     * it overwrites the input array with the output
+     */
+    int result = SDK_SUCCESS;
+    result = binomialOptionCPUReference();
+    CHECK_ERROR(result, SDK_SUCCESS, " verifyResults  failed");
+
+    // compare the results and see if they match
+    if (compare(output, refOutput, numSamples, 0.001f)) {
+      std::cout << "Passed!\n" << std::endl;
+      return SDK_SUCCESS;
+    } else {
+      std::cout << " Failed\n" << std::endl;
+
+      std::cout << "\n\n\nNo. Output Output(hex) Refoutput Refoutput(hex)\n";
+      for (int i = 0; i < min(numSamples, 20); ++i) {
+        if (fabs(output[i] - refOutput[i]) > 0.0001) {
+
+          printf(" [%d] %f %#x ", i, output[i], *(int *)&output[i]);
+          printf(" %f %#x, \n", refOutput[i], *(int *)&refOutput[i]);
         }
+      }
 
-        for(int j = numSteps; j > 0; --j)
-        {
-            for(int k = 0; k <= j - 1; ++k)
-            {
-                for(int i = 0; i < 4; ++i)
-                {
-                    int index_k = k * 4 + i;
-                    int index_k_1 = (k + 1) * 4 + i;
-                    stepsArray[index_k] = pdByr[i] * stepsArray[index_k_1] + puByr[i] *
-                                          stepsArray[index_k];
-                }
-            }
-        }
-
-        //Copy the root to result
-        refOutput[bid] = stepsArray[0];
+      return SDK_FAILURE;
     }
-
-    free(stepsArray);
-
-    return SDK_SUCCESS;
+  }
+  return SDK_SUCCESS;
 }
 
-int BinomialOption::initialize()
-{
-    // Call base class Initialize to get default configuration
-    CHECK_ERROR(sampleArgs->initialize(), SDK_SUCCESS,
-                " Resource Intilization failed");
+void BinomialOption::printStats() {
+  if (sampleArgs->timing) {
+    std::string strArray[4] = {"Option Samples", "Time(sec)",
+                               "Transfer+kernel(sec)", "Options/sec"};
 
-    Option* num_samples = new Option;
-    CHECK_ALLOCATION(num_samples,"Error. Failed to allocate memory (num_samples)\n");
+    sampleTimer->totalTime = setupTime + kernelTime;
 
-    num_samples->_sVersion = "x";
-    num_samples->_lVersion = "samples";
-    num_samples->_description = "Number of samples to be calculated";
-    num_samples->_type = CA_ARG_INT;
-    num_samples->_value = &numSamples;
+    std::string stats[4];
+    stats[0] = toString(numSamples, std::dec);
+    stats[1] = toString(sampleTimer->totalTime, std::dec);
+    stats[2] = toString(kernelTime, std::dec);
+    stats[3] = toString(numSamples / sampleTimer->totalTime, std::dec);
 
-    sampleArgs->AddOption(num_samples);
-
-    delete num_samples;
-
-    Option* num_iterations = new Option;
-    CHECK_ALLOCATION(num_iterations, "Error. Failed to allocate memory (num_iterations)\n");
-
-    num_iterations->_sVersion = "i";
-    num_iterations->_lVersion = "iterations";
-    num_iterations->_description = "Number of iterations for kernel execution";
-    num_iterations->_type = CA_ARG_INT;
-    num_iterations->_value = &iterations;
-
-    sampleArgs->AddOption(num_iterations);
-
-    delete num_iterations;
-
-    return SDK_SUCCESS;
+    printStatistics(strArray, stats, 4);
+  }
 }
 
-int BinomialOption::setup()
-{
-    if(setupBinomialOption())
-    {
-        return SDK_FAILURE;
-    }
+int BinomialOption::cleanup() {
+  hipHostFree(randBuffer);
+  hipHostFree(outBuffer);
 
-    int timer = sampleTimer->createTimer();
-    sampleTimer->resetTimer(timer);
-    sampleTimer->startTimer(timer);
-    if(setupHIP())
-    {
-        return SDK_FAILURE;
-    }
-    sampleTimer->stopTimer(timer);
-    // Compute setup time
-    setupTime = (double)(sampleTimer->readTimer(timer));
+  hipDeviceReset();
 
-    return SDK_SUCCESS;
+  return SDK_SUCCESS;
 }
 
+BinomialOption::~BinomialOption() {
 
-int BinomialOption::run()
-{
-    // Warm up
-    if (iterations > 1)
-    {
-         if(runKernels(2))
-            return SDK_FAILURE;
-    }
+  FREE(randArray);
 
-    std::cout << "Executing kernel for " << iterations
-              << " iterations" << std::endl;
-    std::cout << "-------------------------------------------"
-              << std::endl;
+  FREE(output);
 
-    int timer = sampleTimer->createTimer();
-    sampleTimer->resetTimer(timer);
-    sampleTimer->startTimer(timer);
-
-    if(runKernels(iterations))
-        return SDK_FAILURE;
-    sampleTimer->stopTimer(timer);
-
-    // Compute average kernel time
-    kernelTime = (double)(sampleTimer->readTimer(timer)) / iterations;
-
-    if(!sampleArgs->quiet)
-    {
-	printArray<float>("input", randArray, numSamples, 1);
-	printArray<float>("Output", output, numSamples, 1);
-    }
-
-    return SDK_SUCCESS;
+  FREE(refOutput);
 }
 
-int BinomialOption::verifyResults()
-{
-    if(sampleArgs->verify)
-    {
-        /**
-         * reference implementation
-         * it overwrites the input array with the output
-         */
-        int result = SDK_SUCCESS;
-        result = binomialOptionCPUReference();
-        CHECK_ERROR(result, SDK_SUCCESS, " verifyResults  failed");
+int main(int argc, char *argv[]) {
 
-        // compare the results and see if they match
-        if(compare(output, refOutput, numSamples, 0.001f))
-        {
-            std::cout << "Passed!\n" << std::endl;
-            return SDK_SUCCESS;
-        }
-        else
-        {
-            std::cout <<" Failed\n" << std::endl;
+  BinomialOption hipBinomialOption;
 
-            std::cout <<"\n\n\nNo. Output Output(hex) Refoutput Refoutput(hex)\n";
-            for(int i = 0; i < min(numSamples, 20); ++i)
-            {
-                if(fabs(output[i] - refOutput[i])> 0.0001)
-                {
+  if (hipBinomialOption.initialize() != SDK_SUCCESS) {
+    return SDK_FAILURE;
+  }
 
-                    printf(" [%d] %f %#x ", i, output[i], *(int*)&output[i]);
-                    printf(" %f %#x, \n", refOutput[i], *(int*)&refOutput[i]);
-                }
-            }
+  if (hipBinomialOption.sampleArgs->parseCommandLine(argc, argv) !=
+      SDK_SUCCESS) {
+    return SDK_FAILURE;
+  }
 
-            return SDK_FAILURE;
-        }
-    }
-    return SDK_SUCCESS;
-}
+  if (hipBinomialOption.setup() != SDK_SUCCESS) {
+    return SDK_FAILURE;
+  }
 
-void BinomialOption::printStats()
-{
-    if(sampleArgs->timing)
-    {
-        std::string strArray[4] =
-        {
-            "Option Samples",
-            "Time(sec)",
-            "Transfer+kernel(sec)" ,
-            "Options/sec"
-        };
+  if (hipBinomialOption.run() != SDK_SUCCESS) {
+    return SDK_FAILURE;
+  }
 
-        sampleTimer->totalTime = setupTime + kernelTime;
+  if (hipBinomialOption.verifyResults() != SDK_SUCCESS) {
+    return SDK_FAILURE;
+  }
 
-        std::string stats[4];
-        stats[0] = toString(numSamples, std::dec);
-        stats[1] = toString(sampleTimer->totalTime, std::dec);
-        stats[2] = toString(kernelTime, std::dec);
-        stats[3] = toString(numSamples / sampleTimer->totalTime, std::dec);
+  if (hipBinomialOption.cleanup() != SDK_SUCCESS) {
+    return SDK_FAILURE;
+  }
 
-        printStatistics(strArray, stats, 4);
-    }
-}
+  hipBinomialOption.printStats();
 
-int
-BinomialOption::cleanup()
-{
-    hipHostFree(randBuffer);
-    hipHostFree(outBuffer);
-
-    hipDeviceReset();
-
-    return SDK_SUCCESS;
-}
-
-BinomialOption::~BinomialOption()
-{
-
-    FREE(randArray);
-
-    FREE(output);
-
-    FREE(refOutput);
-
-}
-
-int
-main(int argc, char * argv[])
-{
-
-    BinomialOption hipBinomialOption;
-
-    if(hipBinomialOption.initialize() != SDK_SUCCESS)
-    {
-        return SDK_FAILURE;
-    }
-
-    if(hipBinomialOption.sampleArgs->parseCommandLine(argc, argv) != SDK_SUCCESS)
-    {
-        return SDK_FAILURE;
-    }
-
-    if(hipBinomialOption.setup() != SDK_SUCCESS)
-    {
-        return SDK_FAILURE;
-    }
-
-    if(hipBinomialOption.run() != SDK_SUCCESS)
-    {
-        return SDK_FAILURE;
-    }
-
-    if(hipBinomialOption.verifyResults() != SDK_SUCCESS)
-    {
-        return SDK_FAILURE;
-    }
-
-    if(hipBinomialOption.cleanup() != SDK_SUCCESS)
-    {
-        return SDK_FAILURE;
-    }
-
-    hipBinomialOption.printStats();
-
-    return SDK_SUCCESS;
+  return SDK_SUCCESS;
 }

--- a/samples/hip_async_interop/BinomialOptionLevel0.cpp
+++ b/samples/hip_async_interop/BinomialOptionLevel0.cpp
@@ -78,9 +78,9 @@ static ze_command_list_handle_t getCmdListForCmdQueue(ze_context_handle_t Contex
 void* runLevel0Kernel(void *NativeEventDep, uintptr_t *NativeHandles, int NumHandles, unsigned Blocks, unsigned Threads, unsigned Arg1, void *Arg2, void *Arg3) {
   ze_result_t Err = ZE_RESULT_SUCCESS;
   //ze_driver_handle_t Driv = (ze_driver_handle_t)NativeHandles[0];
-  ze_device_handle_t Dev = (ze_device_handle_t)NativeHandles[1];
-  ze_context_handle_t Ctx = (ze_context_handle_t)NativeHandles[2];
-  ze_command_queue_handle_t CQ = (ze_command_queue_handle_t)NativeHandles[3];
+  ze_device_handle_t Dev = (ze_device_handle_t)NativeHandles[2];
+  ze_context_handle_t Ctx = (ze_context_handle_t)NativeHandles[3];
+  ze_command_queue_handle_t CQ = (ze_command_queue_handle_t)NativeHandles[4];
 
   ze_command_list_handle_t CommandList = getCmdListForCmdQueue(Ctx, Dev);
 

--- a/samples/hip_async_interop/BinomialOptionLevel0.cpp
+++ b/samples/hip_async_interop/BinomialOptionLevel0.cpp
@@ -76,7 +76,6 @@ static ze_command_list_handle_t getCmdListForCmdQueue(ze_context_handle_t Contex
 }
 
 void* runLevel0Kernel(void *NativeEventDep, uintptr_t *NativeHandles, int NumHandles, unsigned Blocks, unsigned Threads, unsigned Arg1, void *Arg2, void *Arg3) {
-  assert (NumHandles == 4);
   ze_result_t Err = ZE_RESULT_SUCCESS;
   //ze_driver_handle_t Driv = (ze_driver_handle_t)NativeHandles[0];
   ze_device_handle_t Dev = (ze_device_handle_t)NativeHandles[1];

--- a/samples/hip_async_interop/BinomialOptionOpenCL.cpp
+++ b/samples/hip_async_interop/BinomialOptionOpenCL.cpp
@@ -38,12 +38,11 @@ static cl_kernel Kernel = 0;
 static cl_program Program = 0;
 
 void* runOpenCLKernel(void *NativeEventDep, uintptr_t *NativeHandles, int NumHandles, unsigned Blocks, unsigned Threads, unsigned Arg1, void *Arg2, void *Arg3) {
-  assert (NumHandles == 4);
   int Err = 0;
   //cl_platform_id Plat = (cl_platform_id)NativeHandles[0];
-  cl_device_id Dev = (cl_device_id)NativeHandles[1];
-  cl_context Ctx = (cl_context)NativeHandles[2];
-  cl_command_queue CQ = (cl_command_queue)NativeHandles[3];
+  cl_device_id Dev = (cl_device_id)NativeHandles[2];
+  cl_context Ctx = (cl_context)NativeHandles[3];
+  cl_command_queue CQ = (cl_command_queue)NativeHandles[4];
 
   cl_event DepEv = (cl_event)NativeEventDep;
 

--- a/samples/hip_sycl_interop/hip_sycl_interop.cpp
+++ b/samples/hip_sycl_interop/hip_sycl_interop.cpp
@@ -61,8 +61,6 @@ void VerifyResult(float *c_A, float *c_B) {
 }
 
 int main() {
-  const char *hip_backend = hipGetBackendName();
-
   float *A = (float *)malloc(WIDTH * WIDTH * sizeof(float));
   float *B = (float *)malloc(WIDTH * WIDTH * sizeof(float));
   float *C = (float *)malloc(WIDTH * WIDTH * sizeof(float));
@@ -120,7 +118,7 @@ int main() {
   CHECK(error);
 
   // Invoke oneMKL GEEM
-  oneMKLGemmTest(nativeHandlers, hip_backend, A, B, C, m, m, k, ldA, ldB, ldC,
+  oneMKLGemmTest(nativeHandlers, A, B, C, m, m, k, ldA, ldB, ldC,
                  alpha, beta);
 
   // check results

--- a/samples/hip_sycl_interop/hip_sycl_interop.cpp
+++ b/samples/hip_sycl_interop/hip_sycl_interop.cpp
@@ -61,7 +61,7 @@ void VerifyResult(float *c_A, float *c_B) {
 }
 
 int main() {
-  const char* hip_backend = hipGetBackendName();
+  const char *hip_backend = hipGetBackendName();
 
   float *A = (float *)malloc(WIDTH * WIDTH * sizeof(float));
   float *B = (float *)malloc(WIDTH * WIDTH * sizeof(float));
@@ -111,13 +111,17 @@ int main() {
 
   assert(stream != nullptr);
 
-  uintptr_t nativeHandlers[4];
-  int numItems = 4;
-  error = (hipError_t)hipGetBackendNativeHandles((uintptr_t)stream, nativeHandlers, &numItems);
+  int numHandles;
+  error = (hipError_t)hipGetBackendNativeHandles(0, 0, &numHandles);
+  CHECK(error);
+  uintptr_t nativeHandlers[numHandles];
+  error = (hipError_t)hipGetBackendNativeHandles((uintptr_t)stream,
+                                                 nativeHandlers, 0);
   CHECK(error);
 
   // Invoke oneMKL GEEM
-  oneMKLGemmTest(nativeHandlers, hip_backend, A, B, C, m, m, k, ldA, ldB, ldC, alpha, beta);
+  oneMKLGemmTest(nativeHandlers, hip_backend, A, B, C, m, m, k, ldA, ldB, ldC,
+                 alpha, beta);
 
   // check results
   std::cout << "Verify results between OneMKL & Serial: ";

--- a/samples/hip_sycl_interop/hip_sycl_interop.h
+++ b/samples/hip_sycl_interop/hip_sycl_interop.h
@@ -25,7 +25,7 @@
 
 extern "C" {
 // Run GEMM test via oneMKL
-int oneMKLGemmTest(uintptr_t *nativeHandlers, const char* hip_backend, float *A, float *B, float *C,
+int oneMKLGemmTest(uintptr_t *nativeHandlers, float *A, float *B, float *C,
                    int M, int N, int K, int ldA, int ldB, int ldC, float alpha,
                    float beta);
 }

--- a/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
@@ -82,17 +82,17 @@ int onemkl_gemm(sycl::queue &my_queue, float *A, float *B, float *C, int m,
 }
 
 // Run GEMM test via oneMKL
-int oneMKLGemmTest(uintptr_t *nativeHandlers, const char *hip_backend, float *A,
+int oneMKLGemmTest(uintptr_t *nativeHandlers, float *A,
                    float *B, float *C, int M, int N, int K, int ldA, int ldB,
                    int ldC, float alpha, float beta) {
-  std::string hipBackend(hip_backend);
+  std::string hipBackendName((char *)nativeHandlers[0]);
   sycl::queue sycl_queue;
-  if (!hipBackend.compare("opencl")) {
+  if (!hipBackendName.compare("opencl")) {
     // handle openCl case here
-    cl_platform_id hPlatformId = (cl_platform_id)nativeHandlers[0];
-    cl_device_id hDeviceId = (cl_device_id)nativeHandlers[1];
-    cl_context hContext = (cl_context)nativeHandlers[2];
-    cl_command_queue hQueue = (cl_command_queue)nativeHandlers[3];
+    cl_platform_id hPlatformId = (cl_platform_id)nativeHandlers[1];
+    cl_device_id hDeviceId = (cl_device_id)nativeHandlers[2];
+    cl_context hContext = (cl_context)nativeHandlers[3];
+    cl_command_queue hQueue = (cl_command_queue)nativeHandlers[4];
     sycl::platform sycl_platform =
         sycl::opencl::make_platform((pi_native_handle)hPlatformId);
     sycl::device sycl_device =
@@ -101,16 +101,16 @@ int oneMKLGemmTest(uintptr_t *nativeHandlers, const char *hip_backend, float *A,
         sycl::opencl::make_context((pi_native_handle)hContext);
     sycl_queue =
         sycl::opencl::make_queue(sycl_context, (pi_native_handle)hQueue);
-  } else if (!hipBackend.compare("level0")) {
+  } else if (!hipBackendName.compare("level0")) {
     // handle L0 here
     // Extract the native information
-    ze_driver_handle_t hDriver = (ze_driver_handle_t)nativeHandlers[0];
-    ze_device_handle_t hDevice = (ze_device_handle_t)nativeHandlers[1];
-    ze_context_handle_t hContext = (ze_context_handle_t)nativeHandlers[2];
+    ze_driver_handle_t hDriver = (ze_driver_handle_t)nativeHandlers[1];
+    ze_device_handle_t hDevice = (ze_device_handle_t)nativeHandlers[2];
+    ze_context_handle_t hContext = (ze_context_handle_t)nativeHandlers[3];
     ze_command_queue_handle_t hQueue =
-        (ze_command_queue_handle_t)nativeHandlers[3];
+        (ze_command_queue_handle_t)nativeHandlers[4];
     ze_command_list_handle_t hCommandList =
-        (ze_command_list_handle_t)nativeHandlers[4];
+        (ze_command_list_handle_t)nativeHandlers[5];
 
     bool isImmCmdList = hCommandList ? true : false;
 
@@ -141,7 +141,7 @@ int oneMKLGemmTest(uintptr_t *nativeHandlers, const char *hip_backend, float *A,
         sycl_context, sycl_device, (pi_native_handle)hQueue, 1);
 #endif
   } else {
-    std::cout << "Unsupported backend: " << hipBackend << std::endl;
+    std::cout << "Unsupported backend: " << hipBackendName << std::endl;
     std::abort();
   }
 

--- a/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
@@ -127,14 +127,15 @@ int oneMKLGemmTest(uintptr_t *nativeHandlers, const char *hip_backend, float *A,
         sycl_devices, (pi_native_handle)hContext, 1);
 
 #if __INTEL_LLVM_COMPILER >= 20240000
-    if (isImmCmdList)
+    if (isImmCmdList) {
       sycl_queue = sycl::ext::oneapi::level_zero::make_queue(
           sycl_context, sycl_device, (pi_native_handle)hCommandList, true, 1,
           sycl::property::queue::in_order());
-    if (!isImmCmdList)
+    } else {
       sycl_queue = sycl::ext::oneapi::level_zero::make_queue(
           sycl_context, sycl_device, (pi_native_handle)hQueue, false, 1,
           sycl::property::queue::in_order());
+    }
 #else
     sycl_queue = sycl::ext::oneapi::level_zero::make_queue(
         sycl_context, sycl_device, (pi_native_handle)hQueue, 1);

--- a/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
@@ -101,7 +101,7 @@ int oneMKLGemmTest(uintptr_t *nativeHandlers, const char *hip_backend, float *A,
         sycl::opencl::make_context((pi_native_handle)hContext);
     sycl_queue =
         sycl::opencl::make_queue(sycl_context, (pi_native_handle)hQueue);
-  } else {
+  } else if (!hipBackend.compare("level0")) {
     // handle L0 here
     // Extract the native information
     ze_driver_handle_t hDriver = (ze_driver_handle_t)nativeHandlers[0];
@@ -140,6 +140,9 @@ int oneMKLGemmTest(uintptr_t *nativeHandlers, const char *hip_backend, float *A,
     sycl_queue = sycl::ext::oneapi::level_zero::make_queue(
         sycl_context, sycl_device, (pi_native_handle)hQueue, 1);
 #endif
+  } else {
+    std::cout << "Unsupported backend: " << hipBackend << std::endl;
+    std::abort();
   }
 
   // Test the oneMKL

--- a/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
@@ -39,17 +39,17 @@
 
 using namespace std;
 
-int onemkl_gemm(sycl::queue& my_queue, float* A, float* B, float* C, int m,
+int onemkl_gemm(sycl::queue &my_queue, float *A, float *B, float *C, int m,
                 int n, int k, int ldA, int ldB, int ldC, float alpha,
                 float beta) {
   auto my_exception_handler = [](sycl::exception_list exceptions) {
-    for (std::exception_ptr const& e : exceptions) {
+    for (std::exception_ptr const &e : exceptions) {
       try {
         std::rethrow_exception(e);
-      } catch (sycl::exception const& e) {
+      } catch (sycl::exception const &e) {
         std::cout << "Caught asynchronous SYCL exception:\n"
                   << e.what() << std::endl;
-      } catch (std::exception const& e) {
+      } catch (std::exception const &e) {
         std::cout << "Caught asynchronous STL exception:\n"
                   << e.what() << std::endl;
       }
@@ -67,10 +67,10 @@ int onemkl_gemm(sycl::queue& my_queue, float* A, float* B, float* C, int m,
         my_queue, oneapi::mkl::transpose::nontrans,
         oneapi::mkl::transpose::nontrans, m, n, k, alpha, A_buffer, ldA,
         B_buffer, ldB, beta, C_buffer, ldC);
-  } catch (sycl::exception const& e) {
+  } catch (sycl::exception const &e) {
     std::cout << "\t\tCaught synchronous SYCL exception during GEMM:\n"
               << e.what() << std::endl;
-  } catch (std::exception const& e) {
+  } catch (std::exception const &e) {
     std::cout << "\t\tCaught synchronous STL exception during GEMM:\n"
               << e.what() << std::endl;
   }
@@ -82,21 +82,25 @@ int onemkl_gemm(sycl::queue& my_queue, float* A, float* B, float* C, int m,
 }
 
 // Run GEMM test via oneMKL
-int oneMKLGemmTest(uintptr_t* nativeHandlers, const char* hip_backend, float* A, float* B, float* C,
-                   int M, int N, int K, int ldA, int ldB, int ldC, float alpha,
-                   float beta) {
+int oneMKLGemmTest(uintptr_t *nativeHandlers, const char *hip_backend, float *A,
+                   float *B, float *C, int M, int N, int K, int ldA, int ldB,
+                   int ldC, float alpha, float beta) {
   std::string hipBackend(hip_backend);
   sycl::queue sycl_queue;
-  if (!hipBackend.compare("opencl")){
+  if (!hipBackend.compare("opencl")) {
     // handle openCl case here
     cl_platform_id hPlatformId = (cl_platform_id)nativeHandlers[0];
     cl_device_id hDeviceId = (cl_device_id)nativeHandlers[1];
     cl_context hContext = (cl_context)nativeHandlers[2];
     cl_command_queue hQueue = (cl_command_queue)nativeHandlers[3];
-    sycl::platform sycl_platform = sycl::opencl::make_platform((pi_native_handle)hPlatformId);
-    sycl::device sycl_device = sycl::opencl::make_device((pi_native_handle)hDeviceId);
-    sycl::context sycl_context = sycl::opencl::make_context((pi_native_handle)hContext);
-    sycl_queue = sycl::opencl::make_queue(sycl_context, (pi_native_handle)hQueue);
+    sycl::platform sycl_platform =
+        sycl::opencl::make_platform((pi_native_handle)hPlatformId);
+    sycl::device sycl_device =
+        sycl::opencl::make_device((pi_native_handle)hDeviceId);
+    sycl::context sycl_context =
+        sycl::opencl::make_context((pi_native_handle)hContext);
+    sycl_queue =
+        sycl::opencl::make_queue(sycl_context, (pi_native_handle)hQueue);
   } else {
     // handle L0 here
     // Extract the native information
@@ -105,20 +109,35 @@ int oneMKLGemmTest(uintptr_t* nativeHandlers, const char* hip_backend, float* A,
     ze_context_handle_t hContext = (ze_context_handle_t)nativeHandlers[2];
     ze_command_queue_handle_t hQueue =
         (ze_command_queue_handle_t)nativeHandlers[3];
+    ze_command_list_handle_t hCommandList =
+        (ze_command_list_handle_t)nativeHandlers[4];
 
-    auto keep_ownership = static_cast<sycl::ext::oneapi::level_zero::ownership>(1);
-    sycl::platform sycl_platform = sycl::ext::oneapi::level_zero::make_platform((pi_native_handle)hDriver);
-    sycl::device sycl_device = sycl::ext::oneapi::level_zero::make_device(sycl_platform, (pi_native_handle)hDevice);
+    bool isImmCmdList = hCommandList ? true : false;
+
+    auto keep_ownership =
+        static_cast<sycl::ext::oneapi::level_zero::ownership>(1);
+    sycl::platform sycl_platform =
+        sycl::ext::oneapi::level_zero::make_platform((pi_native_handle)hDriver);
+    sycl::device sycl_device = sycl::ext::oneapi::level_zero::make_device(
+        sycl_platform, (pi_native_handle)hDevice);
 
     std::vector<sycl::device> sycl_devices(1);
     sycl_devices[0] = sycl_device;
-    sycl::context sycl_context = sycl::ext::oneapi::level_zero::make_context(sycl_devices, (pi_native_handle)hContext, 1);
+    sycl::context sycl_context = sycl::ext::oneapi::level_zero::make_context(
+        sycl_devices, (pi_native_handle)hContext, 1);
 
-    bool isImmCmdList = false;
 #if __INTEL_LLVM_COMPILER >= 20240000
-    sycl_queue = sycl::ext::oneapi::level_zero::make_queue(sycl_context, sycl_device, (pi_native_handle)hQueue, isImmCmdList, 1, sycl::property::queue::in_order());
+    if (isImmCmdList)
+      sycl_queue = sycl::ext::oneapi::level_zero::make_queue(
+          sycl_context, sycl_device, (pi_native_handle)hCommandList, true, 1,
+          sycl::property::queue::in_order());
+    if (!isImmCmdList)
+      sycl_queue = sycl::ext::oneapi::level_zero::make_queue(
+          sycl_context, sycl_device, (pi_native_handle)hQueue, false, 1,
+          sycl::property::queue::in_order());
 #else
-    sycl_queue = sycl::ext::oneapi::level_zero::make_queue(sycl_context, sycl_device, (pi_native_handle)hQueue, 1);
+    sycl_queue = sycl::ext::oneapi::level_zero::make_queue(
+        sycl_context, sycl_device, (pi_native_handle)hQueue, 1);
 #endif
   }
 

--- a/samples/hip_sycl_interop_no_buffers/hip_sycl_interop.cpp
+++ b/samples/hip_sycl_interop_no_buffers/hip_sycl_interop.cpp
@@ -60,7 +60,7 @@ void VerifyResult(float *c_A, float *c_B) {
 }
 
 int main() {
-  const char* hip_backend = hipGetBackendName();
+  const char *hip_backend = hipGetBackendName();
 
   float *A = (float *)malloc(WIDTH * WIDTH * sizeof(float));
   float *B = (float *)malloc(WIDTH * WIDTH * sizeof(float));
@@ -81,9 +81,11 @@ int main() {
   hipStream_t stream = nullptr;
   hipStreamCreate(&stream);
 
-  uintptr_t nativeHandlers[4];
-  int numItems = 4;
-  auto Error = hipGetBackendNativeHandles((uintptr_t)stream, nativeHandlers, &numItems);
+  int numItems;
+  auto Error = hipGetBackendNativeHandles(0, 0, &numItems);
+  assert(Error == hipSuccess);
+  uintptr_t nativeHandlers[numItems];
+  Error = hipGetBackendNativeHandles((uintptr_t)stream, nativeHandlers, 0);
   assert(Error == hipSuccess);
 
   // allocate memory
@@ -118,8 +120,8 @@ int main() {
   hipMemcpy(d_B, B, WIDTH * WIDTH * sizeof(float), hipMemcpyHostToDevice);
 
   // Invoke oneMKL GEMM
-  oneMKLGemmTest(nativeHandlers, hip_backend, d_A, d_B, d_C, WIDTH, WIDTH, WIDTH, ldA, ldB,
-                 ldC, alpha, beta);
+  oneMKLGemmTest(nativeHandlers, hip_backend, d_A, d_B, d_C, WIDTH, WIDTH,
+                 WIDTH, ldA, ldB, ldC, alpha, beta);
 
   // copy back C
   hipMemcpy(C, d_C, WIDTH * WIDTH * sizeof(float), hipMemcpyDeviceToHost);

--- a/samples/hip_sycl_interop_no_buffers/hip_sycl_interop.cpp
+++ b/samples/hip_sycl_interop_no_buffers/hip_sycl_interop.cpp
@@ -60,8 +60,6 @@ void VerifyResult(float *c_A, float *c_B) {
 }
 
 int main() {
-  const char *hip_backend = hipGetBackendName();
-
   float *A = (float *)malloc(WIDTH * WIDTH * sizeof(float));
   float *B = (float *)malloc(WIDTH * WIDTH * sizeof(float));
   float *C = (float *)malloc(WIDTH * WIDTH * sizeof(float));
@@ -120,7 +118,7 @@ int main() {
   hipMemcpy(d_B, B, WIDTH * WIDTH * sizeof(float), hipMemcpyHostToDevice);
 
   // Invoke oneMKL GEMM
-  oneMKLGemmTest(nativeHandlers, hip_backend, d_A, d_B, d_C, WIDTH, WIDTH,
+  oneMKLGemmTest(nativeHandlers, d_A, d_B, d_C, WIDTH, WIDTH,
                  WIDTH, ldA, ldB, ldC, alpha, beta);
 
   // copy back C

--- a/samples/hip_sycl_interop_no_buffers/hip_sycl_interop.h
+++ b/samples/hip_sycl_interop_no_buffers/hip_sycl_interop.h
@@ -25,7 +25,7 @@
 
 extern "C" {
   // Run GEMM test via oneMKL
-  int oneMKLGemmTest(uintptr_t* nativeHandlers, const char* hip_backend, float* A, float* B, float* C, int M, int N, int K,
+  int oneMKLGemmTest(uintptr_t* nativeHandlers, float* A, float* B, float* C, int M, int N, int K,
 		     int ldA, int ldB, int ldC, float alpha, float beta);
 }
 

--- a/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
@@ -125,14 +125,15 @@ int oneMKLGemmTest(uintptr_t *nativeHandlers, const char *hip_backend, float *A,
         sycl_devices, (pi_native_handle)hContext, 1);
 
 #if __INTEL_LLVM_COMPILER >= 20240000
-    if (isImmCmdList)
+    if (isImmCmdList) {
       sycl_queue = sycl::ext::oneapi::level_zero::make_queue(
           sycl_context, sycl_device, (pi_native_handle)hCommandList, true, 1,
           sycl::property::queue::in_order());
-    if (!isImmCmdList)
+    } else {
       sycl_queue = sycl::ext::oneapi::level_zero::make_queue(
           sycl_context, sycl_device, (pi_native_handle)hQueue, false, 1,
           sycl::property::queue::in_order());
+    }
 #else
     sycl_queue = sycl::ext::oneapi::level_zero::make_queue(
         sycl_context, sycl_device, (pi_native_handle)hQueue, 1);

--- a/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
@@ -79,17 +79,17 @@ int onemkl_gemm(sycl::queue &my_queue, float *A, float *B, float *C, int m,
 }
 
 // Run GEMM test via oneMKL
-int oneMKLGemmTest(uintptr_t *nativeHandlers, const char *hip_backend, float *A,
+int oneMKLGemmTest(uintptr_t *nativeHandlers, float *A,
                    float *B, float *C, int M, int N, int K, int ldA, int ldB,
                    int ldC, float alpha, float beta) {
-  std::string hipBackend(hip_backend);
+  std::string hipBackendName((char *)nativeHandlers[0]);
   sycl::queue sycl_queue;
-  if (!hipBackend.compare("opencl")) {
+  if (!hipBackendName.compare("opencl")) {
     // handle openCl case here
-    cl_platform_id hPlatformId = (cl_platform_id)nativeHandlers[0];
-    cl_device_id hDeviceId = (cl_device_id)nativeHandlers[1];
-    cl_context hContext = (cl_context)nativeHandlers[2];
-    cl_command_queue hQueue = (cl_command_queue)nativeHandlers[3];
+    cl_platform_id hPlatformId = (cl_platform_id)nativeHandlers[1];
+    cl_device_id hDeviceId = (cl_device_id)nativeHandlers[2];
+    cl_context hContext = (cl_context)nativeHandlers[3];
+    cl_command_queue hQueue = (cl_command_queue)nativeHandlers[4];
     sycl::platform sycl_platform =
         sycl::opencl::make_platform((pi_native_handle)hPlatformId);
     sycl::device sycl_device =
@@ -98,15 +98,15 @@ int oneMKLGemmTest(uintptr_t *nativeHandlers, const char *hip_backend, float *A,
         sycl::opencl::make_context((pi_native_handle)hContext);
     sycl_queue =
         sycl::opencl::make_queue(sycl_context, (pi_native_handle)hQueue);
-  } else if (!hipBackend.compare("level0")) {
+  } else if (!hipBackendName.compare("level0")) {
       // Extract the native information
-      ze_driver_handle_t hDriver = (ze_driver_handle_t)nativeHandlers[0];
-      ze_device_handle_t hDevice = (ze_device_handle_t)nativeHandlers[1];
-      ze_context_handle_t hContext = (ze_context_handle_t)nativeHandlers[2];
+      ze_driver_handle_t hDriver = (ze_driver_handle_t)nativeHandlers[1];
+      ze_device_handle_t hDevice = (ze_device_handle_t)nativeHandlers[2];
+      ze_context_handle_t hContext = (ze_context_handle_t)nativeHandlers[3];
       ze_command_queue_handle_t hQueue =
-          (ze_command_queue_handle_t)nativeHandlers[3];
+          (ze_command_queue_handle_t)nativeHandlers[4];
       ze_command_list_handle_t hCommandList =
-          (ze_command_list_handle_t)nativeHandlers[4];
+          (ze_command_list_handle_t)nativeHandlers[5];
 
       bool isImmCmdList = hCommandList ? true : false;
 
@@ -141,7 +141,7 @@ int oneMKLGemmTest(uintptr_t *nativeHandlers, const char *hip_backend, float *A,
 #endif
     }
   else {
-    std::cout << "Unsupported backend: " << hipBackend << std::endl;
+    std::cout << "Unsupported backend: " << hipBackendName << std::endl;
     std::abort();
   }
   // Test the oneMKL

--- a/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
@@ -39,17 +39,17 @@
 
 using namespace std;
 
-int onemkl_gemm(sycl::queue& my_queue, float* A, float* B, float* C, int m,
+int onemkl_gemm(sycl::queue &my_queue, float *A, float *B, float *C, int m,
                 int n, int k, int ldA, int ldB, int ldC, float alpha,
                 float beta) {
   auto my_exception_handler = [](sycl::exception_list exceptions) {
-    for (std::exception_ptr const& e : exceptions) {
+    for (std::exception_ptr const &e : exceptions) {
       try {
         std::rethrow_exception(e);
-      } catch (sycl::exception const& e) {
+      } catch (sycl::exception const &e) {
         std::cout << "Caught asynchronous SYCL exception:\n"
                   << e.what() << std::endl;
-      } catch (std::exception const& e) {
+      } catch (std::exception const &e) {
         std::cout << "Caught asynchronous STL exception:\n"
                   << e.what() << std::endl;
       }
@@ -64,10 +64,10 @@ int onemkl_gemm(sycl::queue& my_queue, float* A, float* B, float* C, int m,
         my_queue, oneapi::mkl::transpose::nontrans,
         oneapi::mkl::transpose::nontrans, m, n, k, alpha, A, ldA, B, ldB, beta,
         C, ldC);
-  } catch (sycl::exception const& e) {
+  } catch (sycl::exception const &e) {
     std::cout << "\t\tCaught synchronous SYCL exception during GEMM:\n"
               << e.what() << std::endl;
-  } catch (std::exception const& e) {
+  } catch (std::exception const &e) {
     std::cout << "\t\tCaught synchronous STL exception during GEMM:\n"
               << e.what() << std::endl;
   }
@@ -79,21 +79,25 @@ int onemkl_gemm(sycl::queue& my_queue, float* A, float* B, float* C, int m,
 }
 
 // Run GEMM test via oneMKL
-int oneMKLGemmTest(uintptr_t* nativeHandlers, const char* hip_backend, float* A, float* B, float* C,
-                   int M, int N, int K, int ldA, int ldB, int ldC, float alpha,
-                   float beta) {
+int oneMKLGemmTest(uintptr_t *nativeHandlers, const char *hip_backend, float *A,
+                   float *B, float *C, int M, int N, int K, int ldA, int ldB,
+                   int ldC, float alpha, float beta) {
   std::string hipBackend(hip_backend);
   sycl::queue sycl_queue;
-  if (!hipBackend.compare("opencl")){
+  if (!hipBackend.compare("opencl")) {
     // handle openCl case here
     cl_platform_id hPlatformId = (cl_platform_id)nativeHandlers[0];
     cl_device_id hDeviceId = (cl_device_id)nativeHandlers[1];
     cl_context hContext = (cl_context)nativeHandlers[2];
     cl_command_queue hQueue = (cl_command_queue)nativeHandlers[3];
-    sycl::platform sycl_platform = sycl::opencl::make_platform((pi_native_handle)hPlatformId);
-    sycl::device sycl_device = sycl::opencl::make_device((pi_native_handle)hDeviceId);
-    sycl::context sycl_context = sycl::opencl::make_context((pi_native_handle)hContext);
-    sycl_queue = sycl::opencl::make_queue(sycl_context, (pi_native_handle)hQueue);
+    sycl::platform sycl_platform =
+        sycl::opencl::make_platform((pi_native_handle)hPlatformId);
+    sycl::device sycl_device =
+        sycl::opencl::make_device((pi_native_handle)hDeviceId);
+    sycl::context sycl_context =
+        sycl::opencl::make_context((pi_native_handle)hContext);
+    sycl_queue =
+        sycl::opencl::make_queue(sycl_context, (pi_native_handle)hQueue);
   } else {
     // Extract the native information
     ze_driver_handle_t hDriver = (ze_driver_handle_t)nativeHandlers[0];
@@ -101,23 +105,37 @@ int oneMKLGemmTest(uintptr_t* nativeHandlers, const char* hip_backend, float* A,
     ze_context_handle_t hContext = (ze_context_handle_t)nativeHandlers[2];
     ze_command_queue_handle_t hQueue =
         (ze_command_queue_handle_t)nativeHandlers[3];
+    ze_command_list_handle_t hCommandList =
+        (ze_command_list_handle_t)nativeHandlers[4];
 
-    auto keep_ownership = static_cast<sycl::ext::oneapi::level_zero::ownership>(1);
-    sycl::platform sycl_platform = sycl::ext::oneapi::level_zero::make_platform((pi_native_handle)hDriver);
+    bool isImmCmdList = hCommandList ? true : false;
+
+    auto keep_ownership =
+        static_cast<sycl::ext::oneapi::level_zero::ownership>(1);
+    sycl::platform sycl_platform =
+        sycl::ext::oneapi::level_zero::make_platform((pi_native_handle)hDriver);
 
     // make devices from converted platform and L0 device
-    sycl::device sycl_device = sycl::ext::oneapi::level_zero::make_device(sycl_platform, (pi_native_handle)hDevice);
+    sycl::device sycl_device = sycl::ext::oneapi::level_zero::make_device(
+        sycl_platform, (pi_native_handle)hDevice);
 
     std::vector<sycl::device> sycl_devices(1);
     sycl_devices[0] = sycl_device;
-    sycl::context sycl_context = sycl::ext::oneapi::level_zero::make_context(sycl_devices, (pi_native_handle)hContext, 1);
+    sycl::context sycl_context = sycl::ext::oneapi::level_zero::make_context(
+        sycl_devices, (pi_native_handle)hContext, 1);
 
-    bool isImmCmdList = false;
 #if __INTEL_LLVM_COMPILER >= 20240000
-    sycl_queue = sycl::ext::oneapi::level_zero::make_queue(sycl_context, sycl_device, (pi_native_handle)hQueue,
-                                                           isImmCmdList, 1, sycl::property::queue::in_order());
+    if (isImmCmdList)
+      sycl_queue = sycl::ext::oneapi::level_zero::make_queue(
+          sycl_context, sycl_device, (pi_native_handle)hCommandList, true, 1,
+          sycl::property::queue::in_order());
+    if (!isImmCmdList)
+      sycl_queue = sycl::ext::oneapi::level_zero::make_queue(
+          sycl_context, sycl_device, (pi_native_handle)hQueue, false, 1,
+          sycl::property::queue::in_order());
 #else
-    sycl_queue = sycl::ext::oneapi::level_zero::make_queue(sycl_context, sycl_device, (pi_native_handle)hQueue, 1);
+    sycl_queue = sycl::ext::oneapi::level_zero::make_queue(
+        sycl_context, sycl_device, (pi_native_handle)hQueue, 1);
 #endif
   }
   // Test the oneMKL

--- a/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.cpp
+++ b/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.cpp
@@ -69,9 +69,14 @@ void matrixMultiplyCPUReference(const float *__restrict A,
 }
 
 int main() {
-  const char* val = hipGetBackendName();
-  std::string envVar(val);
-  if (!envVar.compare("opencl")) {
+  int NumHandles;
+  int Err = hipGetBackendNativeHandles(0, 0, &NumHandles);
+  assert(Err == 0);
+  uintptr_t NativeHandles[NumHandles];
+  Err = hipGetBackendNativeHandles((uintptr_t)0, NativeHandles, 0);
+  assert(Err == 0);
+  std::string BackendName((char*)NativeHandles[0]);
+  if (!BackendName.compare("opencl")) {
     std::cout << "HIP_SKIP_THIS_TEST" << std::endl;
     exit(0);
   }

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -86,9 +86,9 @@ if args.modules == "on":
   elif args.backend == "opencl" and args.device_type == "dgpu":
       modules += "opencl/dgpu"
   elif args.backend == "level0" and args.device_type == "igpu":
-      modules += "intel/opencl level-zero/igpu"
+      modules += "level-zero/igpu"
   elif args.backend == "level0" and args.device_type == "dgpu":
-      modules += "intel/opencl level-zero/dgpu"
+      modules += "level-zero/dgpu"
   elif args.backend == "pocl" and args.device_type == "cpu":
       modules += "opencl/pocl"
   modules += " &&  module list;"

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -4935,11 +4935,6 @@ void *hipGetHipEventFromNativeEvent(void *NativeEvent) {
   return E;
 }
 
-const char *hipGetBackendName() {
-  logDebug("hipGetCHIPBackend");
-  return CHIPGetBackendName();
-}
-
 hipError_t hipProfilerStart() {
   CHIP_TRY
   CHIPInitialize();

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -4884,27 +4884,18 @@ int hipGetBackendNativeHandles(uintptr_t Stream, uintptr_t *NativeHandles,
   logDebug("hipGetBackendNativeHandles");
 
   // Check the arugments
-  if (Stream == 0 && NativeHandles == 0 && NumHandles == 0) {
-    logError("hipGetBackendNativeHandles: All arguments are null");
+  if (NativeHandles == 0 && NumHandles == 0) {
+    logError("hipGetBackendNativeHandles: both NativeHandles and NumHandles "
+             "are null");
     return hipErrorInvalidValue;
-  }
-
-  // If NumHandles is not null, make sure that Stream and NativeHandles are null
-  if (NumHandles != 0) {
-    if (Stream != 0 || NativeHandles != 0) {
-      logError("hipGetBackendNativeHandles: NumHandles is not null, but Stream "
-               "or NativeHandles are not null");
-      return hipErrorInvalidValue;
-    }
-  }
-
-  // If NumHandles is null, make sure that Stream and NativeHandles are not null
-  if (NumHandles == 0) {
-    if (Stream == 0 || NativeHandles == 0) {
-      logError("hipGetBackendNativeHandles: NumHandles is null, but Stream or "
-               "NativeHandles are null");
-      return hipErrorInvalidValue;
-    }
+  } else if (NativeHandles && !NumHandles) {
+    logError("hipGetBackendNativeHandles: NativeHandles is not null but "
+             "NumHandles is null");
+    return hipErrorInvalidValue;
+  } else if (!NativeHandles && NumHandles) {
+    logError("hipGetBackendNativeHandles: NativeHandles is null but NumHandles "
+             "is not null");
+    return hipErrorInvalidValue;
   }
 
   auto ChipQueue =

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2283,8 +2283,7 @@ static inline hipError_t hipEventCreateWithFlagsInternal(hipEvent_t *Event,
                                                          unsigned Flags) {
   chipstar::EventFlags EventFlags{Flags};
 
-  *Event =
-      Backend->createEvent(Backend->getActiveContext(), EventFlags);
+  *Event = Backend->createEvent(Backend->getActiveContext(), EventFlags);
 
   return hipSuccess;
 }
@@ -2965,8 +2964,7 @@ hipError_t hipMemcpyInternal(void *Dst, const void *Src, size_t SizeBytes,
   auto Queue = Backend->getActiveDevice()->getDefaultQueue();
   LOCK(Queue->QueueMtx);
 
-  return Queue->memCopy(Dst, Src,
-                                                                SizeBytes);
+  return Queue->memCopy(Dst, Src, SizeBytes);
 }
 
 hipError_t hipMemcpy(void *Dst, const void *Src, size_t SizeBytes,
@@ -4857,11 +4855,58 @@ hipError_t hipLaunchKernel_spt(const void *function_address, dim3 numBlocks,
 // as compiler for sycl and the use of hipError_t mandates inclusion
 // of hip/hip_runtime.h which is not compatible which icpx
 
+/**
+ * @brief Return native handles to the chipStar backend objects. This function
+ * is meant to be called twice:
+ * 1. First call to get the NumHandles. All other arguments must be null.
+ * 2. Use the NumHandles to allocate the NativeHandles array and call the
+ * function again to get the handles. NumHandles must be null;
+ *
+ * Example:
+ *
+ * int numItems;
+ * auto Error = hipGetBackendNativeHandles(0, 0, &numItems);
+ * assert(Error == hipSuccess);
+ * uintptr_t nativeHandlers[numItems];
+ * auto Error = hipGetBackendNativeHandles((uintptr_t)stream, nativeHandlers,
+ * 0); assert(Error == hipSuccess);
+ * @param Stream
+ * @param NativeEvent This pointer must be allocated to the size of at least
+ * NumHandles, and gets
+ * @param NumHandles This pointer gets set to the required array size for
+ * NativeHandles
+ * @return int/hipError_t success or failure
+ */
 int hipGetBackendNativeHandles(uintptr_t Stream, uintptr_t *NativeHandles,
                                int *NumHandles) {
   CHIP_TRY
   CHIPInitialize();
   logDebug("hipGetBackendNativeHandles");
+
+  // Check the arugments
+  if (Stream == 0 && NativeHandles == 0 && NumHandles == 0) {
+    logError("hipGetBackendNativeHandles: All arguments are null");
+    return hipErrorInvalidValue;
+  }
+
+  // If NumHandles is not null, make sure that Stream and NativeHandles are null
+  if (NumHandles != 0) {
+    if (Stream != 0 || NativeHandles != 0) {
+      logError("hipGetBackendNativeHandles: NumHandles is not null, but Stream "
+               "or NativeHandles are not null");
+      return hipErrorInvalidValue;
+    }
+  }
+
+  // If NumHandles is null, make sure that Stream and NativeHandles are not null
+  if (NumHandles == 0) {
+    if (Stream == 0 || NativeHandles == 0) {
+      logError("hipGetBackendNativeHandles: NumHandles is null, but Stream or "
+               "NativeHandles are null");
+      return hipErrorInvalidValue;
+    }
+  }
+
   auto ChipQueue =
       Backend->findQueue(reinterpret_cast<chipstar::Queue *>(Stream));
   RETURN(ChipQueue->getBackendHandles(NativeHandles, NumHandles));

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -4888,13 +4888,9 @@ int hipGetBackendNativeHandles(uintptr_t Stream, uintptr_t *NativeHandles,
     logError("hipGetBackendNativeHandles: both NativeHandles and NumHandles "
              "are null");
     return hipErrorInvalidValue;
-  } else if (NativeHandles && !NumHandles) {
-    logError("hipGetBackendNativeHandles: NativeHandles is not null but "
-             "NumHandles is null");
-    return hipErrorInvalidValue;
-  } else if (!NativeHandles && NumHandles) {
-    logError("hipGetBackendNativeHandles: NativeHandles is null but NumHandles "
-             "is not null");
+  } else if (NativeHandles && NumHandles) {
+    logError("hipGetBackendNativeHandles: both NativeHandles and NumHandles "
+             "are not null");
     return hipErrorInvalidValue;
   }
 

--- a/src/CHIPDriver.cc
+++ b/src/CHIPDriver.cc
@@ -182,5 +182,3 @@ extern hipError_t CHIPReinitialize(const uintptr_t *NativeHandles,
 
   return hipSuccess;
 }
-
-const char *CHIPGetBackendName() { return ChipEnvVars.getBackend().str(); }

--- a/src/CHIPDriver.hh
+++ b/src/CHIPDriver.hh
@@ -105,8 +105,6 @@ void CHIPUninitializeCallOnce();
 extern hipError_t CHIPReinitialize(const uintptr_t *NativeHandles,
                                    int NumHandles);
 
-const char *CHIPGetBackendName();
-
 /**
  * Number of fat binaries registerer through __hipRegisterFatBinary(). On
  * program exit this value (non-zero) will postpone chipStar runtime

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1332,11 +1332,13 @@ CHIPQueueLevel0::memCopyToImage(ze_image_handle_t Image, const void *Src,
 hipError_t CHIPQueueLevel0::getBackendHandles(uintptr_t *NativeInfo,
                                               int *NumHandles) {
   logTrace("CHIPQueueLevel0::getBackendHandles");
-  if (*NumHandles < 4) {
-    logError("getBackendHandles requires space for 4 handles");
-    return hipErrorInvalidValue;
+  if (NumHandles) {
+    *NumHandles = 5;
+    return hipSuccess;
   }
-  *NumHandles = 4;
+
+  // get the immediate command list handle
+  NativeInfo[4] = (uintptr_t)ZeCmdListImm_;
 
   // Get queue handler
   NativeInfo[3] = (uintptr_t)ZeCmdQ_;

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1333,26 +1333,28 @@ hipError_t CHIPQueueLevel0::getBackendHandles(uintptr_t *NativeInfo,
                                               int *NumHandles) {
   logTrace("CHIPQueueLevel0::getBackendHandles");
   if (NumHandles) {
-    *NumHandles = 5;
+    *NumHandles = 6;
     return hipSuccess;
   }
 
   // get the immediate command list handle
-  NativeInfo[4] = (uintptr_t)ZeCmdListImm_;
+  NativeInfo[5] = (uintptr_t)ZeCmdListImm_;
 
   // Get queue handler
-  NativeInfo[3] = (uintptr_t)ZeCmdQ_;
+  NativeInfo[4] = (uintptr_t)ZeCmdQ_;
 
   // Get context handler
   CHIPContextLevel0 *Ctx = (CHIPContextLevel0 *)ChipContext_;
-  NativeInfo[2] = (uintptr_t)Ctx->get();
+  NativeInfo[3] = (uintptr_t)Ctx->get();
 
   // Get device handler
   CHIPDeviceLevel0 *Dev = (CHIPDeviceLevel0 *)ChipDevice_;
-  NativeInfo[1] = (uintptr_t)Dev->get();
+  NativeInfo[2] = (uintptr_t)Dev->get();
 
   // Get driver handler
-  NativeInfo[0] = (uintptr_t)Ctx->ZeDriver;
+  NativeInfo[1] = (uintptr_t)Ctx->ZeDriver;
+
+  NativeInfo[0] = (uintptr_t)ChipEnvVars.getBackend().str();
   return hipSuccess;
 }
 

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -242,8 +242,8 @@ protected:
   ze_command_queue_group_properties_t QueueProperties_;
   ze_command_queue_desc_t QueueDescriptor_;
   ze_command_list_desc_t CommandListDesc_;
-  ze_command_queue_handle_t ZeCmdQ_;
-  ze_command_list_handle_t ZeCmdListImm_;
+  ze_command_queue_handle_t ZeCmdQ_ = 0;
+  ze_command_list_handle_t ZeCmdListImm_ = 0;
   ze_fence_desc_t ZeFenceDesc_ = {ZE_STRUCTURE_TYPE_FENCE_DESC, nullptr, 0};
   ze_fence_handle_t ZeFence_;
 

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -1418,11 +1418,10 @@ std::shared_ptr<chipstar::Event> CHIPQueueOpenCL::memCopy3DAsyncImpl(
 hipError_t CHIPQueueOpenCL::getBackendHandles(uintptr_t *NativeInfo,
                                               int *NumHandles) {
   logTrace("CHIPQueueOpenCL::getBackendHandles");
-  if (*NumHandles < 4) {
-    logError("getBackendHandles requires space for 4 handles");
-    return hipErrorInvalidValue;
+  if (NumHandles) {
+    *NumHandles = 4;
+    return hipSuccess;
   }
-  *NumHandles = 4;
 
   // Get queue handler
   NativeInfo[3] = (uintptr_t)ClQueue_->get();

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -1419,24 +1419,26 @@ hipError_t CHIPQueueOpenCL::getBackendHandles(uintptr_t *NativeInfo,
                                               int *NumHandles) {
   logTrace("CHIPQueueOpenCL::getBackendHandles");
   if (NumHandles) {
-    *NumHandles = 4;
+    *NumHandles = 5;
     return hipSuccess;
   }
 
   // Get queue handler
-  NativeInfo[3] = (uintptr_t)ClQueue_->get();
+  NativeInfo[4] = (uintptr_t)ClQueue_->get();
 
   // Get context handler
   cl::Context *Ctx = ((CHIPContextOpenCL *)ChipContext_)->get();
-  NativeInfo[2] = (uintptr_t)Ctx->get();
+  NativeInfo[3] = (uintptr_t)Ctx->get();
 
   // Get device handler
   cl::Device *Dev = ((CHIPDeviceOpenCL *)ChipDevice_)->get();
-  NativeInfo[1] = (uintptr_t)Dev->get();
+  NativeInfo[2] = (uintptr_t)Dev->get();
 
   // Get platform handler
   cl_platform_id Plat = Dev->getInfo<CL_DEVICE_PLATFORM>();
-  NativeInfo[0] = (uintptr_t)Plat;
+  NativeInfo[1] = (uintptr_t)Plat;
+
+  NativeInfo[0] = (uintptr_t)ChipEnvVars.getBackend().str();
   return hipSuccess;
 }
 


### PR DESCRIPTION
Refactor how backend handles are returned. `hipGetBackendNativeHandles` is now to be called twice - once to get the number of handles and second time to populate the allocated handle array. 