### PR TITLE
Changes to reduce kernel launch overheads

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1771,29 +1771,31 @@ chipstar::Queue::RegisteredVarCopy(chipstar::ExecItem *ExecItem,
 }
 
 void chipstar::Queue::launch(chipstar::ExecItem *ExItem) {
-  std::stringstream InfoStr;
-  InfoStr << "\nLaunching kernel " << ExItem->getKernel()->getName() << "\n";
-  InfoStr << "GridDim: <" << ExItem->getGrid().x << ", " << ExItem->getGrid().y
-          << ", " << ExItem->getGrid().z << ">";
-  InfoStr << " BlockDim: <" << ExItem->getBlock().x << ", "
-          << ExItem->getBlock().y << ", " << ExItem->getBlock().z << ">\n";
-  InfoStr << "SharedMem: " << ExItem->getSharedMem() << "\n";
+  if (shouldLog(spdlog::level::info)) {
+    std::stringstream InfoStr;
+    InfoStr << "\nLaunching kernel " << ExItem->getKernel()->getName() << "\n";
+    InfoStr << "GridDim: <" << ExItem->getGrid().x << ", "
+            << ExItem->getGrid().y << ", " << ExItem->getGrid().z << ">";
+    InfoStr << " BlockDim: <" << ExItem->getBlock().x << ", "
+            << ExItem->getBlock().y << ", " << ExItem->getBlock().z << ">\n";
+    InfoStr << "SharedMem: " << ExItem->getSharedMem() << "\n";
 
-  const auto &FuncInfo = *ExItem->getKernel()->getFuncInfo();
-  InfoStr << "NumArgs: " << FuncInfo.getNumKernelArgs() << "\n";
-  auto Visitor = [&](const SPVFuncInfo::KernelArg &Arg) -> void {
-    InfoStr << "Arg " << Arg.Index << ": " << Arg.getKindAsString() << " "
-            << Arg.Size << " " << Arg.Data;
-    if (Arg.Kind == SPVTypeKind::Pointer && !Arg.isWorkgroupPtr()) {
-      void *PtrVal = *static_cast<void **>(const_cast<void *>(Arg.Data));
-      InfoStr << " (" << PtrVal << ")";
-    }
-    InfoStr << "\n";
-  };
-  FuncInfo.visitKernelArgs(ExItem->getArgs(), Visitor);
+    const auto &FuncInfo = *ExItem->getKernel()->getFuncInfo();
+    InfoStr << "NumArgs: " << FuncInfo.getNumKernelArgs() << "\n";
+    auto Visitor = [&](const SPVFuncInfo::KernelArg &Arg) -> void {
+      InfoStr << "Arg " << Arg.Index << ": " << Arg.getKindAsString() << " "
+              << Arg.Size << " " << Arg.Data;
+      if (Arg.Kind == SPVTypeKind::Pointer && !Arg.isWorkgroupPtr()) {
+        void *PtrVal = *static_cast<void **>(const_cast<void *>(Arg.Data));
+        InfoStr << " (" << PtrVal << ")";
+      }
+      InfoStr << "\n";
+    };
+    FuncInfo.visitKernelArgs(ExItem->getArgs(), Visitor);
 
-  // Making this log info since hipLaunchKernel doesn't know enough about args
-  logInfo("{}", InfoStr.str());
+    // Making this log info since hipLaunchKernel doesn't know enough about args
+    logInfo("{}", InfoStr.str());
+  }
 
   auto TotalThreadsPerBlock =
       ExItem->getBlock().x * ExItem->getBlock().y * ExItem->getBlock().z;

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -379,16 +379,19 @@ chipstar::Module::allocateDeviceVariablesNoLock(chipstar::Device *Device,
 
 void chipstar::Module::prepareDeviceVariablesNoLock(chipstar::Device *Device,
                                                     chipstar::Queue *Queue) {
-  auto Err = allocateDeviceVariablesNoLock(Device, Queue);
-  (void)Err;
-
-  // Mark initialized if the module does not have any device variables.
-  auto *NonSymbolResetKernel = findKernel(ChipNonSymbolResetKernelName);
-  DeviceVariablesInitialized_ |= ChipVars_.empty() && !NonSymbolResetKernel;
-
   if (DeviceVariablesInitialized_) {
     // Can't be initialized if no storage is not allocated.
     assert(DeviceVariablesAllocated_ && "Should have storage.");
+    return;
+  }
+
+  auto Err = allocateDeviceVariablesNoLock(Device, Queue);
+  (void)Err;
+
+  // Skip if the module does not have device variables needing initialization.
+  auto *NonSymbolResetKernel = findKernel(ChipNonSymbolResetKernelName);
+  if (ChipVars_.empty() && !NonSymbolResetKernel) {
+    DeviceVariablesInitialized_ = true;
     return;
   }
 

--- a/src/logging.hh
+++ b/src/logging.hh
@@ -94,4 +94,8 @@ void logCritical(const char *Fmt, const TypeArgs &...Args) {
 #define logCritical(...) void(0)
 #endif
 
+inline bool shouldLog(spdlog::level::level_enum MsgLevel) {
+  return spdlog::default_logger()->should_log(MsgLevel);
+}
+
 #endif


### PR DESCRIPTION
A patch set for reducing kernel launch overheads. These improved HeCBench's mrc, floydwarshall and overlay benchmarks by 41-57% on PVC.

* Skip kernel info string construction when it is not going to be logged/displayed.
* Reduce kernel launch overhead from `__hipPushCallConfiguration()` and `__hipPopCallConfiguration()` functions:
  * Remove unnecessary backend initialization (backend will be initialized at `hipLaunchKernel()`).
  * Avoid creating short living temporary, heap allocated `chipStar::ExecItem`.
* Exit earlier from `prepareDeviceVariablesNoLock()`.
* Recycle OpenCL kernel handles instead of creating them for each exec-item.