### PR TITLE
Fix bunch texture cases

### DIFF
--- a/include/hip/spirv_channel_descriptor.h
+++ b/include/hip/spirv_channel_descriptor.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015 - 2021 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2015 - 2023 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -23,19 +23,16 @@ THE SOFTWARE.
 #ifndef HIP_INCLUDE_HIP_SPIRV_CHANNEL_DESCRIPTOR_H
 #define HIP_INCLUDE_HIP_SPIRV_CHANNEL_DESCRIPTOR_H
 
-//#include "channel_descriptor.h"
-
+#if !defined(__HIPCC_RTC__)
 #include <hip/hip_common.h>
 #include <hip/driver_types.h>
 #include <hip/spirv_hip_vector_types.h>
+#endif
 
 #ifdef __cplusplus
 
-extern "C" HIP_PUBLIC_API hipChannelFormatDesc
-hipCreateChannelDesc(int x, int y, int z, int w, hipChannelFormatKind f);
-
-inline hipChannelFormatDesc hipCreateChannelDesc(int x, int y, int z, int w,
-                                                 hipChannelFormatKind f) {
+extern "C" HIP_PUBLIC_API inline hipChannelFormatDesc
+hipCreateChannelDesc(int x, int y, int z, int w, hipChannelFormatKind f) {
   return {x, y, z, w, f};
 }
 
@@ -51,7 +48,12 @@ static inline hipChannelFormatDesc hipCreateChannelDescHalf1() {
 
 static inline hipChannelFormatDesc hipCreateChannelDescHalf2() {
   int e = (int)sizeof(unsigned short) * 8;
-  return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindFloat);
+  return hipCreateChannelDesc(e, e, 0, 0, hipChannelFormatKindFloat);
+}
+
+static inline hipChannelFormatDesc hipCreateChannelDescHalf4() {
+  int e = (int)sizeof(unsigned short) * 8;
+  return hipCreateChannelDesc(e, e, e, e, hipChannelFormatKindFloat);
 }
 
 template <typename T>
@@ -59,297 +61,254 @@ static inline hipChannelFormatDesc hipCreateChannelDesc() {
   return hipCreateChannelDesc(0, 0, 0, 0, hipChannelFormatKindNone);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<char>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<char>() {
   int e = (int)sizeof(char) * 8;
   return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindSigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<signed char>() {
-  int e = (int)sizeof(signed char) * 8;
-  return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindUnsigned);
-}
-
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<unsigned char>() {
-  int e = (int)sizeof(unsigned char) * 8;
-  return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindUnsigned);
-}
-
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<uchar1>() {
-  int e = (int)sizeof(unsigned char) * 8;
-  return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindSigned);
-}
-
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<char1>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<signed char>() {
   int e = (int)sizeof(signed char) * 8;
   return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindSigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<uchar2>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<unsigned char>() {
   int e = (int)sizeof(unsigned char) * 8;
-  return hipCreateChannelDesc(e, e, 0, 0, hipChannelFormatKindSigned);
+  return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindUnsigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<char2>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<uchar1>() {
+  int e = (int)sizeof(unsigned char) * 8;
+  return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindUnsigned);
+}
+
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<char1>() {
+  int e = (int)sizeof(signed char) * 8;
+  return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindSigned);
+}
+
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<uchar2>() {
+  int e = (int)sizeof(unsigned char) * 8;
+  return hipCreateChannelDesc(e, e, 0, 0, hipChannelFormatKindUnsigned);
+}
+
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<char2>() {
   int e = (int)sizeof(signed char) * 8;
   return hipCreateChannelDesc(e, e, 0, 0, hipChannelFormatKindSigned);
 }
 
