### PR TITLE
Fix math function j1 typo in dp_math.hh

### DIFF
--- a/include/hip/devicelib/double_precision/dp_math.hh
+++ b/include/hip/devicelib/double_precision/dp_math.hh
@@ -234,9 +234,9 @@ extern "C++" inline __device__ double j0(double x) {
   return ::__ocml_j0_f64(x);
 }
 
-extern "C" __device__  double __ocml_j0_f64(double x); // OCML
+extern "C" __device__  double __ocml_j1_f64(double x); // OCML
 extern "C++" inline __device__ double j1(double x) {
-  return ::__ocml_j0_f64(x);
+  return ::__ocml_j1_f64(x);
 }
 
 extern "C" __device__  double __chip_jn_f64(int n, double x); // Custom 


### PR DESCRIPTION
Fixed the typo in double-precision math function j1 so that it calls __ocml_j1_f64 instead of __ocml_j0_f64.