### PR TITLE
OpenCL: Use non-profiling queue, switch to profiling when needed 

### DIFF
--- a/docs/Using.md
+++ b/docs/Using.md
@@ -49,6 +49,11 @@ When set to `0`, chipStar will compile all device modules at the runtime
 initialization. Default setting is `1` meaning the device modules are
 compiled just before kernel launches.
 
+#### CHIP\_OCL\_DISABLE\_QUEUE\_PROFILING
+
+A debug option for forcing queue profiling to be disabled in the
+OpenCL backend. The default setting is `0`.
+
 ### Disabling GPU hangcheck
 
 Note that long-running GPU compute kernels can trigger hang detection mechanism in the GPU driver, which will cause the kernel execution to be terminated and the runtime will report an error. Consult the documentation of your GPU driver on how to disable this hangcheck.

--- a/src/CHIPDriver.hh
+++ b/src/CHIPDriver.hh
@@ -230,6 +230,7 @@ private:
   std::string JitFlags_ = CHIP_DEFAULT_JIT_FLAGS;
   unsigned long L0EventTimeout_ = 0;
   int L0CollectEventsTimeout_ = 0;
+  bool OCLDisableQueueProfiling_ = false;
 
 public:
   EnvVars() {
@@ -252,6 +253,7 @@ public:
 
     return L0EventTimeout_ * 1e9;
   }
