### PR TITLE
OpenCL: Fix memory leak / OoM and stack overflow

### DIFF
--- a/cmake/UnitTests.cmake
+++ b/cmake/UnitTests.cmake
@@ -1046,6 +1046,7 @@ list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipPeekAtLastError_Positive_Threaded"
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipGraphMemcpyNodeSetParams_Functional") # Subprocess aborted
 
 # # dGPU Level Zero Unit Test Failures
+list(APPEND DGPU_LEVEL0_BASE_FAILED_TESTS "CatchMemLeak1") # Memory leak & segfault.
 list(APPEND DGPU_LEVEL0_BASE_FAILED_TESTS "deviceMallocCompile") # Unimplemented
 list(APPEND DGPU_LEVEL0_BASE_FAILED_TESTS "Unit_hipGraphAddEmptyNode_NegTest") # SEGFAULT
 list(APPEND DGPU_LEVEL0_BASE_FAILED_TESTS "Unit_hipGraphAddDependencies_NegTest") # SEGFAULT
@@ -1335,6 +1336,7 @@ list(APPEND DGPU_LEVEL0_BASE_FAILED_TESTS "Unit_hipMemFaultStackAllocation_Check
 list(APPEND DGPU_LEVEL0_BASE_FAILED_TESTS "Unit_hipGraphMemcpyNodeSetParams_Functional") # Subprocess aborted
 
 # iGPU Level Zero Unit Test Failures
+list(APPEND IGPU_LEVEL0_BASE_FAILED_TESTS "CatchMemLeak1") # Memory leak & segfault.
 list(APPEND IGPU_LEVEL0_BASE_FAILED_TESTS "hipStreamSemantics") # SEGFAULT
 list(APPEND IGPU_LEVEL0_BASE_FAILED_TESTS "deviceMallocCompile") # Unimplemented
 list(APPEND IGPU_LEVEL0_BASE_FAILED_TESTS "Unit_hipGraphAddEmptyNode_NegTest") # SEGFAULT

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -1063,7 +1063,6 @@ CHIPQueueOpenCL::addDependenciesQueueSync(
   auto [EventsToWaitOn, EventLocks] = getSyncQueuesLastEvents(TargetEvent);
   std::vector<cl_event> EventHandles;
   for (auto &Event : EventsToWaitOn) {
-    TargetEvent->addDependency(Event);
     EventHandles.push_back(
         std::static_pointer_cast<CHIPEventOpenCL>(Event)->ClEvent);
   }

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -339,8 +339,6 @@ public:
   virtual std::shared_ptr<chipstar::Event> enqueueMarkerImpl() override;
   virtual std::shared_ptr<chipstar::Event>
   memPrefetchImpl(const void *Ptr, size_t Count) override;
-  std::pair<std::vector<cl_event>, chipstar::LockGuardVector>
-  addDependenciesQueueSync(std::shared_ptr<chipstar::Event> TargetEvent);
 
 private:
   void switchModeTo(QueueMode Mode);

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -403,6 +403,7 @@ ALL:
   hipStreamSemantics: ''
   syncthreadsExitedThreads: ''
 LEVEL0_GPU:
+  CatchMemLeak1: ''
 OPENCL_CPU:
   2d_shuffle: ''
   Unit_hipClassKernel_Value: ''

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -105,3 +105,5 @@ add_hip_runtime_test(TestBallot.hip)
 add_hip_runtime_test(TestNegativeHasNoIGBAs1.hip)
 add_hip_runtime_test(TestNegativeHasNoIGBAs2.hip)
 add_hip_runtime_test(TestPositiveHasNoIGBAs.hip)
+
+add_hip_runtime_test(CatchMemLeak1.hip)

--- a/tests/runtime/CatchMemLeak1.hip
+++ b/tests/runtime/CatchMemLeak1.hip
@@ -1,0 +1,52 @@
+// This test tries to catch memory leak occuring during runtime by
+// monitoring changes in process' resident memory size. Note: getting
+// a pass with this test does not mean the absence of memory leaks.
+#include <hip/hip_runtime.h>
+#include <sys/resource.h>
+
+__global__ void k() {}
+
+size_t getMaxRSS() {
+  rusage Rusage;
+  if (getrusage(RUSAGE_SELF, &Rusage) != 0)
+    exit(3);
+  return Rusage.ru_maxrss;
+}
+
+int main() {
+  // If set too low, the changes in maximum resident memory size might
+  // be missed due to runtime's initial memory pools.
+  constexpr size_t NumKernelLaunches = 128 * 1024;
+
+  // A threshold measured in number of consecutive kernel launches
+  // without an increase in the maximum resident set size (MaxRSS)
+  // used as indicator for possible memory leakage.
+  constexpr size_t NoLeakThreshold = NumKernelLaunches / 8u;
+
+  size_t PrevMaxRSS = 0;
+  size_t RSSIncLag = 0; // Number of Kernel launches since the last
+                        // time the MaxRSS value increased.
+  for (size_t i = 0; i < NumKernelLaunches; i++) {
+    k<<<1, 1>>>();
+    if (hipGetLastError() != hipSuccess)
+      return 2;
+    hipDeviceSynchronize();
+
+    size_t CurrMaxRSS = getMaxRSS();
+    if (CurrMaxRSS > PrevMaxRSS)
+      RSSIncLag = 0;
+    else
+      RSSIncLag++;
+    PrevMaxRSS = CurrMaxRSS;
+  }
+
+  printf("RSSIncLag=%zu\n", RSSIncLag);
+
+  if (RSSIncLag < NoLeakThreshold) {
+    printf("Possible memory leak!\n");
+    return 1;
+  }
+
+  printf("Didn't detect memory leak.\n");
+  return 0;
+}


### PR DESCRIPTION
OpenCL backend called ´chipstar::Event::addDependency()´ without ever calling ´chipstar::Event::releaseDependencies()` during HIP application's lifetime and this had two possible outcomes:

1) Crash due to out of memory error because the unreleased event objects. This occured after a HIP program had streamed enough commands - like >30000 kernels.

2) Crash due to stack overflow at program exit / chipStar uninitialization. Because the event dependencies were not released, this led to a build up of very long event dependency chain. At uninitialization, the destruction of a Queue's last event led to destruction of its dependent events which led to destruction their dependend events and this possibly kept going until the crash which was caused by stack overflow from numerous call frames.

Both cases are fixed by removing the `addDependency()` call. AFAIK, the event dependency system is meant for timing safe release of the backend driver objects (cl_events in this case). OpenCL backend does not need this as the driver releases the objects when they are not needed by the application or by the driver for internal in-progress tasks.