### PR TITLE
Add CHIP_DEVICE_TYPE to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Please refer to the [user documentation](docs/Using.md) for instructions on how 
 CHIP_BE=<opencl/level0>                         # Selects the backend to use. If both Level Zero and OpenCL are available, Level Zero is used by default
 CHIP_PLATFORM=<N>                               # If there are multiple platforms present on the system, selects which one to use. Defaults to 0
 CHIP_DEVICE=<N>                                 # If there are multiple devices present on the system, selects which one to use. Defaults to 0
+CHIP_DEVICE_TYPE=<gpu/cpu/accel/fpga> or empty  # Selects which type of device to use. Defaults to empty.
 CHIP_LOGLEVEL=<trace/debug/info/warn/err/crit>  # Sets the log level. If compiled in RELEASE, only err/crit are available
 CHIP_DUMP_SPIRV=<ON/OFF(default)>               # Dumps the generated SPIR-V code to a file
 CHIP_JIT_FLAGS=<flags>                          # String to override the default JIT flags. Defaults to -cl-kernel-arg-info -cl-std=CL3.0

--- a/docs/Using.md
+++ b/docs/Using.md
@@ -14,11 +14,20 @@ If set to "default" (or unset), it automatically selects any available backend i
 #### CHIP_LOGLEVEL
 
 Selects the verbosity of debug info during execution.
-Possible values: trace, debug (default for Debug builds), warn (default for non-Debug builds), err, crit
+Possible values: `trace`, `debug` (default for Debug builds), `warn` (default for non-Debug builds), `err`, `crit`.
+
+Note that the values `trace` and `debug` need chipStar to be compiled in DEBUG mode.
 
 Setting this value to `debug` will print information coming from the chipStar functions which are shared between the backends.
 
 Settings this value to `trace` will print `debug`, as well as debug infomarmation from the backend implementation itself such as results from low-level Level Zero API calls.
+
+#### CHIP_DEVICE_TYPE
+Selects which type of device to use. 
+
+Possible values for Level 0 backend are: `gpu` and `fpga`. Leaving it empty uses all available devices.
+
+Possible values for OpenCL backend are: `gpu`, `cpu` , `accel`. Leaving it empty uses GPU devices.
 
 #### HIP_PLATFORM
 


### PR DESCRIPTION
This add the following two points to the documentation.
1. Document existance and usage of the `CHIP_DEVICE_TYPE` environment variable.
2. Adds one more note regarding availability of trace and debug log level information.

# Motivation
Thanks for this great library, works great!
I had to spent some hours at the beginning tracking down the root for the following two error messages using OpenCL backend: `Selected OpenCL device 0 is out of range`.
It took some time to find the undocumented environment variable which caused chipStar to only look for GPUs on my CPU-only system.