+  bool getOCLDisableQueueProfiling() const { return OCLDisableQueueProfiling_; }
 
 private:
   void parseEnvironmentVariables() {
@@ -282,6 +284,12 @@ private:
 
     if (!readEnvVar("CHIP_L0_EVENT_TIMEOUT").empty())
       L0EventTimeout_ = parseInt("CHIP_L0_EVENT_TIMEOUT");
+
+    constexpr char DisableQProfilingEnv[] = "CHIP_OCL_DISABLE_QUEUE_PROFILING";
+    if (!readEnvVar(DisableQProfilingEnv).empty()) {
+      OCLDisableQueueProfiling_ = parseBoolean(DisableQProfilingEnv);
+      logDebug("{}={}", DisableQProfilingEnv, OCLDisableQueueProfiling_);
+    }
   }
 
   std::string_view parseJitFlags(const std::string &StrIn) {

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -654,8 +654,11 @@ void CHIPQueueOpenCL::recordEvent(chipstar::Event *ChipEvent) {
   logTrace("chipstar::Queue::recordEvent({})", (void *)ChipEvent);
   auto ChipEventCL = static_cast<CHIPEventOpenCL *>(ChipEvent);
 
-  std::shared_ptr<chipstar::Event> LastEvent = getLastEvent();
-  ChipEventCL->recordEventCopy(LastEvent ? LastEvent : enqueueMarker());
+  // Need profiling command queue for querying timestamps for possible
+  // later hipEventElapsedTime() calls.
+  switchModeTo(Profiling);
+
+  ChipEventCL->recordEventCopy(enqueueMarker());
   ChipEventCL->setRecording();
 }
 
@@ -1084,24 +1087,25 @@ void CHIPQueueOpenCL::MemMap(const chipstar::AllocationInfo *AllocInfo,
   auto [SyncQueuesEventHandles, EventLocks] =
       addDependenciesQueueSync(MemMapEvent);
 
+  auto QueueHandle = get()->get();
   cl_int Status;
   if (Type == chipstar::Queue::MEM_MAP_TYPE::HOST_READ) {
     logDebug("CHIPQueueOpenCL::MemMap HOST_READ");
-    Status = clEnqueueSVMMap(ClQueue_->get(), CL_TRUE, CL_MAP_READ,
-                             AllocInfo->HostPtr, AllocInfo->Size,
-                             SyncQueuesEventHandles.size(),
-                             SyncQueuesEventHandles.data(), MemMapEventNative);
+    Status =
+        clEnqueueSVMMap(QueueHandle, CL_TRUE, CL_MAP_READ, AllocInfo->HostPtr,
+                        AllocInfo->Size, SyncQueuesEventHandles.size(),
+                        SyncQueuesEventHandles.data(), MemMapEventNative);
   } else if (Type == chipstar::Queue::MEM_MAP_TYPE::HOST_WRITE) {
     logDebug("CHIPQueueOpenCL::MemMap HOST_WRITE");
-    Status = clEnqueueSVMMap(ClQueue_->get(), CL_TRUE, CL_MAP_WRITE,
-                             AllocInfo->HostPtr, AllocInfo->Size,
-                             SyncQueuesEventHandles.size(),
-                             SyncQueuesEventHandles.data(), MemMapEventNative);
+    Status =
+        clEnqueueSVMMap(QueueHandle, CL_TRUE, CL_MAP_WRITE, AllocInfo->HostPtr,
+                        AllocInfo->Size, SyncQueuesEventHandles.size(),
+                        SyncQueuesEventHandles.data(), MemMapEventNative);
   } else if (Type == chipstar::Queue::MEM_MAP_TYPE::HOST_READ_WRITE) {
     logDebug("CHIPQueueOpenCL::MemMap HOST_READ_WRITE");
-    Status = clEnqueueSVMMap(ClQueue_->get(), CL_TRUE,
-                             CL_MAP_READ | CL_MAP_WRITE, AllocInfo->HostPtr,
-                             AllocInfo->Size, SyncQueuesEventHandles.size(),
+    Status = clEnqueueSVMMap(QueueHandle, CL_TRUE, CL_MAP_READ | CL_MAP_WRITE,
+                             AllocInfo->HostPtr, AllocInfo->Size,
+                             SyncQueuesEventHandles.size(),
                              SyncQueuesEventHandles.data(), MemMapEventNative);
   } else {
     assert(0 && "Invalid MemMap Type");
@@ -1123,13 +1127,23 @@ void CHIPQueueOpenCL::MemUnmap(const chipstar::AllocationInfo *AllocInfo) {
       addDependenciesQueueSync(MemMapEvent);
 
   auto Status = clEnqueueSVMUnmap(
-      ClQueue_->get(), AllocInfo->HostPtr, SyncQueuesEventHandles.size(),
+      get()->get(), AllocInfo->HostPtr, SyncQueuesEventHandles.size(),
       SyncQueuesEventHandles.data(),
       std::static_pointer_cast<CHIPEventOpenCL>(MemMapEvent)->getNativePtr());
   assert(Status == CL_SUCCESS);
 }
 
-cl::CommandQueue *CHIPQueueOpenCL::get() { return ClQueue_; }
+cl::CommandQueue *CHIPQueueOpenCL::get() {
+  switch (QueueMode_) {
+  default:
+    assert(!"Unknown queue mode!");
+    // Fallthrough.
+  case Profiling:
+    return &ClProfilingQueue_;
+  case Regular:
+    return &ClRegularQueue_;
+  }
+}
 
 void CHIPQueueOpenCL::addCallback(hipStreamCallback_t Callback,
                                   void *UserData) {
@@ -1187,7 +1201,7 @@ void CHIPQueueOpenCL::addCallback(hipStreamCallback_t Callback,
   CHIPERR_CHECK_LOG_AND_THROW(Status, CL_SUCCESS, hipErrorTbd);
 
   updateLastEvent(CallbackCompleted);
-  ClQueue_->flush();
+  get()->flush();
 
   // Now the CB can start executing in the background:
   clSetUserEventStatus(
@@ -1251,7 +1265,7 @@ CHIPQueueOpenCL::launchImpl(chipstar::ExecItem *ExecItem) {
   auto [SyncQueuesEventHandles, EventLocks] =
       addDependenciesQueueSync(LaunchEvent);
   auto Status = clEnqueueNDRangeKernel(
-      ClQueue_->get(), KernelHandle, NumDims, GlobalOffset, Global, Local,
+      get()->get(), KernelHandle, NumDims, GlobalOffset, Global, Local,
       SyncQueuesEventHandles.size(), SyncQueuesEventHandles.data(),
       std::static_pointer_cast<CHIPEventOpenCL>(LaunchEvent)->getNativePtr());
   CHIPERR_CHECK_LOG_AND_THROW(Status, CL_SUCCESS, hipErrorTbd);
@@ -1289,7 +1303,7 @@ CHIPQueueOpenCL::launchImpl(chipstar::ExecItem *ExecItem) {
 }
 
 CHIPQueueOpenCL::CHIPQueueOpenCL(chipstar::Device *ChipDevice, int Priority,
-                                 cl_command_queue Queue)
+                                 cl_command_queue QueueForInterop)
     : chipstar::Queue(ChipDevice, chipstar::QueueFlags{}, Priority) {
 
   cl_queue_priority_khr PrioritySelection;
@@ -1312,31 +1326,54 @@ CHIPQueueOpenCL::CHIPQueueOpenCL(chipstar::Device *ChipDevice, int Priority,
   if (PrioritySelection != CL_QUEUE_PRIORITY_MED_KHR)
     logWarn("CHIPQueueOpenCL is ignoring Priority value");
 
-  if (Queue)
-    ClQueue_ = new cl::CommandQueue(Queue);
-  else {
-    cl::Context *ClContext_ = ((CHIPContextOpenCL *)ChipContext_)->get();
-    cl::Device *ClDevice_ = ((CHIPDeviceOpenCL *)ChipDevice_)->get();
+  if (QueueForInterop) {
+    auto QFromUser = cl::CommandQueue(QueueForInterop);
+
     cl_int Status;
-    // Adding priority breaks correctness?
-    // cl_queue_properties QueueProperties[] = {
-    //     CL_QUEUE_PRIORITY_KHR, PrioritySelection, CL_QUEUE_PROPERTIES,
-    //     CL_QUEUE_PROFILING_ENABLE, 0};
-    cl_queue_properties QueueProperties[] = {CL_QUEUE_PROPERTIES,
-                                             CL_QUEUE_PROFILING_ENABLE, 0};
-
-    const cl_command_queue Q = clCreateCommandQueueWithProperties(
-        ClContext_->get(), ClDevice_->get(), QueueProperties, &Status);
-    ClQueue_ = new cl::CommandQueue(Q);
-
+    cl_command_queue_properties QProps =
+        QFromUser.getInfo<CL_QUEUE_PROPERTIES>(&Status);
     CHIPERR_CHECK_LOG_AND_THROW(Status, CL_SUCCESS,
                                 hipErrorInitializationError);
+
+    bool ProfilingIsEnabled = CL_QUEUE_PROFILING_ENABLE & QProps;
+    if (ProfilingIsEnabled) {
+      ClProfilingQueue_ = QFromUser;
+      QueueMode_ = Profiling;
+    } else {
+      logWarn("Provided queue has profiling disable. hipEventElapsedTime() "
+              "calls will fail.");
+      ClRegularQueue_ = QFromUser;
+      QueueMode_ = Regular;
+    }
+    UsedInInterOp = true;
+  } else {
+    cl::Context &ClContext =
+        *static_cast<CHIPContextOpenCL *>(ChipContext_)->get();
+    cl::Device &ClDevice = *static_cast<CHIPDeviceOpenCL *>(ChipDevice_)->get();
+
+    cl_queue_properties QPropsForProfiling[] = {CL_QUEUE_PROPERTIES,
+                                                CL_QUEUE_PROFILING_ENABLE, 0};
+
+    cl_int Status;
+    ClRegularQueue_ = cl::CommandQueue(
+        clCreateCommandQueueWithProperties(ClContext.get(), ClDevice.get(),
+                                           nullptr, &Status),
+        false);
+    CHIPERR_CHECK_LOG_AND_THROW(Status, CL_SUCCESS,
+                                hipErrorInitializationError);
+    ClProfilingQueue_ = cl::CommandQueue(
+        clCreateCommandQueueWithProperties(ClContext.get(), ClDevice.get(),
+                                           QPropsForProfiling, &Status),
+        false);
+    CHIPERR_CHECK_LOG_AND_THROW(Status, CL_SUCCESS,
+                                hipErrorInitializationError);
+
+    QueueMode_ = Regular;
   }
 }
 
 CHIPQueueOpenCL::~CHIPQueueOpenCL() {
   logTrace("~CHIPQueueOpenCL() {}", (void *)this);
-  delete ClQueue_;
 }
 
 std::shared_ptr<chipstar::Event>
@@ -1356,7 +1393,7 @@ CHIPQueueOpenCL::memCopyAsyncImpl(void *Dst, const void *Src, size_t Size) {
     // a maker here, so we can return an event.
     cl::Event MarkerEvent;
     auto Status = clEnqueueMarker(
-        ClQueue_->get(),
+        get()->get(),
         std::static_pointer_cast<CHIPEventOpenCL>(Event)->getNativePtr());
     CHIPERR_CHECK_LOG_AND_THROW(Status, CL_SUCCESS, hipErrorTbd);
   } else {
@@ -1365,8 +1402,8 @@ CHIPQueueOpenCL::memCopyAsyncImpl(void *Dst, const void *Src, size_t Size) {
 #endif
     auto [SyncQueuesEventHandles, EventLocks] = addDependenciesQueueSync(Event);
     auto Status = ::clEnqueueSVMMemcpy(
-        ClQueue_->get(), CL_FALSE, Dst, Src, Size,
-        SyncQueuesEventHandles.size(), SyncQueuesEventHandles.data(),
+        get()->get(), CL_FALSE, Dst, Src, Size, SyncQueuesEventHandles.size(),
+        SyncQueuesEventHandles.data(),
         std::static_pointer_cast<CHIPEventOpenCL>(Event)->getNativePtr());
     CHIPERR_CHECK_LOG_AND_THROW(Status, CL_SUCCESS, hipErrorRuntimeMemory);
   }
@@ -1378,7 +1415,7 @@ void CHIPQueueOpenCL::finish() {
 #ifdef CHIP_DUBIOUS_LOCKS
   LOCK(Backend->DubiousLockOpenCL)
 #endif
-  auto Status = ClQueue_->finish();
+  auto Status = get()->finish();
   CHIPERR_CHECK_LOG_AND_ABORT(Status, CL_SUCCESS, hipErrorTbd);
 }
 
@@ -1391,7 +1428,7 @@ CHIPQueueOpenCL::memFillAsyncImpl(void *Dst, size_t Size, const void *Pattern,
   logTrace("clSVMmemfill {} / {} B\n", Dst, Size);
   auto [SyncQueuesEventHandles, EventLocks] = addDependenciesQueueSync(Event);
   int Retval = ::clEnqueueSVMMemFill(
-      ClQueue_->get(), Dst, Pattern, PatternSize, Size,
+      get()->get(), Dst, Pattern, PatternSize, Size,
       SyncQueuesEventHandles.size(), SyncQueuesEventHandles.data(),
       std::static_pointer_cast<CHIPEventOpenCL>(Event)->getNativePtr());
   CHIPERR_CHECK_LOG_AND_THROW(Retval, CL_SUCCESS, hipErrorRuntimeMemory);
@@ -1433,8 +1470,12 @@ hipError_t CHIPQueueOpenCL::getBackendHandles(uintptr_t *NativeInfo,
     return hipSuccess;
   }
 
+  // Interop API expects one queue handle. Switch to the profiling queue which
+  // works for the interop user and for us in case we need profiling later.
+  switchModeTo(Profiling);
+
   // Get queue handler
-  NativeInfo[4] = (uintptr_t)ClQueue_->get();
+  NativeInfo[4] = (uintptr_t)get()->get();
 
   // Get context handler
   cl::Context *Ctx = ((CHIPContextOpenCL *)ChipContext_)->get();
@@ -1481,7 +1522,7 @@ std::shared_ptr<chipstar::Event> CHIPQueueOpenCL::enqueueBarrierImpl(
       SyncQueuesEventHandles.push_back(Event);
     }
     auto Status = clEnqueueBarrierWithWaitList(
-        ClQueue_->get(), SyncQueuesEventHandles.size(),
+        get()->get(), SyncQueuesEventHandles.size(),
         SyncQueuesEventHandles.data(),
         &(std::static_pointer_cast<CHIPEventOpenCL>(Event)->getNativeRef()));
     CHIPERR_CHECK_LOG_AND_THROW(Status, CL_SUCCESS, hipErrorTbd);
@@ -1489,7 +1530,7 @@ std::shared_ptr<chipstar::Event> CHIPQueueOpenCL::enqueueBarrierImpl(
     // auto Status = ClQueue_->enqueueBarrierWithWaitList(nullptr, &Barrier);
     auto [SyncQueuesEventHandles, EventLocks] = addDependenciesQueueSync(Event);
     auto Status = clEnqueueBarrierWithWaitList(
-        ClQueue_->get(), SyncQueuesEventHandles.size(),
+        get()->get(), SyncQueuesEventHandles.size(),
         SyncQueuesEventHandles.data(),
         std::static_pointer_cast<CHIPEventOpenCL>(Event)->getNativePtr());
     CHIPERR_CHECK_LOG_AND_THROW(Status, CL_SUCCESS, hipErrorTbd);
@@ -1500,6 +1541,41 @@ std::shared_ptr<chipstar::Event> CHIPQueueOpenCL::enqueueBarrierImpl(
       CL_EVENT_REFERENCE_COUNT, 4, &RefCount, NULL);
   updateLastEvent(Event);
   return Event;
+}
+
+void CHIPQueueOpenCL::switchModeTo(QueueMode ToMode) {
+  if (QueueMode_ == ToMode)
+    return;
+
+  // Can't switch mode if the queue is used for interop. Otherwise, we
+  // may cause situations where commands enqueued via HIP and other
+  // API end up be executed out of order.
+  if (UsedInInterOp)
+    CHIPERR_LOG_AND_THROW("Can't switch mode for a queue used of interop.",
+                          hipErrorTbd);
+
+  logDebug("Queue {}: switching mode to {}", (void *)this,
+           ToMode == Profiling ? "profiling" : "regular");
+
+  // Make sure commands are executed in-order across the current and
+  // switched-to queue.
+  auto &FromQ = *get();
+  auto &ToQ = ToMode == Profiling ? ClProfilingQueue_ : ClRegularQueue_;
+  assert(FromQ.get());
+  assert(ToQ.get());
+
+  cl_event SwitchEv;
+  cl_int Status;
+  Status = clEnqueueMarkerWithWaitList(FromQ.get(), 0, nullptr, &SwitchEv);
+  CHIPERR_CHECK_LOG_AND_THROW(Status, CL_SUCCESS, hipErrorTbd);
+
+  Status = clEnqueueBarrierWithWaitList(ToQ.get(), 1, &SwitchEv, nullptr);
+  CHIPERR_CHECK_LOG_AND_THROW(Status, CL_SUCCESS, hipErrorTbd);
+
+  auto *ChipEv = new CHIPEventOpenCL(
+      static_cast<CHIPContextOpenCL *>(ChipContext_), SwitchEv);
+  updateLastEvent(std::shared_ptr<chipstar::Event>(ChipEv));
+  QueueMode_ = ToMode;
 }
 
 // CHIPExecItemOpenCL


### PR DESCRIPTION
Enabling queue profiling by default slow down kernel enqueue API calls according to vtune, at least, on Intel OpenCL targeting Intel ARC A750. Disabling the profiling improved some HeCBench cases on the device:

* overlay-hip: ~1.80x speed up.

* floydwarshall-hip: ~1.47x speed up.

* tqs-hip: ~1.13x speed up.

This patch creates queues with and without profiling and the non-profiling one is used at start. The BE switches to use the profiling queue when needed. Note, there is only transition from non-profiling queue to profiling one but not back.

Also, add environment variable for forcing queue profiling to be disabled.
