### PR TITLE
Sample and Test Profiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,13 @@ option(CHIP_USE_INTEL_USM "enable support for cl_intel_unified_shared_memory in 
 option(CHIP_L0_FIRST_TOUCH "First-touch workaround for Level Zero." OFF)
 set(CHIP_DEFAULT_JIT_FLAGS "-cl-kernel-arg-info -cl-std=CL3.0")
 
+option(CHIP_PROFILE_TESTS "Attach iprof to each test under ctest" OFF)
+if (CHIP_PROFILE_TESTS)
+  set(HIP_PROFILE_TESTS_COMMAND "iprof" "-m" "full" "--")
+  else()
+  set(HIP_PROFILE_TESTS_COMMAND "")
+endif()
+
 option(OCML_BASIC_ROUNDED_OPERATIONS "Use OCML implementations for devicelib functions with explicit rounding mode such as __dadd_rd. Otherwise, rounding mode will be ignored" OFF)
 
 # (old) ARM Mali GPU driver is known to fail to process valid SPIR-V

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -53,7 +53,7 @@ function(add_chip_test EXEC_NAME TEST_NAME TEST_PASS SOURCE)
             RUNTIME DESTINATION "${CHIP_SAMPLE_BINDIR}")
 
     add_test(NAME "${TEST_NAME}"
-             COMMAND "${CMAKE_CURRENT_BINARY_DIR}/${EXEC_NAME}" ${TEST_EXEC_ARGS}
+             COMMAND ${HIP_PROFILE_TESTS_COMMAND} "${CMAKE_CURRENT_BINARY_DIR}/${EXEC_NAME}" ${TEST_EXEC_ARGS}
              )
 
     set_tests_properties("${TEST_NAME}" PROPERTIES

--- a/samples/cuda_samples/CMakeLists.txt
+++ b/samples/cuda_samples/CMakeLists.txt
@@ -25,7 +25,7 @@ function(add_cuda_sample_args)
     RUNTIME DESTINATION "${CHIP_SAMPLE_BINDIR}/cuda_samples")
 
   add_test(NAME "${CUDA_NAME}"
-    COMMAND "${CMAKE_CURRENT_BINARY_DIR}/${EXEC_NAME}" ${CUDA_ARGS})
+    COMMAND ${HIP_PROFILE_TESTS_COMMAND} "${CMAKE_CURRENT_BINARY_DIR}/${EXEC_NAME}" ${CUDA_ARGS})
   set_property(TEST "${CUDA_NAME}" PROPERTY LABELS "internal;cuda")
 
 endfunction()