-#ifndef __GNUC__  // vector3 is the same as vector4
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<uchar3>() {
+#ifndef __GNUC__ // vector3 is the same as vector4
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<uchar3>() {
   int e = (int)sizeof(unsigned char) * 8;
-  return hipCreateChannelDesc(e, e, e, 0, hipChannelFormatKindSigned);
+  return hipCreateChannelDesc(e, e, e, 0, hipChannelFormatKindUnsigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<char3>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<char3>() {
   int e = (int)sizeof(signed char) * 8;
   return hipCreateChannelDesc(e, e, e, 0, hipChannelFormatKindSigned);
 }
 #endif
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<uchar4>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<uchar4>() {
   int e = (int)sizeof(unsigned char) * 8;
-  return hipCreateChannelDesc(e, e, e, e, hipChannelFormatKindSigned);
+  return hipCreateChannelDesc(e, e, e, e, hipChannelFormatKindUnsigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<char4>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<char4>() {
   int e = (int)sizeof(signed char) * 8;
   return hipCreateChannelDesc(e, e, e, e, hipChannelFormatKindSigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<unsigned short>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<unsigned short>() {
   int e = (int)sizeof(unsigned short) * 8;
   return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindUnsigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<signed short>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<signed short>() {
   int e = (int)sizeof(signed short) * 8;
   return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindSigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<ushort1>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<ushort1>() {
   int e = (int)sizeof(unsigned short) * 8;
   return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindUnsigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<short1>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<short1>() {
   int e = (int)sizeof(signed short) * 8;
   return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindSigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<ushort2>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<ushort2>() {
   int e = (int)sizeof(unsigned short) * 8;
   return hipCreateChannelDesc(e, e, 0, 0, hipChannelFormatKindUnsigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<short2>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<short2>() {
   int e = (int)sizeof(signed short) * 8;
   return hipCreateChannelDesc(e, e, 0, 0, hipChannelFormatKindSigned);
 }
 
 #ifndef __GNUC__
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<ushort3>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<ushort3>() {
   int e = (int)sizeof(unsigned short) * 8;
   return hipCreateChannelDesc(e, e, e, 0, hipChannelFormatKindUnsigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<short3>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<short3>() {
   int e = (int)sizeof(signed short) * 8;
   return hipCreateChannelDesc(e, e, e, 0, hipChannelFormatKindSigned);
 }
 #endif
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<ushort4>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<ushort4>() {
   int e = (int)sizeof(unsigned short) * 8;
   return hipCreateChannelDesc(e, e, e, e, hipChannelFormatKindUnsigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<short4>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<short4>() {
   int e = (int)sizeof(signed short) * 8;
   return hipCreateChannelDesc(e, e, e, e, hipChannelFormatKindSigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<unsigned int>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<unsigned int>() {
   int e = (int)sizeof(unsigned int) * 8;
   return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindUnsigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<signed int>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<signed int>() {
   int e = (int)sizeof(signed int) * 8;
   return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindSigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<uint1>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<uint1>() {
   int e = (int)sizeof(unsigned int) * 8;
   return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindUnsigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<int1>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<int1>() {
   int e = (int)sizeof(signed int) * 8;
   return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindSigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<uint2>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<uint2>() {
   int e = (int)sizeof(unsigned int) * 8;
   return hipCreateChannelDesc(e, e, 0, 0, hipChannelFormatKindUnsigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<int2>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<int2>() {
   int e = (int)sizeof(signed int) * 8;
   return hipCreateChannelDesc(e, e, 0, 0, hipChannelFormatKindSigned);
 }
 
 #ifndef __GNUC__
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<uint3>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<uint3>() {
   int e = (int)sizeof(unsigned int) * 8;
   return hipCreateChannelDesc(e, e, e, 0, hipChannelFormatKindUnsigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<int3>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<int3>() {
   int e = (int)sizeof(signed int) * 8;
   return hipCreateChannelDesc(e, e, e, 0, hipChannelFormatKindSigned);
 }
 #endif
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<uint4>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<uint4>() {
   int e = (int)sizeof(unsigned int) * 8;
   return hipCreateChannelDesc(e, e, e, e, hipChannelFormatKindUnsigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<int4>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<int4>() {
   int e = (int)sizeof(signed int) * 8;
   return hipCreateChannelDesc(e, e, e, e, hipChannelFormatKindSigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<float>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<float>() {
   int e = (int)sizeof(float) * 8;
   return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindFloat);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<float1>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<float1>() {
   int e = (int)sizeof(float) * 8;
   return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindFloat);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<float2>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<float2>() {
   int e = (int)sizeof(float) * 8;
   return hipCreateChannelDesc(e, e, 0, 0, hipChannelFormatKindFloat);
 }
 
 #ifndef __GNUC__
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<float3>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<float3>() {
   int e = (int)sizeof(float) * 8;
   return hipCreateChannelDesc(e, e, e, 0, hipChannelFormatKindFloat);
 }
 #endif
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<float4>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<float4>() {
   int e = (int)sizeof(float) * 8;
   return hipCreateChannelDesc(e, e, e, e, hipChannelFormatKindFloat);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<unsigned long>() {
+#if !defined(__LP64__)
+
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<unsigned long>() {
   int e = (int)sizeof(unsigned long) * 8;
   return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindUnsigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<signed long>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<signed long>() {
   int e = (int)sizeof(signed long) * 8;
   return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindSigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<ulong1>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<ulong1>() {
   int e = (int)sizeof(unsigned long) * 8;
   return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindUnsigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<long1>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<long1>() {
   int e = (int)sizeof(signed long) * 8;
   return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindSigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<ulong2>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<ulong2>() {
   int e = (int)sizeof(unsigned long) * 8;
   return hipCreateChannelDesc(e, e, 0, 0, hipChannelFormatKindUnsigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<long2>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<long2>() {
   int e = (int)sizeof(signed long) * 8;
   return hipCreateChannelDesc(e, e, 0, 0, hipChannelFormatKindSigned);
 }
 
 #ifndef __GNUC__
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<ulong3>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<ulong3>() {
   int e = (int)sizeof(unsigned long) * 8;
   return hipCreateChannelDesc(e, e, e, 0, hipChannelFormatKindUnsigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<long3>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<long3>() {
   int e = (int)sizeof(signed long) * 8;
   return hipCreateChannelDesc(e, e, e, 0, hipChannelFormatKindSigned);
 }
 #endif
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<ulong4>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<ulong4>() {
   int e = (int)sizeof(unsigned long) * 8;
   return hipCreateChannelDesc(e, e, e, e, hipChannelFormatKindUnsigned);
 }
 
-template <>
-inline hipChannelFormatDesc hipCreateChannelDesc<long4>() {
+template <> inline hipChannelFormatDesc hipCreateChannelDesc<long4>() {
   int e = (int)sizeof(signed long) * 8;
   return hipCreateChannelDesc(e, e, e, e, hipChannelFormatKindSigned);
 }
+#endif /* !__LP64__ */
 
 #else
 
 struct hipChannelFormatDesc hipCreateChannelDesc(int x, int y, int z, int w,
                                                  enum hipChannelFormatKind f);
 
-#endif
+#endif /* __cplusplus */
 
-#endif
+#endif /* !HIP_INCLUDE_HIP_SPIRV_CHANNEL_DESCRIPTOR_H */

--- a/include/hip/spirv_texture_functions.h
+++ b/include/hip/spirv_texture_functions.h
@@ -134,7 +134,7 @@ extern "C" __device__ NativeUint4 _chip_tex2du(hipTextureObject_t TexObj,
     Pos.x = X;                                                                 \
     Pos.y = Y;                                                                 \
     auto Res = _IFN(TexObj, Pos);                                              \
-    *RetVal = make_##_RES_TY(Res.x, Res.y, Res.z, Res.y);                      \
+    *RetVal = make_##_RES_TY(Res.x, Res.y, Res.z, Res.w);                      \
   }                                                                            \
   __asm__("")
 

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -122,7 +122,8 @@ public:
         ", " + std::to_string(Size[2]) + "), Offset=(" +
         std::to_string(Offset[0]) + ", " + std::to_string(Offset[1]) + ", " +
         std::to_string(Offset[2]) + "), Pitch=(" + std::to_string(Pitch[0]) +
-        "," + std::to_string(Pitch[1]) + ")";
+        "," + std::to_string(Pitch[1]) +
+        "), EltSize=" + std::to_string(ElementSize);
     return Result;
   }
 
@@ -177,7 +178,7 @@ public:
     return R;
   }
 
-  static chipstar::RegionDesc get1DRegion(size_t TheWidth, size_t TheHeight,
+  static chipstar::RegionDesc get1DRegion(size_t TheWidth,
                                           size_t ElementByteSize = 1) {
     auto R = get2DRegion(TheWidth, 1, ElementByteSize);
     R.NumDims = 1;

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -146,6 +146,16 @@ public:
     }
   }
 
+  /// Return size of the region in bytes that includes gaps between
+  /// rows/slices.
+  size_t getAllocationSize() const {
+    unsigned LastDimIdx = getNumDims() - 1;
+    if (LastDimIdx == 0)
+      return Size[0] * ElementSize;
+    assert(Pitch[LastDimIdx - 1]);
+    return Pitch[LastDimIdx - 1] * Size[LastDimIdx];
+  }
+
   static chipstar::RegionDesc get3DRegion(size_t TheWidth, size_t TheHeight,
                                           size_t TheDepth,
                                           size_t ElementByteSize = 1) {

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -255,6 +255,13 @@ public:
   bool hasBallot() const noexcept { return HasSubgroupBallot_; }
 };
 
+template <typename T>
+static void CL_CALLBACK deleteArrayCallback(cl_event Event,
+                                            cl_int CommandExecStatus,
+                                            void *UserData) {
+  delete[] static_cast<T *>(UserData);
+}
+
 class CHIPQueueOpenCL : public chipstar::Queue {
   // Profiling queue is known to slow down driver API calls on Intel
   // OpenCL implementation but profiling is only needed for acquiring
@@ -341,6 +348,23 @@ public:
   memPrefetchImpl(const void *Ptr, size_t Count) override;
   std::pair<std::vector<cl_event>, chipstar::LockGuardVector>
   addDependenciesQueueSync(std::shared_ptr<chipstar::Event> TargetEvent);
+
+  /// Enqueues a virtual command that deletes the give host array
+  /// after previously enqueud commands have finished.
+  ///
+  /// Precondition: HostPtr must be a valid pointer to a host allocation
+  /// created with new T[].
+  template <typename T>
+  cl_int enqueueDeleteHostArray(T *HostPtr) {
+    assert(HostPtr);
+    cl::Event CallbackEv;
+    auto Status = get()->enqueueMarkerWithWaitList(nullptr, &CallbackEv);
+    if (Status != CL_SUCCESS)
+      return Status;
+
+    return CallbackEv.setCallback(CL_COMPLETE, deleteArrayCallback<T>,
+                                  reinterpret_cast<void *>(HostPtr));
+  }
 
 private:
   void switchModeTo(QueueMode Mode);

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -378,11 +378,8 @@ ALL:
   Unit_hipStreamIsCapturing_hipStreamPerThread: ''
   Unit_hipStreamPerThread_Basic: ''
   Unit_hipStreamSynchronize_UninitializedStream: ''
-  Unit_hipTextureObj1DCheckRGBAModes - array: ''
-  Unit_hipTextureObj1DCheckRGBAModes - buffer: ''
   Unit_hipTextureObj1DCheckSRGBAModes - array: ''
   Unit_hipTextureObj1DCheckSRGBAModes - buffer: ''
-  Unit_hipTextureObj2DCheckRGBAModes: ''
   Unit_hipTextureObj2DCheckSRGBAModes: ''
   Unit_hipUserObj_Negative_Test: ''
   Unit_hipUserObjectCreate_Functional_1: ''
@@ -413,7 +410,6 @@ OPENCL_CPU:
   unroll: ''
 OPENCL_GPU:
   TestStlFunctionsDouble: ''
-  Unit_hipCreateTextureObject_tex1DfetchVerification: ''
   Unit_hipEventRecord: ''
   Unit_hipGraphAddEventRecordNode_Functional_ElapsedTime: ''
   Unit_hipGraphEventRecordNodeSetEvent_SetEventProperty: ''
@@ -427,17 +423,6 @@ OPENCL_GPU:
   Unit_hipStreamAddCallback_ParamTst_Positive: Timeout dgpu
   Unit_hipStreamPerThread_DeviceReset_1: ''
   Unit_hipStreamPerThread_MultiThread: ''
-  Unit_hipTexObjPitch_texture2D - char: ''
-  Unit_hipTexObjPitch_texture2D - float: ''
-  Unit_hipTexObjPitch_texture2D - int: ''
-  Unit_hipTexObjPitch_texture2D - int16_t: ''
-  Unit_hipTexObjPitch_texture2D - unsigned char: ''
-  Unit_hipTexObjPitch_texture2D - unsigned int: ''
-  Unit_hipTextureFetch_vector: ''
-  Unit_hipTextureObj1DCheckModes: ''
-  Unit_hipTextureObj2DCheckModes: ''
-  Unit_hipTextureObj2D_Check: ''
-  Unit_tex1Dfetch_CheckModes: ''
   hipTestDeviceSymbol: ''
 OPENCL_POCL:
   BinomialOption: ''
@@ -467,3 +452,8 @@ OPENCL_POCL:
   hip_async_binomial: ''
   hip_sycl_interop: ''
   hip_sycl_interop_no_buffers: ''
+  # Results differs a tiny bit compared to CPU computed reference values for
+  # the following three texture tests.
+  Unit_hipTextureObj1DCheckRGBAModes - array: ''
+  Unit_hipTextureObj1DCheckRGBAModes - buffer: ''
+  Unit_hipTextureObj2DCheckRGBAModes: ''


### PR DESCRIPTION
* OpenCL: Fix used device pointer as source image data for `clEnqueueWriteImage()` which is not (guaranteed) to work unless it points to fine-grained SVM allocation.
* Fix `get1DRegion()` had unrelated parameter which effectively caused element size to be ignored.
* spirv_channel_descriptor.h had multiple `hipCreateChannelDesc()` specializations setting incorrect `hipChannelFormatKind` value. Fix by importing the more recent `hipCreateChannelDesc()` implementations from the original source (hipamd).
* Fix miswiring in the `DEF_TEX2D_VEC4` macro.