### PR TITLE
OpenCL: Support devices with cl_ext_buffer_device_address

### DIFF
--- a/docs/Using.md
+++ b/docs/Using.md
@@ -54,6 +54,30 @@ compiled just before kernel launches.
 A debug option for forcing queue profiling to be disabled in the
 OpenCL backend. The default setting is `0`.
 
+#### CHIP\_OCL\_USE\_ALLOC\_STRATEGY
+
+Defines the allocation strategy the OpenCL backend uses for managing
+HIP allocations. The valid case-insensitive choices and their meaning
+are:
+
+* `intelusm` or `usm`: The backend uses Intel Unified Shared Memory
+  (USM) extension for HIP allocations. The OpenCL devices must support
+  `cl_intel_unified_shared_memory` extension to use this strategy.
+
+* `svm`: The backend uses shared virtual memory (SVM). The OpenCL
+  devices must support at least coarse grain SVM to use this strategy.
+
+* `bufferdevaddr`: The backend uses `cl_mem` buffers and experimental
+  `cl_ext_buffer_devive_address` extension. Note: unified virtual
+  addressing is not available when using this strategy. Consequently,
+  `hipMemcpyDefault` flag is not supported and `hipMallocHost()`
+  allocations are not implicitly mapped and portable. The OpenCL
+  devices must support the `cl_ext_buffer_devive_address`
+  extension to use this strategy.
+
+If this variable is not set, the backend chooses the first available
+strategy in this order: `usm`, `svm`, `bufferdevaddr`.
+
 ### Disabling GPU hangcheck
 
 Note that long-running GPU compute kernels can trigger hang detection mechanism in the GPU driver, which will cause the kernel execution to be terminated and the runtime will report an error. Consult the documentation of your GPU driver on how to disable this hangcheck.

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -232,26 +232,6 @@ void chipstar::Event::releaseDependencies() {
 
 // CHIPModuleflags_
 //*************************************************************************************
-void chipstar::Module::consumeSPIRV() {
-  FuncIL_ = (uint8_t *)Src_->getBinary().data();
-  IlSize_ = Src_->getBinary().size();
-
-  // dump the SPIR-V source into current directory if CHIP_DUMP_SPIRV is set
-  // dump here prior to parsing in case parsing crashes
-  if (ChipEnvVars.getDumpSpirv())
-    dumpSpirv(Src_->getBinary());
-
-  // Parse the SPIR-V fat binary to retrieve kernel function
-  size_t NumWords = IlSize_ / 4;
-  BinaryData_ = new uint32_t[NumWords + 1];
-  std::memcpy(BinaryData_, FuncIL_, IlSize_);
-  // Extract kernel function information
-  bool Res = parseSPIR(BinaryData_, NumWords, ModuleInfo_);
-  delete[] BinaryData_;
-  if (!Res) {
-    CHIPERR_LOG_AND_THROW("SPIR-V parsing failed", hipErrorUnknown);
-  }
-}
 
 chipstar::Module::~Module() {
   for (auto *K : ChipKernels_)
@@ -435,7 +415,7 @@ void chipstar::Module::deallocateDeviceVariablesNoLock(
 }
 
 SPVFuncInfo *chipstar::Module::findFunctionInfo(const std::string &FName) {
-  auto &FuncInfos = ModuleInfo_.FuncInfoMap;
+  auto &FuncInfos = getInfo().FuncInfoMap;
   return FuncInfos.count(FName) ? FuncInfos.at(FName).get() : nullptr;
 }
 

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -908,11 +908,7 @@ class Module : public ihipModule_t {
   /// this module is attached to.
   bool DeviceVariablesInitialized_ = false;
 
-  SPVModuleInfo ModuleInfo_;
-
 protected:
-  uint8_t *FuncIL_;
-  size_t IlSize_;
   std::mutex Mtx_;
   // Global variables
   std::vector<chipstar::DeviceVar *> ChipVars_;
@@ -922,8 +918,6 @@ protected:
   const SPVModule *Src_;
   // Kernel JIT compilation can be lazy
   std::once_flag Compiled_;
-
-  uint32_t *BinaryData_;
 
   /**
    * @brief hidden default constuctor. Only derived type constructor should be
@@ -1026,12 +1020,6 @@ public:
   chipstar::Kernel *getKernel(const void *HostFPtr);
 
   /**
-   * @brief consume SPIRV and fill in SPVFuncINFO
-   *
-   */
-  void consumeSPIRV();
-
-  /**
    * @brief Record a device variable
    *
    * Takes ownership of the variable.
@@ -1051,7 +1039,7 @@ public:
 
   SPVFuncInfo *findFunctionInfo(const std::string &FName);
 
-  const SPVModuleInfo &getInfo() const noexcept { return ModuleInfo_; }
+  const SPVModuleInfo &getInfo() const noexcept { return Src_->getInfo(); }
 
   const SPVModule &getSourceModule() const { return *Src_; }
 };

--- a/src/CHIPDriver.hh
+++ b/src/CHIPDriver.hh
@@ -234,6 +234,7 @@ private:
   unsigned long L0EventTimeout_ = 0;
   int L0CollectEventsTimeout_ = 0;
   bool OCLDisableQueueProfiling_ = false;
+  std::optional<std::string> OclUseAllocStrategy_;
 
 public:
   EnvVars() {
@@ -257,6 +258,9 @@ public:
     return L0EventTimeout_ * 1e9;
   }
   bool getOCLDisableQueueProfiling() const { return OCLDisableQueueProfiling_; }
+  const std::optional<std::string> &getOclUseAllocStrategy() const noexcept {
+    return OclUseAllocStrategy_;
+  }
 
 private:
   void parseEnvironmentVariables() {
@@ -293,6 +297,10 @@ private:
       OCLDisableQueueProfiling_ = parseBoolean(DisableQProfilingEnv);
       logDebug("{}={}", DisableQProfilingEnv, OCLDisableQueueProfiling_);
     }
+
+    constexpr char OclUseAllocStrategyEnv[] = "CHIP_OCL_USE_ALLOC_STRATEGY";
+    if (auto Str = readEnvVar(OclUseAllocStrategyEnv, true); !Str.empty())
+      OclUseAllocStrategy_ = Str;
   }
 
   std::string_view parseJitFlags(const std::string &StrIn) {

--- a/src/SPVRegister.hh
+++ b/src/SPVRegister.hh
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #define SRC_SPVREGISTER_HH
 
 #include "Utils.hh"
+#include "common.hh"
 
 #include <string_view>
 #include <memory>
@@ -74,7 +75,9 @@ class SPVModule {
 
   /// Post-processed, finalized source. It's empty if the
   /// post-processing step has not been performed (yet).
-  std::string FinalizedBinary_;
+  std::vector<uint32_t> FinalizedBinary_;
+
+  SPVModuleInfo ModuleInfo_;
 
 public:
   // Using lists for iterator stability.
@@ -85,7 +88,14 @@ public:
 
   std::string_view getBinary() const {
     assert(FinalizedBinary_.size() && "Has not finalized yet!");
-    return FinalizedBinary_;
+    return std::string_view(
+        reinterpret_cast<const char *>(FinalizedBinary_.data()),
+        FinalizedBinary_.size() * sizeof(uint32_t));
+  }
+
+  const SPVModuleInfo &getInfo() const {
+    assert(FinalizedBinary_.size() && "Has not finalized yet!");
+    return ModuleInfo_;
   }
 };
 

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -68,19 +68,21 @@ std::string generateShortHash(std::string_view input, size_t length) {
 }
 
 /// Dump the SPIR-V to a file
-void dumpSpirv(std::string_view Spirv) {
-  std::string hashSum = generateShortHash(Spirv, 6);
-  std::string fileName = "hip-spirv-" + hashSum + ".spv";
-  std::ofstream SpirvFile(fileName, std::ios::binary);
-
+///
+/// On success return the path to the file.
+std::optional<fs::path> dumpSpirv(std::string_view Spirv) {
+  std::string HashSum = generateShortHash(Spirv, 6);
+  std::string FileName = "hip-spirv-" + HashSum + ".spv";
+  std::ofstream SpirvFile(FileName, std::ios::binary);
   if (!SpirvFile) {
-    std::cerr << "Error: Could not open file " << fileName << " for writing"
+    std::cerr << "Error: Could not open file " << FileName << " for writing"
               << std::endl;
-    return;
+    return std::nullopt;
   }
 
   SpirvFile.write(Spirv.data(), Spirv.size());
   SpirvFile.close();
+  return FileName;
 }
 
 /// Returns true if the hipcc can be executed by the user.

--- a/src/Utils.hh
+++ b/src/Utils.hh
@@ -35,7 +35,15 @@
 bool isConvertibleToInt(const std::string &str);
 
 std::string readEnvVar(std::string EnvVar, bool Lower = true);
-void dumpSpirv(std::string_view Spirv);
+
+std::optional<fs::path> dumpSpirv(std::string_view Spirv);
+
+inline std::optional<fs::path> dumpSpirv(const std::vector<uint32_t> &Spirv,
+                                         std::string_view Path = "") {
+  auto Str = std::string_view(reinterpret_cast<const char *>(Spirv.data()),
+                              Spirv.size() * sizeof(uint32_t));
+  return dumpSpirv(Str);
+}
 
 /// Reinterpret the pointed region, starting from BaseAddr +
 /// ByteOffset, as a value of the given type.

--- a/src/Utils.hh
+++ b/src/Utils.hh
@@ -123,20 +123,22 @@ public:
 
 // A less comparator for comparing mixed raw and smart pointers.
 //
-// From https://stackoverflow.com/questions/18939882. Formatted for
-// chipStar.
+// Originally from https://stackoverflow.com/questions/18939882. Improved and
+// formatted for chipStar.
 template <class T> struct PointerCmp {
   typedef std::true_type is_transparent;
   struct Helper {
-    T *Ptr;
+    const T *Ptr;
     Helper() : Ptr(nullptr) {}
     Helper(Helper const &) = default;
-    Helper(T *p) : Ptr(p) {}
+    Helper(const T *p) : Ptr(p) {}
     template <class U> Helper(std::shared_ptr<U> const &Sp) : Ptr(Sp.get()) {}
     template <class U, class... Ts>
     Helper(std::unique_ptr<U, Ts...> const &Up) : Ptr(Up.get()) {}
     // && optional: enforces rvalue use only
-    bool operator<(Helper o) const { return std::less<T *>()(Ptr, o.Ptr); }
+    bool operator<(Helper o) const {
+      return std::less<const T *>()(Ptr, o.Ptr);
+    }
   };
 
   bool operator()(Helper const &&lhs, Helper const &&rhs) const {

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1234,14 +1234,17 @@ CHIPQueueLevel0::memFillAsyncImpl(void *Dst, size_t Size, const void *Pattern,
 
 std::shared_ptr<chipstar::Event>
 CHIPQueueLevel0::memCopy2DAsyncImpl(void *Dst, size_t Dpitch, const void *Src,
-                                    size_t Spitch, size_t Width,
-                                    size_t Height) {
-  return memCopy3DAsyncImpl(Dst, Dpitch, 0, Src, Spitch, 0, Width, Height, 0);
+                                    size_t Spitch, size_t Width, size_t Height,
+                                    hipMemcpyKind Kind) {
+  return memCopy3DAsyncImpl(Dst, Dpitch, 0, Src, Spitch, 0, Width, Height, 0,
+                            Kind);
 };
 
-std::shared_ptr<chipstar::Event> CHIPQueueLevel0::memCopy3DAsyncImpl(
-    void *Dst, size_t Dpitch, size_t Dspitch, const void *Src, size_t Spitch,
-    size_t Sspitch, size_t Width, size_t Height, size_t Depth) {
+std::shared_ptr<chipstar::Event>
+CHIPQueueLevel0::memCopy3DAsyncImpl(void *Dst, size_t Dpitch, size_t Dspitch,
+                                    const void *Src, size_t Spitch,
+                                    size_t Sspitch, size_t Width, size_t Height,
+                                    size_t Depth, hipMemcpyKind Kind) {
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
   std::shared_ptr<chipstar::Event> MemCopyRegionEvent =
       static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(ChipCtxZe);
@@ -1438,7 +1441,8 @@ std::shared_ptr<chipstar::Event> CHIPQueueLevel0::enqueueBarrierImpl(
 }
 
 std::shared_ptr<chipstar::Event>
-CHIPQueueLevel0::memCopyAsyncImpl(void *Dst, const void *Src, size_t Size) {
+CHIPQueueLevel0::memCopyAsyncImpl(void *Dst, const void *Src, size_t Size,
+                                  hipMemcpyKind Kind) {
   logTrace("CHIPQueueLevel0::memCopyAsync");
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
   std::shared_ptr<chipstar::Event> MemCopyEvent =
@@ -2131,6 +2135,8 @@ void CHIPDeviceLevel0::populateDevicePropertiesImpl() {
   static_assert(sizeof(ArchName) <= sizeof(HipDeviceProps_.gcnArchName),
                 "Buffer overflow!");
   std::strncpy(HipDeviceProps_.gcnArchName, ArchName, sizeof(ArchName));
+
+  HipDeviceProps_.unifiedAddressing = true;
 }
 
 chipstar::Queue *CHIPDeviceLevel0::createQueue(chipstar::QueueFlags Flags,
@@ -2584,7 +2590,7 @@ void CHIPExecItemLevel0::setupAllArgs() {
   if (FuncInfo->hasByRefArgs())
     ChipQueue_->memCopyAsync(ArgSpillBuffer_->getDeviceBuffer(),
                              ArgSpillBuffer_->getHostBuffer(),
-                             ArgSpillBuffer_->getSize());
+                             ArgSpillBuffer_->getSize(), hipMemcpyHostToDevice);
 
   return;
 }

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -2419,7 +2419,6 @@ static void appendDeviceLibrarySources(
 
 void CHIPModuleLevel0::compile(chipstar::Device *ChipDev) {
   logTrace("CHIPModuleLevel0.compile()");
-  consumeSPIRV();
 
   auto *LzBackend = static_cast<CHIPBackendLevel0 *>(Backend);
   if (!LzBackend->hasExperimentalModuleProgramExt())
@@ -2428,8 +2427,11 @@ void CHIPModuleLevel0::compile(chipstar::Device *ChipDev) {
                           hipErrorTbd);
 
   auto *LzDev = static_cast<CHIPDeviceLevel0 *>(ChipDev);
-  std::vector<size_t> ILSizes(1, IlSize_);
-  std::vector<const uint8_t *> ILInputs(1, FuncIL_);
+
+  std::string_view SPIRVBin = Src_->getBinary();
+  std::vector<size_t> ILSizes(1, SPIRVBin.size());
+  std::vector<const uint8_t *> ILInputs(
+      1, reinterpret_cast<const uint8_t *>(SPIRVBin.data()));
   std::vector<const char *> BuildFlags(1, ChipEnvVars.getJitFlags().c_str());
 
   appendDeviceLibrarySources(ILSizes, ILInputs, BuildFlags,

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -320,7 +320,8 @@ public:
   virtual void finish() override;
 
   virtual std::shared_ptr<chipstar::Event>
-  memCopyAsyncImpl(void *Dst, const void *Src, size_t Size) override;
+  memCopyAsyncImpl(void *Dst, const void *Src, size_t Size,
+                   hipMemcpyKind Kind) override;
 
   /*
    * @brief Execute a given FencedCmdList, move it to the backend tracker, and
@@ -351,12 +352,12 @@ public:
 
   virtual std::shared_ptr<chipstar::Event>
   memCopy2DAsyncImpl(void *Dst, size_t Dpitch, const void *Src, size_t Spitch,
-                     size_t Width, size_t Height) override;
+                     size_t Width, size_t Height, hipMemcpyKind Kind) override;
 
   virtual std::shared_ptr<chipstar::Event>
   memCopy3DAsyncImpl(void *Dst, size_t Dpitch, size_t Dspitch, const void *Src,
                      size_t Spitch, size_t Sspitch, size_t Width, size_t Height,
-                     size_t Depth) override;
+                     size_t Depth, hipMemcpyKind Kind) override;
 
   virtual std::shared_ptr<chipstar::Event>
   memCopyToImage(ze_image_handle_t TexStorage, const void *Src,

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -865,10 +865,7 @@ static void appendRuntimeObjects(cl::Context Ctx, CHIPDeviceOpenCL &ChipDev,
 }
 
 void CHIPModuleOpenCL::compile(chipstar::Device *ChipDev) {
-
-  // TODO make compile_ which calls consumeSPIRV()
   logTrace("CHIPModuleOpenCL::compile()");
-  consumeSPIRV();
   CHIPDeviceOpenCL *ChipDevOcl = (CHIPDeviceOpenCL *)ChipDev;
   CHIPContextOpenCL *ChipCtxOcl =
       (CHIPContextOpenCL *)(ChipDevOcl->getContext());

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -53,6 +53,28 @@
 
 #define OCL_DEFAULT_QUEUE_PRIORITY CL_QUEUE_PRIORITY_MED_KHR
 
+// Temporary definitions (copied from <POCL>/include/CL/cl_ext_pocl.h)
+// until the extension is made official.
+#ifndef cl_ext_buffer_device_address
+#define cl_ext_buffer_device_address
+
+#ifndef CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT
+#define CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT 0x11B8
+#endif
+
+#ifndef CL_MEM_DEVICE_ADDRESS_EXT
+#define CL_MEM_DEVICE_ADDRESS_EXT (1ul << 31)
+#endif
+
+#ifndef CL_MEM_DEVICE_PTR_EXT
+#define CL_MEM_DEVICE_PTR_EXT 0xff01
+#endif
+
+typedef cl_int(CL_API_CALL *clSetKernelArgDevicePointerEXT_fn)(
+    cl_kernel kernel, cl_uint arg_index, const void *arg_value);
+
+#endif // cl_ext_buffer_device_address
+
 std::string resultToString(int Status);
 
 class CHIPContextOpenCL;
@@ -130,17 +152,35 @@ struct CHIPContextUSMExts {
 using const_alloc_iterator = ConstMapKeyIterator<
     std::map<std::shared_ptr<void>, size_t, PointerCmp<void>>>;
 
-class MemoryManager {
-  // ContextMutex should be enough
+/// Used to select a strategy for managing HIP allocations.
+enum class AllocationStrategy {
+  Unset = 0,
+  CoarseGrainSVM,
+  FineGrainSVM,
+  IntelUSM,
+  /// Use regular cl_mem buffers and an experimental
+  /// cl_ext_buffer_device_address extension to obtain their fixed
+  /// device addresses.
+  BufferDevAddr
+};
 
+class MemoryManager {
+private:
+  // ContextMutex should be enough
   std::map<std::shared_ptr<void>, size_t, PointerCmp<void>> Allocations_;
   cl::Context Context_;
   cl::Device Device_;
 
   CHIPContextOpenCL *ChipCtxCl;
-  CHIPContextUSMExts USM;
-  bool UseSVMFineGrain;
-  bool UseIntelUSM;
+
+  /// Valid and used when AllocStrategy_ == IntelUSM.
+  CHIPContextUSMExts USM_;
+
+  /// Used when AllocStrategy_ == BufferDevAddr.
+  std::map<const void *, cl_mem> DevPtrToBuffer_;
+
+  /// The allocation strategy to use.
+  AllocationStrategy AllocStrategy_;
 
 public:
   void init(CHIPContextOpenCL *ChipCtxCl);
@@ -162,19 +202,30 @@ public:
         const_alloc_iterator(Allocations_.end()));
   }
 
-  bool usesUSM() const noexcept { return UseIntelUSM; }
-  bool usesSVM() const noexcept { return !usesUSM(); }
+  AllocationStrategy getAllocStrategy() const noexcept {
+    return AllocStrategy_;
+  }
+
+  std::pair<cl_mem, size_t> translateDevPtrToBuffer(const void *DevPtr) const;
+
+private:
+  std::shared_ptr<void> allocateSVM(size_t Size, size_t Alignment,
+                                    hipMemoryType MemType, bool FineGrain);
+  std::shared_ptr<void> allocateUSM(size_t Size, size_t Alignment,
+                                    hipMemoryType MemType);
+  std::shared_ptr<void> allocateBufferDevAddr(size_t Size, size_t Alignment,
+                                              hipMemoryType MemType);
 };
 
 class CHIPContextOpenCL : public chipstar::Context {
 private:
+  cl::Platform Platform_;
   cl::Context ClContext;
+  mutable clSetKernelArgDevicePointerEXT_fn clSetKernelArgDevicePointerEXT_ =
+      nullptr;
 
 public:
-  CHIPContextUSMExts USM;
   MemoryManager MemManager_;
-  bool SupportsIntelUSM;
-  bool SupportsFineGrainSVM;
   bool allDevicesSupportFineGrainSVMorUSM();
   CHIPContextOpenCL(cl::Context CtxIn, cl::Device Dev, cl::Platform Plat);
   virtual ~CHIPContextOpenCL() {
@@ -195,8 +246,28 @@ public:
     return MemManager_.getAllocPointers();
   }
 
-  bool usesUSM() const noexcept { return MemManager_.usesUSM(); }
-  bool usesSVM() const noexcept { return MemManager_.usesSVM(); }
+  AllocationStrategy getAllocStrategy() const noexcept {
+    return MemManager_.getAllocStrategy();
+  }
+
+  cl_int clSetKernelArgDevicePointerEXT(cl_kernel Kernel, cl_uint ArgIdx,
+                                        const void *DevPtr) const {
+    assert(getAllocStrategy() == AllocationStrategy::BufferDevAddr);
+    if (!clSetKernelArgDevicePointerEXT_) {
+      clSetKernelArgDevicePointerEXT_ =
+          reinterpret_cast<clSetKernelArgDevicePointerEXT_fn>(
+              clGetExtensionFunctionAddressForPlatform(
+                  Platform_(), "clSetKernelArgDevicePointerEXT"));
+    }
+    assert(clSetKernelArgDevicePointerEXT_);
+    return clSetKernelArgDevicePointerEXT_(Kernel, ArgIdx, DevPtr);
+  }
+
+  std::pair<cl_mem, size_t> translateDevPtrToBuffer(const void *DevPtr) const {
+    return MemManager_.translateDevPtrToBuffer(DevPtr);
+  }
+
+  const cl::Platform &getPlatform() const { return Platform_; }
 };
 
 class CHIPDeviceOpenCL : public chipstar::Device {
@@ -254,6 +325,10 @@ public:
 
   bool hasBallot() const noexcept { return HasSubgroupBallot_; }
   bool hasDoubles() const { return HipDeviceProps_.arch.hasDoubles; }
+
+  CHIPContextOpenCL *getContext() override {
+    return static_cast<CHIPContextOpenCL *>(this->Device::getContext());
+  }
 };
 
 template <typename T>
@@ -326,18 +401,19 @@ public:
                            void *UserData) override;
   virtual void finish() override;
   virtual std::shared_ptr<chipstar::Event>
-  memCopyAsyncImpl(void *Dst, const void *Src, size_t Size) override;
+  memCopyAsyncImpl(void *Dst, const void *Src, size_t Size,
+                   hipMemcpyKind Kind) override;
   cl::CommandQueue *get();
   virtual std::shared_ptr<chipstar::Event>
   memFillAsyncImpl(void *Dst, size_t Size, const void *Pattern,
                    size_t PatternSize) override;
   virtual std::shared_ptr<chipstar::Event>
   memCopy2DAsyncImpl(void *Dst, size_t Dpitch, const void *Src, size_t Spitch,
-                     size_t Width, size_t Height) override;
+                     size_t Width, size_t Height, hipMemcpyKind Kind) override;
   virtual std::shared_ptr<chipstar::Event>
   memCopy3DAsyncImpl(void *Dst, size_t Dpitch, size_t Dspitch, const void *Src,
                      size_t Spitch, size_t Sspitch, size_t Width, size_t Height,
-                     size_t Depth) override;
+                     size_t Depth, hipMemcpyKind Kind) override;
 
   virtual hipError_t getBackendHandles(uintptr_t *NativeInfo,
                                        int *NumHandles) override;
@@ -364,6 +440,10 @@ public:
     return CallbackEv.setCallback(CL_COMPLETE, deleteArrayCallback<T>,
                                   reinterpret_cast<void *>(HostPtr));
   }
+
+  CHIPContextOpenCL *getContext() override {
+    return static_cast<CHIPContextOpenCL *>(ChipContext_);
+  };
 
 private:
   void switchModeTo(QueueMode Mode);
@@ -404,6 +484,11 @@ public:
   CHIPModuleOpenCL *getModule() override { return Module; }
   const CHIPModuleOpenCL *getModule() const override { return Module; }
   virtual hipError_t getAttributes(hipFuncAttributes *Attr) override;
+
+  CHIPContextOpenCL *getContext() {
+    assert(Device);
+    return Device->getContext();
+  }
 
 private:
   // Only allowed for CHIPExecItemOpenCL instances.

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -70,8 +70,10 @@
 #define CL_MEM_DEVICE_PTR_EXT 0xff01
 #endif
 
+typedef cl_ulong cl_mem_device_address_EXT;
+
 typedef cl_int(CL_API_CALL *clSetKernelArgDevicePointerEXT_fn)(
-    cl_kernel kernel, cl_uint arg_index, const void *arg_value);
+    cl_kernel kernel, cl_uint arg_index, cl_mem_device_address_EXT dev_addr);
 
 #endif // cl_ext_buffer_device_address
 
@@ -260,7 +262,11 @@ public:
                   Platform_(), "clSetKernelArgDevicePointerEXT"));
     }
     assert(clSetKernelArgDevicePointerEXT_);
-    return clSetKernelArgDevicePointerEXT_(Kernel, ArgIdx, DevPtr);
+    static_assert(
+        sizeof(cl_mem_device_address_EXT) == sizeof(void *),
+        "sizeof(cl_mem_device_address_EXT) does not match host pointer size!");
+    auto IntPtr = reinterpret_cast<cl_mem_device_address_EXT>(DevPtr);
+    return clSetKernelArgDevicePointerEXT_(Kernel, ArgIdx, IntPtr);
   }
 
   std::pair<cl_mem, size_t> translateDevPtrToBuffer(const void *DevPtr) const {

--- a/src/backend/OpenCL/MemoryManager.cc
+++ b/src/backend/OpenCL/MemoryManager.cc
@@ -25,93 +25,233 @@
 #define SVM_ALIGNMENT 128
 
 void MemoryManager::init(CHIPContextOpenCL *ChipCtxCl_) {
-
   ChipCtxCl = ChipCtxCl_;
   CHIPDeviceOpenCL *ChipDevCl = (CHIPDeviceOpenCL *)ChipCtxCl->getDevice();
   Device_ = *ChipDevCl->get();
   Context_ = *ChipCtxCl_->get();
 
-  std::memset(&USM, 0, sizeof(USM));
+  // Initialize set of allowed allocation strategies.
+  using AS = AllocationStrategy;
+  std::set<AS> AllowedAllocStrats;
+  if (auto ChoiceStrOpt = ChipEnvVars.getOclUseAllocStrategy()) {
+    // Note: the environment variable is lower-cased by ChipEnvVars instance.
+    const auto &ChoiceStr = *ChoiceStrOpt;
 
-  cl_device_svm_capabilities DeviceSVMCapabilities;
-  int Err = Device_.getInfo(CL_DEVICE_SVM_CAPABILITIES, &DeviceSVMCapabilities);
-  CHIPERR_CHECK_LOG_AND_THROW(Err, CL_SUCCESS, hipErrorTbd);
-  ChipCtxCl->SupportsFineGrainSVM =
-      DeviceSVMCapabilities & CL_DEVICE_SVM_FINE_GRAIN_BUFFER;
-  if (ChipCtxCl->SupportsFineGrainSVM) {
-    logTrace("Device supports fine grain SVM");
+#ifdef CHIP_USE_INTEL_USM
+    if (ChoiceStr == "intelusm" || ChoiceStr == "usm")
+      AllowedAllocStrats = {AS::IntelUSM};
+    else
+#endif
+        if (ChoiceStr == "svm")
+      AllowedAllocStrats = {AS::FineGrainSVM, AS::CoarseGrainSVM};
+    else if (ChoiceStr == "bufferdevaddr")
+      AllowedAllocStrats = {AS::BufferDevAddr};
+    else
+      CHIPERR_LOG_AND_THROW("Unrecognized allocation strategy.",
+                            hipErrorInitializationError);
   } else {
-    logTrace("Device does not support fine grain SVM");
+    // Default set.
+    AllowedAllocStrats = {
+#ifdef CHIP_USE_INTEL_USM
+        AS::IntelUSM,
+#endif
+        AS::FineGrainSVM, AS::CoarseGrainSVM, AS::BufferDevAddr};
   }
 
-  USM = ChipCtxCl->USM;
-  UseSVMFineGrain = ChipCtxCl->SupportsFineGrainSVM;
-  UseIntelUSM = ChipCtxCl->SupportsIntelUSM;
+  std::string DevExts = Device_.getInfo<CL_DEVICE_EXTENSIONS>();
+  cl_device_svm_capabilities SVMCapabilities =
+      Device_.getInfo<CL_DEVICE_SVM_CAPABILITIES>();
+  auto ChosenStrategy = AS::Unset;
+
+  // Select an available strategy in this order.
+  if (AllowedAllocStrats.count(AS::IntelUSM) &&
+      DevExts.find("cl_intel_unified_shared_memory") != std::string::npos) {
+    logDebug("Chosen allocation strategy: Intel USM.");
+    ChosenStrategy = AS::IntelUSM;
+  } else if (AllowedAllocStrats.count(AS::FineGrainSVM) &&
+             (SVMCapabilities & (CL_DEVICE_SVM_FINE_GRAIN_BUFFER |
+                                 CL_DEVICE_SVM_FINE_GRAIN_SYSTEM))) {
+    logDebug("Chosen allocation strategy: fine-grain SVM.");
+    ChosenStrategy = AS::FineGrainSVM;
+  } else if (AllowedAllocStrats.count(AS::CoarseGrainSVM) &&
+             (SVMCapabilities & CL_DEVICE_SVM_COARSE_GRAIN_BUFFER)) {
+    logDebug("Chosen allocation strategy: coarse-grain SVM.");
+    ChosenStrategy = AS::CoarseGrainSVM;
+  } else if (AllowedAllocStrats.count(AS::BufferDevAddr) &&
+             DevExts.find("cl_ext_buffer_device_address") !=
+                 std::string::npos) {
+    logDebug("Chosen allocation strategy: buffer-device-address\n");
+    ChosenStrategy = AS::BufferDevAddr;
+  }
+
+  if (ChosenStrategy == AS::Unset)
+    CHIPERR_LOG_AND_THROW("Insufficient memory capabilities.",
+                          hipErrorInitializationError);
+  AllocStrategy_ = ChosenStrategy;
+
+  const cl::Platform &Plat = ChipCtxCl_->getPlatform();
+  if (AllocStrategy_ == AllocationStrategy::IntelUSM) {
+    USM_.clSharedMemAllocINTEL =
+        (clSharedMemAllocINTEL_fn)::clGetExtensionFunctionAddressForPlatform(
+            Plat(), "clSharedMemAllocINTEL");
+    USM_.clDeviceMemAllocINTEL =
+        (clDeviceMemAllocINTEL_fn)::clGetExtensionFunctionAddressForPlatform(
+            Plat(), "clDeviceMemAllocINTEL");
+    USM_.clHostMemAllocINTEL =
+        (clHostMemAllocINTEL_fn)::clGetExtensionFunctionAddressForPlatform(
+            Plat(), "clHostMemAllocINTEL");
+    USM_.clMemFreeINTEL =
+        (clMemFreeINTEL_fn)::clGetExtensionFunctionAddressForPlatform(
+            Plat(), "clMemFreeINTEL");
+  } else {
+    std::memset(&USM_, 0, sizeof(USM_));
+  }
 }
 
 MemoryManager &MemoryManager::operator=(MemoryManager &&Rhs) {
   Allocations_ = std::move(Rhs.Allocations_);
   Context_ = std::move(Rhs.Context_);
   Device_ = std::move(Rhs.Device_);
-  USM = std::move(Rhs.USM);
-  UseSVMFineGrain = Rhs.UseSVMFineGrain;
-  UseIntelUSM = Rhs.UseIntelUSM;
+  USM_ = std::move(Rhs.USM_);
+  AllocStrategy_ = std::move(Rhs.AllocStrategy_);
   return *this;
+}
+
+std::shared_ptr<void> MemoryManager::allocateSVM(size_t Size, size_t Alignment,
+                                                 hipMemoryType MemType,
+                                                 bool FineGrain) {
+  std::shared_ptr<void> Result;
+  auto MemFlags = CL_MEM_READ_WRITE;
+  MemFlags |= FineGrain ? CL_MEM_SVM_FINE_GRAIN_BUFFER : 0;
+  void *RawPtr = ::clSVMAlloc(Context_(), MemFlags, Size, 0);
+  if (!RawPtr)
+    return Result;
+
+  auto Deleter = [Ctx = this->Context_()](void *PtrToFree) -> void {
+    clSVMFree(Ctx, PtrToFree);
+  };
+
+  Result.reset(RawPtr, Deleter);
+  return Result;
+}
+
+std::shared_ptr<void> MemoryManager::allocateUSM(size_t Size, size_t Alignment,
+                                                 hipMemoryType MemType) {
+  std::shared_ptr<void> Result;
+  cl_int Err;
+  void *RawPtr = nullptr;
+  switch (MemType) {
+  default:
+    assert(!"Unexpected HIP memory type!");
+    return Result;
+  case hipMemoryTypeHost:
+    RawPtr =
+        USM_.clHostMemAllocINTEL(Context_(), nullptr, Size, Alignment, &Err);
+    break;
+  case hipMemoryTypeDevice:
+    RawPtr = USM_.clDeviceMemAllocINTEL(Context_(), Device_(), nullptr, Size,
+                                        Alignment, &Err);
+    break;
+  case hipMemoryTypeManaged:
+  case hipMemoryTypeUnified:
+    RawPtr = USM_.clSharedMemAllocINTEL(Context_(), Device_(), nullptr, Size,
+                                        Alignment, &Err);
+    break;
+  }
+
+  if (!RawPtr || Err != CL_SUCCESS)
+    return Result;
+
+  auto Deleter =
+      [Ctx = this->Context_(), clMemFreeINTEL = this->USM_.clMemFreeINTEL](
+          void *PtrToFree) -> void { clMemFreeINTEL(Ctx, PtrToFree); };
+
+  Result.reset(RawPtr, Deleter);
+  return Result;
+}
+
+std::shared_ptr<void>
+MemoryManager::allocateBufferDevAddr(size_t Size, size_t Alignment,
+                                     hipMemoryType MemType) {
+  std::shared_ptr<void> Result;
+  cl_int Err = CL_SUCCESS;
+  void *RawPtr = nullptr;
+  cl::Buffer Buf;
+
+  switch (MemType) {
+  default:
+    assert(!"Unexpected HIP memory type!");
+    return Result;
+    break;
+
+  case hipMemoryTypeDevice: {
+    const cl_mem_flags MemFlags = CL_MEM_READ_WRITE | CL_MEM_DEVICE_ADDRESS_EXT;
+    Buf = cl::Buffer(Context_, MemFlags, Size, nullptr, &Err);
+    if (Err != CL_SUCCESS)
+      break;
+    Err = Buf.getInfo(CL_MEM_DEVICE_PTR_EXT, &RawPtr);
+    DevPtrToBuffer_.insert(std::make_pair(RawPtr, Buf.get()));
+    break;
+  }
+  case hipMemoryTypeHost:
+  case hipMemoryTypeManaged:
+  case hipMemoryTypeUnified:
+    logWarn("hipMemoryTypeHost/Managed/Unified memory types are not currently "
+            "supported.");
+    return Result;
+  }
+
+  if (!RawPtr || Err != CL_SUCCESS)
+    return Result;
+
+  auto Deleter = [ToBeDestructed = Buf](void *Ignored) -> void {
+    // This lambda keeps the buffer (Buf) alive until the outer object gets
+    // destroyed.
+  };
+  Result.reset(RawPtr, Deleter);
+  return Result;
 }
 
 void *MemoryManager::allocate(size_t Size, size_t Alignment,
                               hipMemoryType MemType) {
-  // 0 passed for the alignment will use the default alignment which is equal to
-  // the largest data type supported.
-  void *Ptr;
-  int Err;
-  if (UseIntelUSM) {
-    switch (MemType) {
-    case hipMemoryTypeHost:
-      Ptr = USM.clHostMemAllocINTEL(Context_(), NULL, Size, Alignment, &Err);
-      break;
-    case hipMemoryTypeDevice:
-      Ptr = USM.clDeviceMemAllocINTEL(Context_(), Device_(), NULL, Size,
-                                      Alignment, &Err);
-      break;
-    case hipMemoryTypeManaged:
-    case hipMemoryTypeUnified:
-    default:
-      Ptr = USM.clSharedMemAllocINTEL(Context_(), Device_(), NULL, Size,
-                                      Alignment, &Err);
-      break;
-    }
-  } else if (UseSVMFineGrain) {
-    Ptr = ::clSVMAlloc(
-        Context_(), CL_MEM_READ_WRITE | CL_MEM_SVM_FINE_GRAIN_BUFFER, Size, 0);
-  } else {
-    Ptr = ::clSVMAlloc(Context_(), CL_MEM_READ_WRITE, Size, 0);
+  std::shared_ptr<void> Ptr;
+
+  switch (AllocStrategy_) {
+  default:
+    assert(!"Unexpected allocation strategy!");
+    return nullptr;
+  case AllocationStrategy::FineGrainSVM:
+  case AllocationStrategy::CoarseGrainSVM: {
+    Ptr = allocateSVM(Size, Alignment, MemType,
+                      AllocStrategy_ == AllocationStrategy::FineGrainSVM);
+    break;
+  }
+  case AllocationStrategy::IntelUSM: {
+    Ptr = allocateUSM(Size, Alignment, MemType);
+    break;
+  }
+  case AllocationStrategy::BufferDevAddr:
+    Ptr = allocateBufferDevAddr(Size, Alignment, MemType);
+    break;
   }
 
-  if (Ptr) {
-    auto Deleter = [Ctx = this->Context_, UseUSM = this->UseIntelUSM,
-                    clMemFreeINTEL =
-                        this->USM.clMemFreeINTEL](void *PtrToFree) -> void {
-      logTrace("clSVMFree on: {}\n", PtrToFree);
-      if (UseUSM)
-        clMemFreeINTEL(Ctx(), PtrToFree);
-      else
-        clSVMFree(Ctx(), PtrToFree);
-    };
-    auto SPtr = std::shared_ptr<void>(Ptr, Deleter);
-    logTrace("Memory allocated: {} / {}\n", Ptr, Size);
-    assert(Allocations_.find(SPtr) == Allocations_.end());
-    Allocations_.emplace(SPtr, Size);
-  } else
-    CHIPERR_LOG_AND_THROW("clSVMAlloc failed", hipErrorMemoryAllocation);
+  if (!Ptr)
+    CHIPERR_LOG_AND_THROW("Memory allocation failed", hipErrorMemoryAllocation);
 
-  return Ptr;
+  logTrace("Memory allocated: {} / {}\n", Ptr.get(), Size);
+  assert(Allocations_.find(Ptr) == Allocations_.end());
+  Allocations_.emplace(Ptr, Size);
+  return Ptr.get();
 }
 
 bool MemoryManager::free(void *Ptr) {
   auto I = Allocations_.find(Ptr);
   if (I != Allocations_.end())
     Allocations_.erase(I);
+
+  if (AllocStrategy_ == AllocationStrategy::BufferDevAddr)
+    DevPtrToBuffer_.erase(Ptr);
+
   return true;
 }
 
@@ -149,4 +289,35 @@ bool MemoryManager::pointerInfo(void *Ptr, void **Base, size_t *Size) {
 void MemoryManager::clear() {
   Backend->getActiveDevice()->getLegacyDefaultQueue()->finish();
   Allocations_.clear();
+}
+
+/// Returns a cl_mem object the 'DevPtr' corresponds to and distance
+/// to its base.
+///
+/// returns {nullptr, 0 } if 'DevPtr' is not pointing to any known
+/// device pinned allocation.
+///
+/// Precondition: getAllocStrategy() == AllocationStrategy::BufferDevAddr;
+std::pair<cl_mem, size_t>
+MemoryManager::translateDevPtrToBuffer(const void *DevPtr) const {
+  assert(getAllocStrategy() == AllocationStrategy::BufferDevAddr);
+
+  // Find entry with largest key so that 'key <= DevPtr'.
+  auto UpperIt = Allocations_.upper_bound(DevPtr);
+  auto CandIt = UpperIt == Allocations_.begin() ? UpperIt : std::prev(UpperIt);
+  if (CandIt == Allocations_.end() || DevPtr < CandIt->first.get())
+    return {nullptr, 0};
+
+  const char *BasePtr = static_cast<const char *>(CandIt->first.get());
+  size_t Offset = 0;
+
+  // Handle offseted pointer, check it is within the bounds of the allocation.
+  if (BasePtr != DevPtr) {
+    const char *CandPtr = static_cast<const char *>(DevPtr);
+    if (CandPtr >= (BasePtr + CandIt->second))
+      return {nullptr, 0};
+    Offset = CandPtr - BasePtr;
+  }
+
+  return {DevPtrToBuffer_.at(BasePtr), Offset};
 }

--- a/src/common.hh
+++ b/src/common.hh
@@ -51,10 +51,12 @@ struct SPVModuleInfo {
   bool HasNoIGBAs = false;
 };
 
-bool filterSPIRV(const char *Bytes, size_t NumBytes,
-                 bool PreventNameDemangling, std::string &Dst);
-
-bool parseSPIR(uint32_t *Stream, size_t NumWords, SPVModuleInfo &ModuleInfo);
+// Processing done before analysis.
+bool preprocessSPIRV(const char *Bytes, size_t NumBytes,
+                     bool PreventNameDemangling, std::vector<uint32_t> &Dst);
+bool analyzeSPIRV(uint32_t *Stream, size_t NumWords, SPVModuleInfo &ModuleInfo);
+// Processing done after analysis.
+bool postprocessSPIRV(std::vector<uint32_t> &Binary);
 
 /// A prefix given to lowered global scope device variables.
 constexpr char ChipVarPrefix[] = "__chip_var_";

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -1,5 +1,10 @@
 TOTAL_TESTS: 1397
 ALL:
+  # Invalid test (if it is the one from HIP/ submodule instead of hip-tests/).
+  # The source allocation 'Ah' is not initialized (this is fixed in hip-tests/)
+  # and input is therefore random. Because of this the test is known to fail
+  # due to NaNs appearing in the input sometimes (NaN == NaN --> false).
+  Unit_hipMultiThreadStreams2: ''
   Print_Out_Attributes: 'old HIP tests + new HIP API'
   TestAssert: ''
   TestAssertFail: ''

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -107,3 +107,4 @@ add_hip_runtime_test(TestNegativeHasNoIGBAs2.hip)
 add_hip_runtime_test(TestPositiveHasNoIGBAs.hip)
 
 add_hip_runtime_test(CatchMemLeak1.hip)
+add_hip_runtime_test(TestBufferDevAddr.hip)

--- a/tests/runtime/TestBufferDevAddr.hip
+++ b/tests/runtime/TestBufferDevAddr.hip
@@ -1,0 +1,102 @@
+// OpenCL-only test. Check CHIP_OCL_USE_ALLOC_STRATEGY=bufferdevaddr
+// and its excepted consequences. Notably unified virtual addressing (UVA)
+// won't not supported.
+
+#include <hip/hip_runtime.h>
+#include "backend/OpenCL/CHIPBackendOpenCL.hh"
+
+#include <unistd.h>
+
+void check(bool Ok, size_t Line) {
+  if (!Ok) {
+    std::cerr << "Error at line " << Line << ".\n";
+    std::quick_exit(1);
+  }
+}
+
+#define CHECK(_Cond) check(_Cond, __LINE__)
+
+void setupTest(int ArgC, char *ArgV[]) {
+  // Run the test if we are running on an OpenCL implementation with
+  // cl_ext_buffer_device_address available and set the allocation
+  // strategy to 'bufferdevaddr'
+
+  auto *OclBE = dynamic_cast<CHIPBackendOpenCL *>(::Backend);
+  if (!OclBE) {
+    printf("Skip: not running on OpenCL.\n");
+    exit(CHIP_SKIP_TEST);
+  }
+
+  auto *OclDev = static_cast<CHIPDeviceOpenCL *>(OclBE->getActiveDevice());
+  std::string DevExts = OclDev->ClDevice->getInfo<CL_DEVICE_EXTENSIONS>();
+  if (DevExts.find("cl_ext_buffer_device_address") == std::string::npos) {
+    printf("Skip: target does not have cl_ext_buffer_device_address.\n");
+    exit(CHIP_SKIP_TEST);
+  }
+
+  auto *Env = std::getenv("CHIP_OCL_USE_ALLOC_STRATEGY");
+  if (!Env || std::string_view(Env) != "bufferdevaddr") {
+    if (ArgC > 1) // Infinite recursion!
+      exit(3);
+
+    printf("Relaunch with CHIP_OCL_USE_ALLOC_STRATEGY=bufferdevaddr.\n");
+
+    // Relaunch test with CHIP_OCL_USE_ALLOC_STRATEGY=bufferdevaddr. Simpler to
+    // do this way than trying to construct new backend the right way. Add an
+    // extra argument to catch accidental inifinite recursion.
+    const char *Args[] = {ArgV[0], "1", nullptr};
+    setenv("CHIP_OCL_USE_ALLOC_STRATEGY", "bufferdevaddr", 1);
+    execve(ArgV[0], const_cast<char *const *>(Args), environ);
+    exit(4); // Something went wrong.
+  }
+
+  printf("Test setup complete.\n");
+}
+
+struct SomeStruct {
+  int A;
+  int *Ptr;
+};
+
+__global__ void k0(int *Dst, SomeStruct Src) { *Dst = *Src.Ptr; }
+
+int main(int ArgC, char *ArgV[]) {
+  setupTest(ArgC, ArgV);
+
+  int AttrVal = -1;
+  CHECK(hipDeviceGetAttribute(&AttrVal, hipDeviceAttributeUnifiedAddressing,
+                              0) == hipSuccess);
+  // Can't comply UVA expectations with bufferdevaddr allocation strategy, hence
+  // it must be off.
+  CHECK(AttrVal == 0);
+
+  int SrcH = 123, *SrcD;
+  CHECK(hipMalloc(&SrcD, sizeof(int)) == hipSuccess);
+
+  // Device and host allocations may alias, thus copy direction can't
+  // be determined robustly.
+  CHECK(hipMemcpy(SrcD, &SrcH, sizeof(int), hipMemcpyDefault) ==
+        hipErrorInvalidMemcpyDirection);
+
+  CHECK(hipMemcpy(SrcD, &SrcH, sizeof(int), hipMemcpyHostToDevice) ==
+        hipSuccess);
+
+  int *DstD;
+  CHECK(hipMalloc(&DstD, sizeof(int)) == hipSuccess);
+
+  int *DstH;
+  // With UVA off, hipHostMalloc should still work - the allocation just won't
+  // be mapped and portable implicitly.
+  CHECK(hipHostMalloc(&DstH, sizeof(int)) == hipSuccess);
+
+  k0<<<1, 1>>>(DstD, {123, SrcD});
+  CHECK(hipMemcpy(DstH, DstD, sizeof(int), hipMemcpyDeviceToHost) ==
+        hipSuccess);
+  CHECK(*DstH == 123);
+
+  CHECK(hipFree(DstD) == hipSuccess);
+  CHECK(hipFree(SrcD) == hipSuccess);
+  CHECK(hipHostFree(DstH) == hipSuccess);
+
+  return 0;
+}


### PR DESCRIPTION
Use [cl_ext_buffer_device_address](https://github.com/pocl/pocl/blob/1f80005557222a35f44a7d0d076aa4ae86499bdc/include/CL/cl_ext_pocl.h#L69) extension (experimental at the time
of this commit) for managing HIP device allocations on devices where neither USM
nor SVM is available. The latest main of POCL and, hopefully soon,
Mesa's rusticl supports this extension. Briefly, the extension enables
the OpenCL backend to pin cl_mem buffers to device memory and obtain their
fixed addresses.

The extension has a down side that the addresses of the device and
host allocations may alias, thus, we can't automatically determine
copy direction in `hipMemcpy*(, hipMemcpyDefault)` calls. For this
reason the unified [virtual] addressing feature is set off and,
consequently, hipMemcpyDefault is unsupported and allocations from
hipHostMalloc() are not implicitly mapped and portable. Also,
`hipHostMalloc(..., hipHostMallocMapped)` calls are not supported yet
(unimplemented).

Other changes:

* Use hipMemoryTypeDevice type for the shadow buffers of the
  global-scope `__device__` variables.

* Remove redundant hipDeviceProp_t structure copy in
  chipStar::Device::getAttr().

* Define missing unifiedAddressing device property.

* Define missing hipDeviceAttributeUnifiedAddressing attribute.

* On devices with `unifiedAddressing == 1` hipHostMallocMapped and
  hipHostMallocPortable flags are set on when calling hipHostMalloc().

* Map/unmap only device accessible host allocations (ones with
  hipHostMallocMapped).

* On devices with `unifiedAddressing == 0` hipHostMalloc() called with
  default flags allocates plain host memory instead of device
  (accessible) memory.

* Add hipMemcpyKind parameter to chipstar::Queue::hipMemcpy*() methods
  which is needed by the OpenCL backend for calling the right driver
  copy API function under `unifiedAddressing == 0`.

* Add CHIP_OCL_USE_ALLOC_STRATEGY environment variable for instructing
  OpenCL the backend to use either USM, SVM or the
  cl_ext_buffer_device_address.

* Added a test for cl_ext_buffer_device_address and also check
  excepted API behaviors for `unifiedAddressing == 0`. The test is
  run if the device supports the extension.

* Refactor SPIR-V processing. Filter out chipStar metadata expressed as global-scope variables.

* CHIP_DUMP_SPIRV=1 dumps SPIR-V on failing SPIR-V processing step.