--- a/samples/hip_async_interop/CMakeLists.txt
+++ b/samples/hip_async_interop/CMakeLists.txt
@@ -16,7 +16,7 @@ add_chip_binary(hip_async_binomial ${SOURCES})
 target_compile_definitions(hip_async_binomial PRIVATE ${OPTS})
 
 add_test(NAME "hip_async_binomial"
-         COMMAND "${CMAKE_CURRENT_BINARY_DIR}/hip_async_binomial"
+         COMMAND ${HIP_PROFILE_TESTS_COMMAND} "${CMAKE_CURRENT_BINARY_DIR}/hip_async_binomial"
          -q -e -t -x 2048 -i 32)
 
 set_tests_properties("hip_async_binomial" PROPERTIES

--- a/samples/hip_sycl_interop/CMakeLists.txt
+++ b/samples/hip_sycl_interop/CMakeLists.txt
@@ -7,7 +7,7 @@ target_link_libraries(hip_sycl_interop onemkl_gemm_wrapper -L${CMAKE_BINARY_DIR}
 target_include_directories(hip_sycl_interop PUBLIC ${CHIP_SRC_DIR}/HIP/include ${CHIP_SRC_DIR}/include)
 
 add_test(NAME "hip_sycl_interop"
-    COMMAND "${CMAKE_CURRENT_BINARY_DIR}/hip_sycl_interop"
+    COMMAND ${HIP_PROFILE_TESTS_COMMAND} "${CMAKE_CURRENT_BINARY_DIR}/hip_sycl_interop"
 )
 
 set_tests_properties("hip_sycl_interop" PROPERTIES

--- a/samples/hip_sycl_interop_no_buffers/CMakeLists.txt
+++ b/samples/hip_sycl_interop_no_buffers/CMakeLists.txt
@@ -6,7 +6,7 @@ target_link_options(hip_sycl_interop_no_buffers PRIVATE -fsycl -L${CMAKE_BINARY_
 target_link_libraries(hip_sycl_interop_no_buffers onemkl_gemm_wrapper_no_buffers)
 
 add_test(NAME "hip_sycl_interop_no_buffers"
-         COMMAND "${CMAKE_CURRENT_BINARY_DIR}/hip_sycl_interop_no_buffers" 
+         COMMAND ${HIP_PROFILE_TESTS_COMMAND} "${CMAKE_CURRENT_BINARY_DIR}/hip_sycl_interop_no_buffers" 
          )
 
 set_tests_properties("hip_sycl_interop_no_buffers" PROPERTIES

--- a/samples/shuffles/CMakeLists.txt
+++ b/samples/shuffles/CMakeLists.txt
@@ -15,4 +15,4 @@ configure_file(
   COPYONLY)
 add_test(
   NAME shuffles
-  COMMAND "${CMAKE_COMMAND}" -P ${CMAKE_CURRENT_BINARY_DIR}/run-shuffles.cmake)
+  COMMAND ${HIP_PROFILE_TESTS_COMMAND} "${CMAKE_COMMAND}" -P ${CMAKE_CURRENT_BINARY_DIR}/run-shuffles.cmake)

--- a/samples/sycl_hip_interop/sycl_hip_interop_driver/CMakeLists.txt
+++ b/samples/sycl_hip_interop/sycl_hip_interop_driver/CMakeLists.txt
@@ -13,7 +13,7 @@ install(TARGETS sycl_chip_interop
     RUNTIME DESTINATION "${CHIP_SAMPLE_BINDIR}")
 
 add_test(NAME "sycl_chip_interop"
-    COMMAND "${CMAKE_CURRENT_BINARY_DIR}/sycl_chip_interop"
+    COMMAND ${HIP_PROFILE_TESTS_COMMAND} "${CMAKE_CURRENT_BINARY_DIR}/sycl_chip_interop"
 )
 
 set_tests_properties("sycl_chip_interop" PROPERTIES
@@ -35,7 +35,7 @@ install(TARGETS sycl_chip_interop_usm
 
 add_dependencies(samples sycl_chip_interop sycl_chip_interop_usm)
 add_test(NAME "sycl_chip_interop_usm"
-    COMMAND "${CMAKE_CURRENT_BINARY_DIR}/sycl_chip_interop_usm"
+    COMMAND ${HIP_PROFILE_TESTS_COMMAND} "${CMAKE_CURRENT_BINARY_DIR}/sycl_chip_interop_usm"
 )
 
 set_tests_properties("sycl_chip_interop_usm" PROPERTIES

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -40,7 +40,7 @@ function(add_hip_runtime_test MAIN_SOURCE)
   target_compile_definitions("${EXEC_NAME}"
     PRIVATE CHIP_SKIP_TEST=${CHIP_SKIP_TEST})
 
-  add_test(NAME ${EXEC_NAME} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${EXEC_NAME})
+  add_test(NAME ${EXEC_NAME} COMMAND ${HIP_PROFILE_TESTS_COMMAND} ${CMAKE_CURRENT_BINARY_DIR}/${EXEC_NAME})
 
   set_tests_properties("${EXEC_NAME}" PROPERTIES
     SKIP_RETURN_CODE ${CHIP_SKIP_TEST})


### PR DESCRIPTION
* add `CHIP_PROFILE_TESTS` option
* Most samples modify `add_test()` such that they're run through `HIP_PROFILE_TESTS_COMMAND` which in our case is iprof
* Allows for profiling tests and collecting traces from issues that arise only when things are run in parallel through ctest