### PR TITLE
Implement missing host-side math functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,9 +512,9 @@ set(HIP_OFFLOAD_COMPILE_OPTIONS_BUILD_
 #             combined compile and link or when the --hip-link is
 #             present at the link step.
 list(APPEND HIP_OFFLOAD_LINK_OPTIONS_INSTALL_
-  "-L${LIB_INSTALL_DIR}" "-lCHIP" "-no-hip-rt")
+  "-L${LIB_INSTALL_DIR}" "-lCHIP" "-no-hip-rt -locml_host_math_funcs")
 list(APPEND HIP_OFFLOAD_LINK_OPTIONS_BUILD_
-  "-L${CMAKE_BINARY_DIR}" "-lCHIP" "-no-hip-rt")
+  "-L${CMAKE_BINARY_DIR}" "-lCHIP" "-no-hip-rt -locml_host_math_funcs")
 
 if(OpenCL_LIBRARY)
   target_link_options(CHIP PUBLIC -Wl,-rpath,${OpenCL_DIR})
@@ -808,3 +808,6 @@ endif()
 
 # Include docker targets
 include(cmake/docker.cmake)
+
+add_subdirectory(host_math_funcs)
+target_link_libraries(CHIP PUBLIC ocml_host_math_funcs)

--- a/host_math_funcs/CMakeLists.txt
+++ b/host_math_funcs/CMakeLists.txt
@@ -1,0 +1,130 @@
+message(STATUS "Building host math functions")
+set(ROCm-Device-Libs_SRC_DIR ${CMAKE_SOURCE_DIR}/bitcode/ROCm-Device-Libs)
+set(OCML_SRC_DIR ${ROCm-Device-Libs_SRC_DIR}/ocml/src)
+set(OCML_INCLUDE_DIR ${ROCm-Device-Libs_SRC_DIR}/ocml/include)
+set(OCML_LIB_DIR ${ROCm-Device-Libs_SRC_DIR}/ocml/lib)
+
+# Add include directories for OCML
+include_directories(
+  ${OCML_INCLUDE_DIR}
+  ${ROCm-Device-Libs_SRC_DIR}/irif/inc
+  ${ROCm-Device-Libs_SRC_DIR}/oclc/inc
+  ${ROCm-Device-Libs_SRC_DIR}/ocml/inc
+  ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+
+# Create host_math_funcs directory in build
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+# Copy ncdfF.cl to the build directory
+
+# cospi			OpenCL in chipStar (extern)
+# cospif			OpenCL in chipStar (calling cospi)
+file(COPY ${OCML_SRC_DIR}/trigredF.h DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+file(COPY ${OCML_SRC_DIR}/sincospiredF.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+file(COPY ${OCML_SRC_DIR}/tanpiredF.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+file(COPY ${OCML_SRC_DIR}/trigpiredF.h DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+file(COPY ${OCML_SRC_DIR}/trigpiredF.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+file(COPY ${OCML_SRC_DIR}/cospiF.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+file(COPY ${OCML_SRC_DIR}/trigpiredD.h DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+file(COPY ${OCML_SRC_DIR}/sincospiredD.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+file(COPY ${OCML_SRC_DIR}/tanpiredD.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+file(COPY ${OCML_SRC_DIR}/trigpiredD.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+file(COPY ${OCML_SRC_DIR}/cospiD.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+file(COPY ${OCML_SRC_DIR}/erfcD.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+file(COPY ${OCML_SRC_DIR}/erfcF.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+file(COPY ${OCML_SRC_DIR}/expD_base.h DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+file(COPY ${OCML_SRC_DIR}/expF_base.h DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+file(COPY ${OCML_SRC_DIR}/logD_base.h DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+file(COPY ${OCML_SRC_DIR}/logF_base.h DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+file(COPY ${OCML_SRC_DIR}/logD.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+file(COPY ${OCML_SRC_DIR}/logF.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+
+file(COPY ${OCML_SRC_DIR}/expD.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+file(COPY ${OCML_SRC_DIR}/expF.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+# erfcinv			OCML in chipStar (__ocml_erfcinv_f64)
+file(COPY ${OCML_SRC_DIR}/erfcinvD.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+# # erfcinvf		OCML in chipStar (__ocml_erfcinv_f32)
+file(COPY ${OCML_SRC_DIR}/erfcinvF.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+# # erfcx			OCML in chipStar (__ocml_erfcx_f64)
+file(COPY ${OCML_SRC_DIR}/erfcxD.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+# # erfcxf			OCML in chipStar (__ocml_erfcx_f32)
+file(COPY ${OCML_SRC_DIR}/erfcxF.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+# # erfinv			OCML in chipStar (__ocml_erfinv_f64)
+file(COPY ${OCML_SRC_DIR}/erfinvD.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+# # erfinvf			OCML in chipStar (__ocml_erfinv_f32)
+file(COPY ${OCML_SRC_DIR}/erfinvF.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+# # normcdf			OCML in chipStar (__ocml_ncdf_f64)
+file(COPY ${OCML_SRC_DIR}/ncdfD.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+# # normcdff		OCML in chipStar (__ocml_ncdf_f32)
+file(COPY ${OCML_SRC_DIR}/ncdfF.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+# # normcdfinv		OCML in chipStar (__ocml_ncdfinv_f64)
+file(COPY ${OCML_SRC_DIR}/ncdfinvD.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+# # normcdfinvf		OCML in chipStar (__ocml_ncdfinv_f32)
+file(COPY ${OCML_SRC_DIR}/ncdfinvF.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+# # rcbrt			OCML in chipStar (__ocml_rcbrt_f64)
+file(COPY ${OCML_SRC_DIR}/rcbrtD.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+# # rcbrtf			OCML in chipStar (__ocml_rcbrt_f32)
+file(COPY ${OCML_SRC_DIR}/rcbrtF.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+# # sincospi		OCML in chipStar (__ocml_sincospi_f64)
+file(COPY ${OCML_SRC_DIR}/sincospiD.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+# # sincospif		OCML in chipStar (__ocml_sincospi_f32)
+file(COPY ${OCML_SRC_DIR}/sincospiF.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+# # sinpi			OpenCL in chipStar (extern)
+file(COPY ${OCML_SRC_DIR}/sinpiD.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+# # sinpif			OpenCL in chipStar (call sinpi)
+file(COPY ${OCML_SRC_DIR}/sinpiF.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+# llmax			calling max() in chipStar
+# llmin			calling min() in chipStar
+# ullmax			calling max() in chipStar
+# ullmin			calling min() in chipStar
+# umax			calling max() in chipStar
+# umin			calling min() in chipStar
+
+# signbit			OCML in chipStar (__ocml_signbit_f64)
+file(COPY ${OCML_SRC_DIR}/signbitD.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+file(COPY ${OCML_SRC_DIR}/signbitF.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+
+# Gather all .cl sources from the OCML source directory
+file(GLOB OCML_CL_SOURCES ${CMAKE_BINARY_DIR}/host_math_funcs/*.cl)
+
+# Print the list of gathered .cl sources for debugging
+message(STATUS "OCML CL Sources: ${OCML_CL_SOURCES}")
+
+# Set the language for the target
+set_source_files_properties(${OCML_CL_SOURCES} PROPERTIES LANGUAGE C)
+
+# Add the library target
+add_library(ocml_host_math_funcs STATIC ${OCML_CL_SOURCES})
+set_target_properties(ocml_host_math_funcs PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+)
+# Set the linker language explicitly
+set_target_properties(ocml_host_math_funcs PROPERTIES LINKER_LANGUAGE C)
+
+# Add ocml_host_math_funcs to the export set
+install(TARGETS ocml_host_math_funcs EXPORT hip-targets)
+install(TARGETS ocml_host_math_funcs EXPORT CHIPTargets)

--- a/host_math_funcs/CMakeLists.txt
+++ b/host_math_funcs/CMakeLists.txt
@@ -96,6 +96,12 @@ file(COPY ${OCML_SRC_DIR}/sinpiD.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_fu
 # # sinpif			OpenCL in chipStar (call sinpi)
 file(COPY ${OCML_SRC_DIR}/sinpiF.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
 
+# rsqrt			OCML in chipStar (__ocml_rsqrt_f64)
+file(COPY ${OCML_SRC_DIR}/rsqrtD.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
+# rsqrtf			OCML in chipStar (__ocml_rsqrt_f32)
+file(COPY ${OCML_SRC_DIR}/rsqrtF.cl DESTINATION ${CMAKE_BINARY_DIR}/host_math_funcs)
+
 # llmax			calling max() in chipStar
 # llmin			calling min() in chipStar
 # ullmax			calling max() in chipStar

--- a/host_math_funcs/common.h
+++ b/host_math_funcs/common.h
@@ -1,0 +1,260 @@
+#include <math.h>
+#include <string.h> // for std::memcpy
+
+// Floating point patterns
+#define SIGNBIT_SP32      (int)0x80000000
+#define EXSIGNBIT_SP32    0x7fffffff
+#define EXPBITS_SP32      0x7f800000
+#define MANTBITS_SP32     0x007fffff
+#define ONEEXPBITS_SP32   0x3f800000
+#define TWOEXPBITS_SP32   0x40000000
+#define HALFEXPBITS_SP32  0x3f000000
+#define IMPBIT_SP32       0x00800000
+#define QNANBITPATT_SP32  0x7fc00000
+#define PINFBITPATT_SP32  0x7f800000
+#define NINFBITPATT_SP32  (int)0xff800000
+#define EXPBIAS_SP32      127
+#define EXPSHIFTBITS_SP32 23
+#define BIASEDEMIN_SP32   1
+#define EMIN_SP32         -126
+#define BIASEDEMAX_SP32   254
+#define EMAX_SP32         127
+#define MANTLENGTH_SP32   24
+#define BASEDIGITS_SP32   7
+
+// Bit patterns
+#define SIGNBIT_DP64      0x8000000000000000L
+#define EXSIGNBIT_DP64    0x7fffffffffffffffL
+#define EXPBITS_DP64      0x7ff0000000000000L
+#define MANTBITS_DP64     0x000fffffffffffffL
+#define ONEEXPBITS_DP64   0x3ff0000000000000L
+#define TWOEXPBITS_DP64   0x4000000000000000L
+#define HALFEXPBITS_DP64  0x3fe0000000000000L
+#define IMPBIT_DP64       0x0010000000000000L
+#define QNANBITPATT_DP64  0x7ff8000000000000L
+#define INDEFBITPATT_DP64 0xfff8000000000000L
+#define PINFBITPATT_DP64  0x7ff0000000000000L
+#define NINFBITPATT_DP64  0xfff0000000000000L
+#define EXPBIAS_DP64      1023
+#define EXPSHIFTBITS_DP64 52
+#define BIASEDEMIN_DP64   1
+#define EMIN_DP64         -1022
+#define BIASEDEMAX_DP64   2046
+#define EMAX_DP64         1023
+#define LAMBDA_DP64       1.0e300
+#define MANTLENGTH_DP64   53
+#define BASEDIGITS_DP64   15
+
+// Floating point patterns
+#define SIGNBIT_HP16      0x8000
+#define EXSIGNBIT_HP16    0x7fff
+#define EXPBITS_HP16      0x7c00
+#define MANTBITS_HP16     0x03ff
+#define ONEEXPBITS_HP16   0x3c00
+#define TWOEXPBITS_HP16   0x4000
+#define HALFEXPBITS_HP16  0x3800
+#define IMPBIT_HP16       0x0400
+#define QNANBITPATT_HP16  0x7e00
+#define PINFBITPATT_HP16  0x7c00
+#define NINFBITPATT_HP16  0xfc00
+#define EXPBIAS_HP16      15
+#define EXPSHIFTBITS_HP16 10
+#define BIASEDEMIN_HP16   1
+#define EMIN_HP16         -14
+#define BIASEDEMAX_HP16   30
+#define EMAX_HP16         15
+#define MANTLENGTH_HP16   11
+#define BASEDIGITS_HP16   5
+
+
+
+typedef int bool;
+#define true 1
+#define false 0
+typedef float half;
+typedef struct int2 {
+    union {
+        struct { int x, y; };
+        struct { int lo, hi; };
+    };
+} int2;
+
+typedef struct float2 {
+    union {
+        struct { float x, y; };
+        struct { float lo, hi; };
+    };
+} float2;
+
+typedef struct double2 {
+    union {
+        struct { double x, y; };
+        struct { double lo, hi; };
+    };
+} double2;
+
+typedef struct half2 {
+    union {
+        struct { half x, y; };
+        struct { half lo, hi; };
+    };
+} half2;
+
+typedef struct uint2 {
+    union {
+        struct { unsigned int x, y; };
+        struct { unsigned int lo, hi; };
+    };
+} uint2;
+
+typedef struct ushort2 {
+    union {
+        struct { unsigned short x, y; };
+        struct { unsigned short lo, hi; };
+    };
+} ushort2;
+
+typedef struct short2 {
+    union {
+        struct { short x, y; };
+        struct { short lo, hi; };
+    };
+} short2;
+
+typedef struct long2 {
+    union {
+        struct { long x, y; };
+        struct { long lo, hi; };
+    };
+} long2;
+
+typedef struct ulong2 {
+    union {
+        struct { unsigned long x, y; };
+        struct { unsigned long lo, hi; };
+    };
+} ulong2;
+
+#define __private 
+#define __constant 
+#include <stdint.h>
+
+typedef uint32_t uint;
+typedef uint16_t ushort;
+typedef uint64_t ulong;
+#include "ocml.h"
+
+#define bit_cast(To, From, src) \
+    ({ \
+        To dst; \
+        From tmp = src; \
+        memcpy(&dst, &tmp, sizeof(To)); \
+        dst; \
+    })
+#define AS_SHORT(X) bit_cast(short, typeof(X), X)
+#define AS_SHORT2(X) bit_cast(short2, typeof(X), X)
+#define AS_USHORT(X) bit_cast(unsigned short, typeof(X), X)
+#define AS_USHORT2(X) bit_cast(ushort2, typeof(X), X)
+#define AS_INT(X) bit_cast(int, typeof(X), X)
+#define AS_INT2(X) bit_cast(int2, typeof(X), X)
+#define AS_UINT(X) bit_cast(unsigned int, typeof(X), X)
+#define AS_UINT2(X) bit_cast(uint2, typeof(X), X)
+#define AS_LONG(X) bit_cast(long, typeof(X), X)
+#define AS_ULONG(X) bit_cast(unsigned long, typeof(X), X)
+#define AS_DOUBLE(X) bit_cast(double, typeof(X), X)
+#define AS_FLOAT(X) bit_cast(float, typeof(X), X)
+#define AS_HALF(X) bit_cast(half, typeof(X), X)
+#define AS_HALF2(X) bit_cast(half2, typeof(X), X)
+// // Class mask bits
+#define CLASS_SNAN 0x001
+#define CLASS_QNAN 0x002
+#define CLASS_NINF 0x004
+#define CLASS_NNOR 0x008
+#define CLASS_NSUB 0x010
+#define CLASS_NZER 0x020
+#define CLASS_PZER 0x040
+#define CLASS_PSUB 0x080
+#define CLASS_PNOR 0x100
+#define CLASS_PINF 0x200
+
+#define BUILTIN_ABS_F32(x) __builtin_fabs(x)
+#define BUILTIN_FMA_F32(a, b, c) __builtin_fma(a, b, c)
+#define BUILTIN_FMA_F64(a, b, c) __builtin_fma(a, b, c)
+#define BUILTIN_COPYSIGN_F32(a, b) __builtin_copysignf(a, b)
+#define BUILTIN_ISNAN_F32(x) __builtin_isnanf(x)
+#define BUILTIN_ISINF_F32(x) __builtin_isinf(x)
+#define BUILTIN_ISINF_F64(x) __builtin_isinf(x)
+static inline double BUILTIN_FREXP_MANT_F64(double x) {
+    int exp;
+    return frexp(x, &exp);
+}
+#define BUILTIN_EXP_F32(x) __builtin_expf(x)
+#define BUILTIN_LOG_F32(x) __builtin_logf(x)
+#define BUILTIN_SQRT_F32(x) __builtin_sqrtf(x)
+
+#define BUILTIN_RSQRT_F32(x) (1.0f / __builtin_sqrtf(x))
+#define BUILTIN_RSQRT_F64(x) __builtin_fabs(1.0 / __builtin_sqrt(x))
+
+#define BUILTIN_DIV_F32(a, b) (a) / (b)
+#define BUILTIN_DIV_F64(a, b) (a) / (b)
+
+#define UGEN(x) x
+
+#define BUILTIN_MAD_F32(a, b, c) __builtin_fmaf(a, b, c)
+#define BUILTIN_MAD_2F32(a, b, c) vec2(__builtin_fmaf(a.x, b.x, c.x), __builtin_fmaf(a.y, b.y, c.y))
+#define BUILTIN_MAD_F64(a, b, c) __builtin_fma(a, b, c)
+#define BUILTIN_MAD_F16(a, b, c) __builtin_fmaf(a, b, c)
+#define BUILTIN_MAD_2F16(a, b, c) vec2(__builtin_fmaf(a.x, b.x, c.x), __builtin_fmaf(a.y, b.y, c.y))
+
+#define BUILTIN_RCP_F32(x) (1.0f / (x))
+#define BUILTIN_RCP_F64(x) (1.0 / (x))
+
+#define BUILTIN_ABS_F64(x) __builtin_fabs(x)
+#define BUILTIN_COPYSIGN_F64(a, b) __builtin_copysignf(a, b)
+
+#define BUILTIN_ISFINITE_F32(x) __builtin_isfinite(x)
+
+// __builtin_modff and __builtin_modf return the fractional part of x, and store the integer part in the address of the second argument
+// so we need to subtract the integer part from the fractional part to get the fractional part
+static inline float BUILTIN_FRACTION_F32(float x) { float rem; return x - __builtin_modff(x, &rem); }
+static inline double BUILTIN_FRACTION_F64(double x) { double rem; return x - __builtin_modf(x, &rem); }
+#define BUILTIN_RINT_F32(x) __builtin_rintf(x)
+#define BUILTIN_RINT_F64(x) __builtin_rint(x)
+#define BUILTIN_ISFINITE_F64(x) __builtin_isfinite(x)
+
+
+
+// Attributes
+#define ALIGNEDATTR(X) __attribute__((aligned(X)))
+#define INLINEATTR __attribute__((always_inline))
+#define PUREATTR __attribute__((pure))
+#define CONSTATTR __attribute__((const))
+
+// #include "opts.h"
+static inline bool HAVE_FAST_FMA32() { return true; }
+static inline bool FINITE_ONLY_OPT() { return false; }
+static inline bool UNSAFE_MATH_OPT() { return false; }
+static inline bool DAZ_OPT() { return false; }
+static inline bool CORRECTLY_ROUNDED_SQRT32() { return false; }
+
+
+#define BUILTIN_CLASS_F32(x, class) __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, x) == (class)
+#define BUILTIN_CLASS_F64(x, class) __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, x) == (class)
+#define BUILTIN_CLASS_F16(x, class) __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, x) == (class)
+
+#define BUILTIN_FREXP_EXP_F64(x) ({ \
+    int exp; \
+    (void)frexp(x, &exp); \
+    exp; \
+})
+
+#define BUILTIN_FLDEXP_F64(x, exp) ldexp(x, exp)
+
+#define BUILTIN_LOG2_F32(x) __builtin_log2f(x)
+
+#define BUILTIN_EXP2_F32(x) __builtin_exp2f(x)
+#define BUILTIN_CANONICALIZE_F32(x) (x)
+
+#define BUILTIN_FLDEXP_F32(x, exp) ldexpf(x, exp)
+
+

--- a/host_math_funcs/ep.h
+++ b/host_math_funcs/ep.h
@@ -1,0 +1,462 @@
+
+#define ATTR __attribute__((const, overloadable))
+
+#if defined FLOAT_SPECIALIZATION
+#define T float
+#define T2 float2
+#define FMA BUILTIN_FMA_F32
+#define RCP MATH_FAST_RCP
+#define DIV(X,Y) MATH_FAST_DIV(X,Y)
+#define LDEXP BUILTIN_FLDEXP_F32
+#define SQRT MATH_FAST_SQRT
+#define ISINF(X) BUILTIN_ISINF_F32(X)
+#define USE_FMA HAVE_FAST_FMA32()
+#define HIGH(X) AS_FLOAT(AS_UINT(X) & 0xfffff000U)
+#define SIGNBIT(X) (AS_INT(X) < 0)
+#define SAMESIGN(X,Y) ((AS_INT(X)& 0x80000000) == (AS_INT(Y) & 0x80000000))
+#endif
+
+#if defined DOUBLE_SPECIALIZATION
+#define T double
+#define T2 double2
+#define FMA BUILTIN_FMA_F64
+#define RCP MATH_FAST_RCP
+#define DIV(X,Y) MATH_FAST_DIV(X,Y)
+#define LDEXP BUILTIN_FLDEXP_F64
+#define SQRT MATH_FAST_SQRT
+#define ISINF(X) BUILTIN_ISINF_F64(X)
+#define USE_FMA true
+#define HIGH(X) AS_DOUBLE(AS_ULONG(X) & 0xfffffffff8000000UL)
+#define SIGNBIT(X) (AS_INT2(X).hi < 0)
+#define SAMESIGN(X,Y) ((AS_INT2(X).hi & 0x80000000) == (AS_INT2(Y).hi & 0x80000000))
+#endif
+
+#if defined HALF_SPECIALIZATION
+#define T half
+#define T2 half2
+#define FMA BUILTIN_FMA_F16
+#define RCP MATH_FAST_RCP
+#define DIV(X,Y) MATH_FAST_DIV(X,Y)
+#define LDEXP BUILTIN_FLDEXP_F16
+#define SQRT MATH_FAST_SQRT
+#define ISINF(X) BUILTIN_ISINF_F16(X)
+#define USE_FMA true
+#define HIGH(X) AS_HALF(AS_USHORT(X) & (ushort)0xffc0U)
+#define SIGNBIT(X) (AS_SHORT(X) < (short)0)
+#define SAMESIGN(X,Y) ((AS_USHORT(X) & (ushort)0x8000) == (AS_USHORT(Y) & (ushort)0x8000))
+#endif
+
+static ATTR T2
+absv(T2 a)
+{
+    return SIGNBIT(a.hi) ? (T2){-a.hi, -a.lo} : a;
+}
+
+static ATTR T2
+csgn(T2 a, T2 b)
+{
+    return SAMESIGN(a.hi, b.hi) ? a : (T2){-a.hi, -a.lo};
+}
+
+static ATTR T2
+con(T a, T b)
+{
+    return (T2){b, a};
+}
+
+static ATTR T2
+fadd(T a, T b)
+{
+    T s = a + b;
+    return con(s, b - (s - a));
+}
+
+static ATTR T2
+nrm(T2 a)
+{
+    return fadd(a.hi, a.lo);
+}
+
+static ATTR T2
+onrm(T2 a)
+{
+    T s = a.hi + a.lo;
+    T t = a.lo - (s - a.hi);
+    s = ISINF(a.hi) ? a.hi : s;
+    return con(s, ISINF(s) ? (T)0 : t);
+}
+
+static ATTR T2
+fsub(T a, T b)
+{
+    T d = a - b;
+    return con(d, (a - d) - b);
+}
+
+static ATTR T2
+add(T a, T b)
+{
+    T s = a + b;
+    T d = s - a;
+    return con(s, (a - (s - d)) + (b - d));
+}
+
+static ATTR T2
+sub(T a, T b)
+{
+    T d = a - b;
+    T e = d - a;
+    return con(d, (a - (d - e)) - (b + e));
+}
+
+static ATTR T2
+mul(T a, T b)
+{
+    T p = a * b;
+    if (USE_FMA) {
+        return con(p, FMA(a, b, -p));
+    } else {
+        T ah = HIGH(a);
+        T al = a - ah;
+        T bh = HIGH(b);
+        T bl = b - bh;
+        T p = a * b;
+        return con(p, ((ah*bh - p) + ah*bl + al*bh) + al*bl);
+    }
+}
+
+static ATTR T2
+sqr(T a)
+{
+    T p = a * a;
+    if (USE_FMA) {
+        return con(p, FMA(a, a, -p));
+    } else {
+        T ah = HIGH(a);
+        T al = a - ah;
+        return con(p, ((ah*ah - p) + 2.0f*ah*al) + al*al);
+    }
+}
+
+static ATTR T2
+add(T2 a, T b)
+{
+    T2 s = add(a.hi, b);
+    s.lo += a.lo;
+    return nrm(s);
+}
+
+static ATTR T2
+fadd(T2 a, T b)
+{
+    T2 s = fadd(a.hi, b);
+    s.lo += a.lo;
+    return nrm(s);
+}
+
+static ATTR T2
+add(T a, T2 b)
+{
+    T2 s = add(a, b.hi);
+    s.lo += b.lo;
+    return nrm(s);
+}
+
+static ATTR T2
+fadd(T a, T2 b)
+{
+    T2 s = fadd(a, b.hi);
+    s.lo += b.lo;
+    return nrm(s);
+}
+
+static ATTR T2
+add(T2 a, T2 b)
+{
+    T2 s = add(a.hi, b.hi);
+    T2 t = add(a.lo, b.lo);
+    s.lo += t.hi;
+    s = nrm(s);
+    s.lo += t.lo;
+    return nrm(s);
+}
+
+static ATTR T2
+fadd(T2 a, T2 b)
+{
+    T2 s = fadd(a.hi, b.hi);
+    s.lo += a.lo + b.lo;
+    return nrm(s);
+}
+
+static ATTR T2
+sub(T2 a, T b)
+{
+    T2 d = sub(a.hi, b);
+    d.lo += a.lo;
+    return nrm(d);
+}
+
+static ATTR T2
+fsub(T2 a, T b)
+{
+    T2 d = fsub(a.hi, b);
+    d.lo += a.lo;
+    return nrm(d);
+}
+
+static ATTR T2
+sub(T a, T2 b)
+{
+    T2 d = sub(a, b.hi);
+    d.lo -= b.lo;
+    return nrm(d);
+}
+
+static ATTR T2
+fsub(T a, T2 b)
+{
+    T2 d = fsub(a, b.hi);
+    d.lo -= b.lo;
+    return nrm(d);
+}
+
+static ATTR T2
+sub(T2 a, T2 b)
+{
+    T2 d = sub(a.hi, b.hi);
+    T2 e = sub(a.lo, b.lo);
+    d.lo += e.hi;
+    d = nrm(d);
+    d.lo += e.lo;
+    return nrm(d);
+}
+
+static ATTR T2
+fsub(T2 a, T2 b)
+{
+    T2 d = fsub(a.hi, b.hi);
+    d.lo = d.lo + a.lo - b.lo;
+    return nrm(d);
+}
+
+static ATTR T2
+ldx(T2 a, int e)
+{
+    return con(LDEXP(a.hi, e), LDEXP(a.lo, e));
+}
+
+static ATTR T2
+mul(T2 a, T b)
+{
+    T2 p = mul(a.hi, b);
+    if (USE_FMA) {
+        p.lo = FMA(a.lo, b, p.lo);
+    } else {
+        p.lo += a.lo * b;
+    }
+    return nrm(p);
+}
+
+static ATTR T2
+omul(T2 a, T b)
+{
+    T2 p = mul(a.hi, b);
+    if (USE_FMA) {
+        p.lo = FMA(a.lo, b, p.lo);
+    } else {
+        p.lo += a.lo * b;
+    }
+    return onrm(p);
+}
+
+static ATTR T2
+mul(T a, T2 b)
+{
+    T2 p = mul(a, b.hi);
+    if (USE_FMA) {
+        p.lo = FMA(a, b.lo, p.lo);
+    } else {
+        p.lo += a * b.lo;
+    }
+    return nrm(p);
+}
+
+static ATTR T2
+omul(T a, T2 b)
+{
+    T2 p = mul(a, b.hi);
+    if (USE_FMA) {
+        p.lo = FMA(a, b.lo, p.lo);
+    } else {
+        p.lo += a * b.lo;
+    }
+    return onrm(p);
+}
+
+static ATTR T2
+mul(T2 a, T2 b)
+{
+    T2 p = mul(a.hi, b.hi);
+    if (USE_FMA) {
+        p.lo = FMA(a.lo, b.hi, FMA(a.hi, b.lo, p.lo));
+    } else {
+        p.lo += a.hi*b.lo + a.lo*b.hi;
+    }
+    return nrm(p);
+}
+
+static ATTR T2
+omul(T2 a, T2 b)
+{
+    T2 p = mul(a.hi, b.hi);
+    if (USE_FMA) {
+        p.lo += FMA(a.hi, b.lo, a.lo*b.hi);
+    } else {
+        p.lo += a.hi*b.lo + a.lo*b.hi;
+    }
+    return onrm(p);
+}
+
+static ATTR T2
+div(T a, T b)
+{
+    T r = RCP(b);
+    T qhi = a * r;
+    T2 p = mul(qhi, b);
+    T2 d = fsub(a, p.hi);
+    d.lo -= p.lo;
+    T qlo = (d.hi + d.lo) * r;
+    return fadd(qhi, qlo);
+}
+
+static ATTR T2
+div(T2 a, T b)
+{
+    T r = RCP(b);
+    T qhi = a.hi * r;
+    T2 p = mul(qhi, b);
+    T2 d = fsub(a.hi, p.hi);
+    d.lo = d.lo + a.lo - p.lo;
+    T qlo = (d.hi + d.lo) * r;
+    return fadd(qhi, qlo);
+}
+
+static ATTR T2
+div(T a, T2 b)
+{
+    T r = RCP(b.hi);
+    T qhi = a * r;
+    T2 p = mul(qhi, b);
+    T2 d = fsub(a, p.hi);
+    d.lo -= p.lo;
+    T qlo = (d.hi + d.lo) * r;
+    return fadd(qhi, qlo);
+}
+
+static ATTR T2
+fdiv(T2 a, T2 b)
+{
+    T r = RCP(b.hi);
+    T qhi = a.hi * r;
+    T2 p = mul(qhi, b);
+    T2 d = fsub(a.hi, p.hi);
+    d.lo = d.lo - p.lo + a.lo;
+    T qlo = (d.hi + d.lo) * r;
+    return fadd(qhi, qlo);
+}
+
+static ATTR T2
+div(T2 a, T2 b)
+{
+    T y = RCP(b.hi);
+    T qhi = a.hi * y;
+    T2 r = fsub(a, mul(qhi, b));
+    T qmi = r.hi * y;
+    r = fsub(r, mul(qmi, b));
+    T qlo = r.hi * y;
+    T2 q = fadd(qhi, qmi);
+    q.lo += qlo;
+    return nrm(q);
+}
+
+static ATTR T2
+rcp(T b)
+{
+    T qhi = RCP(b);
+    T2 p = mul(qhi, b);
+    T2 d = fsub((T)1, p.hi);
+    d.lo -= p.lo;
+    T qlo = (d.hi + d.lo) * qhi;
+    return fadd(qhi, qlo);
+}
+
+static ATTR T2
+frcp(T2 b)
+{
+    T qhi = RCP(b.hi);
+    T2 p = mul(qhi, b);
+    T2 d = fsub((T)1, p.hi);
+    d.lo -= p.lo;
+    T qlo = (d.hi + d.lo) * qhi;
+    return fadd(qhi, qlo);
+}
+
+static ATTR T2
+rcp(T2 b)
+{
+    T qhi = RCP(b.hi);
+    T2 r = fsub((T)1, mul(qhi, b));
+    T qmi = r.hi * qhi;
+    r = fsub(r, mul(qmi, b));
+    T qlo = r.hi * qhi;
+    T2 q = fadd(qhi, qmi);
+    q.lo += qlo;
+    return nrm(q);
+}
+
+static ATTR T2
+sqr(T2 a)
+{
+    T2 p = sqr(a.hi);
+    if (USE_FMA) {
+        p.lo = FMA(a.hi, (T)2 * a.lo, p.lo);
+    } else {
+        p.lo = p.lo + (T)2 * a.lo * a.hi;
+    }
+    return nrm(p);
+}
+
+static ATTR T2
+root2(T a)
+{
+    T shi = SQRT(a);
+    T2 e = fsub(a, sqr(shi));
+    T slo = DIV(e.hi, (T)2 * shi);
+    return fadd(shi, a == (T)0 ? (T)0 : slo);
+}
+
+static ATTR T2
+root2(T2 a)
+{
+    T shi = SQRT(a.hi);
+    T2 e = fsub(a, sqr(shi));
+    T slo = DIV(e.hi, (T)2 * shi);
+    return fadd(shi, a.hi == (T)0 ? (T)0 : slo);
+}
+
+#undef ATTR
+#undef T
+#undef T2
+#undef FMA
+#undef RCP
+#undef DIV
+#undef LDEXP
+#undef SQRT
+#undef ISINF
+#undef USE_FMA
+#undef HIGH
+#undef COPYSIGN
+#undef SIGNBIT
+#undef SAMESIGN
+

--- a/host_math_funcs/mathD.h
+++ b/host_math_funcs/mathD.h
@@ -1,0 +1,6 @@
+#include "common.h"
+#include "privD.h"
+
+// Mangling
+#define MATH_MANGLE(N) OCML_MANGLE_F64(N)
+#define MATH_PRIVATE(N) MANGLE3(__ocmlpriv,N,f64)

--- a/host_math_funcs/mathF.h
+++ b/host_math_funcs/mathF.h
@@ -1,0 +1,6 @@
+#include "common.h"
+#include "privF.h"
+
+// Mangling
+#define MATH_MANGLE(N) OCML_MANGLE_F32(N)
+#define MATH_PRIVATE(N) MANGLE3(__ocmlpriv,N,f32)

--- a/host_math_funcs/mathH.h
+++ b/host_math_funcs/mathH.h
@@ -1,0 +1,6 @@
+#include "common.h"
+#include "privH.h"
+
+// Mangling
+#define MATH_MANGLE(N) OCML_MANGLE_F16(N)
+#define MATH_PRIVATE(N) MANGLE3(__ocmlpriv,N,f16)

--- a/host_math_funcs/opts.h
+++ b/host_math_funcs/opts.h
@@ -1,0 +1,15 @@
+/*===--------------------------------------------------------------------------
+ *                   ROCm Device Libraries
+ *
+ * This file is distributed under the University of Illinois Open Source
+ * License. See LICENSE.TXT for details.
+ *===------------------------------------------------------------------------*/
+
+#include "oclc.h"
+
+#define HAVE_FAST_FMA32() (__oclc_ISA_version == 7001 || __oclc_ISA_version == 8001 || __oclc_ISA_version >= 9000)
+#define FINITE_ONLY_OPT() __oclc_finite_only_opt
+#define UNSAFE_MATH_OPT() __oclc_unsafe_math_opt
+#define DAZ_OPT() __oclc_daz_opt
+#define CORRECTLY_ROUNDED_SQRT32() __oclc_correctly_rounded_sqrt32
+

--- a/host_math_funcs/privD.h
+++ b/host_math_funcs/privD.h
@@ -1,0 +1,82 @@
+/*===--------------------------------------------------------------------------
+ *                   ROCm Device Libraries
+ *
+ * This file is distributed under the University of Illinois Open Source
+ * License. See LICENSE.TXT for details.
+ *===------------------------------------------------------------------------*/
+
+#define MATH_CLZI(U) ({ \
+    uint _clzi_u = U; \
+    uint _clzi_z = BUILTIN_FIRSTBIT_U32(_clzi_u); \
+    uint _clzi_ret = _clzi_u == 0u ? 32u : _clzi_z; \
+    _clzi_ret; \
+})
+
+#define MATH_CLZL(U) ({ \
+    ulong _clzl_u = U; \
+    uint2 _clzl_u2 = AS_UINT2(_clzl_u); \
+    uint _clzl_zlo = BUILTIN_FIRSTBIT_U32(_clzl_u2.lo); \
+    uint _clzl_zhi = BUILTIN_FIRSTBIT_U32(_clzl_u2.hi); \
+    uint _clzl_clo = (_clzl_u2.lo == 0 ? 32 : _clzl_zlo) + 32; \
+    uint _clzl_ret = _clzl_u2.hi == 0 ? _clzl_clo : _clzl_zhi; \
+    _clzl_ret; \
+})
+
+#define MATH_MAD(A,B,C) BUILTIN_FMA_F64(A, B, C)
+
+#define MATH_FAST_RCP(X) ({ \
+    double _frcp_x = X; \
+    double _frcp_ret; \
+    _frcp_ret = BUILTIN_RCP_F64(_frcp_x); \
+    _frcp_ret = BUILTIN_FMA_F64(BUILTIN_FMA_F64(-_frcp_x, _frcp_ret, 1.0), _frcp_ret, _frcp_ret); \
+    _frcp_ret = BUILTIN_FMA_F64(BUILTIN_FMA_F64(-_frcp_x, _frcp_ret, 1.0), _frcp_ret, _frcp_ret); \
+    _frcp_ret; \
+})
+#define MATH_RCP(X) BUILTIN_DIV_F64(1.0, X)
+
+#define MATH_FAST_DIV(X, Y) ({ \
+    double _fdiv_x = X; \
+    double _fdiv_y = Y; \
+    double _fdiv_ret; \
+    double _fdiv_r = BUILTIN_RCP_F64(_fdiv_y); \
+    _fdiv_r = BUILTIN_FMA_F64(BUILTIN_FMA_F64(-_fdiv_y, _fdiv_r, 1.0), _fdiv_r, _fdiv_r); \
+    _fdiv_r = BUILTIN_FMA_F64(BUILTIN_FMA_F64(-_fdiv_y, _fdiv_r, 1.0), _fdiv_r, _fdiv_r); \
+    _fdiv_ret = _fdiv_x * _fdiv_r; \
+    _fdiv_ret = BUILTIN_FMA_F64(BUILTIN_FMA_F64(-_fdiv_y, _fdiv_ret, _fdiv_x), _fdiv_r, _fdiv_ret); \
+    _fdiv_ret; \
+})
+#define MATH_DIV(X,Y) BUILTIN_DIV_F64(X, Y)
+
+#define MATH_FAST_SQRT(X) ({ \
+    double _fsqrt_x = X; \
+    double _fsqrt_y = BUILTIN_RSQRT_F64(_fsqrt_x); \
+    double _fsqrt_s0 = _fsqrt_x * _fsqrt_y; \
+    double _fsqrt_h0 = 0.5 * _fsqrt_y; \
+    double _fsqrt_r0 = BUILTIN_FMA_F64(-_fsqrt_h0, _fsqrt_s0, 0.5); \
+    double _fsqrt_h1 = BUILTIN_FMA_F64(_fsqrt_h0, _fsqrt_r0, _fsqrt_h0); \
+    double _fsqrt_s1 = BUILTIN_FMA_F64(_fsqrt_s0, _fsqrt_r0, _fsqrt_s0); \
+    double _fsqrt_d0 = BUILTIN_FMA_F64(-_fsqrt_s1, _fsqrt_s1, _fsqrt_x); \
+    double _fsqrt_ret = BUILTIN_FMA_F64(_fsqrt_d0, _fsqrt_h1, _fsqrt_s1); \
+    _fsqrt_ret = _fsqrt_x == 0.0 ? _fsqrt_x : _fsqrt_ret; \
+    _fsqrt_ret; \
+})
+
+#define MATH_SQRT(X) ({ \
+    double _sqrt_x = X; \
+    bool _sqrt_b = _sqrt_x < 0x1.0p-767; \
+    _sqrt_x *= _sqrt_b ? 0x1.0p+256 : 1.0; \
+    double _sqrt_y = BUILTIN_RSQRT_F64(_sqrt_x); \
+    double _sqrt_s0 = _sqrt_x * _sqrt_y; \
+    double _sqrt_h0 = 0.5 * _sqrt_y; \
+    double _sqrt_r0 = BUILTIN_FMA_F64(-_sqrt_h0, _sqrt_s0, 0.5); \
+    double _sqrt_h1 = BUILTIN_FMA_F64(_sqrt_h0, _sqrt_r0, _sqrt_h0); \
+    double _sqrt_s1 = BUILTIN_FMA_F64(_sqrt_s0, _sqrt_r0, _sqrt_s0); \
+    double _sqrt_d0 = BUILTIN_FMA_F64(-_sqrt_s1, _sqrt_s1, _sqrt_x); \
+    double _sqrt_s2 = BUILTIN_FMA_F64(_sqrt_d0, _sqrt_h1, _sqrt_s1); \
+    double _sqrt_d1 = BUILTIN_FMA_F64(-_sqrt_s2, _sqrt_s2, _sqrt_x); \
+    double _sqrt_ret = BUILTIN_FMA_F64(_sqrt_d1, _sqrt_h1, _sqrt_s2); \
+    _sqrt_ret *= _sqrt_b ? 0x1.0p-128 : 1.0; \
+    _sqrt_ret = ((_sqrt_x == 0.0) | (_sqrt_x == (double)INFINITY)) ? _sqrt_x : _sqrt_ret; \
+    _sqrt_ret; \
+})
+

--- a/host_math_funcs/privF.h
+++ b/host_math_funcs/privF.h
@@ -1,0 +1,58 @@
+/*===--------------------------------------------------------------------------
+ *                   ROCm Device Libraries
+ *
+ * This file is distributed under the University of Illinois Open Source
+ * License. See LICENSE.TXT for details.
+ *===------------------------------------------------------------------------*/
+
+#define MATH_CLZI(U) ({ \
+    uint _clzi_u = U; \
+    uint _clzi_z = BUILTIN_FIRSTBIT_U32(_clzi_u); \
+    uint _clzi_ret = _clzi_u == 0u ? 32u : _clzi_z; \
+    _clzi_ret; \
+})
+
+#define MATH_MAD(A,B,C) BUILTIN_MAD_F32(A, B, C)
+#define MATH_MAD2(A,B,C) BUILTIN_MAD_2F32(A, B, C)
+
+#define MATH_FAST_RCP(X) BUILTIN_RCP_F32(X)
+#define MATH_RCP(X) BUILTIN_DIV_F32(1.0f, X)
+
+#define MATH_FAST_DIV(X, Y) ({ \
+    float _fdiv_x = X; \
+    float _fdiv_y = Y; \
+    float _fdiv_ret = _fdiv_x * BUILTIN_RCP_F32(_fdiv_y); \
+    _fdiv_ret; \
+})
+#define MATH_DIV(X,Y) BUILTIN_DIV_F32(X, Y)
+
+
+#define MATH_FAST_SQRT(X) BUILTIN_SQRT_F32(X)
+
+#define MATH_SQRT(X) ({ \
+    float _sqrt_x = X; \
+    bool _sqrt_b = _sqrt_x < 0x1.0p-96f; \
+    _sqrt_x *= _sqrt_b ? 0x1.0p+32f : 1.0f; \
+    float _sqrt_s; \
+    if (!DAZ_OPT()) { \
+        _sqrt_s = BUILTIN_SQRT_F32(_sqrt_x); \
+        float _sqrt_sp = AS_FLOAT(AS_INT(_sqrt_s) - 1); \
+        float _sqrt_ss = AS_FLOAT(AS_INT(_sqrt_s) + 1); \
+        float _sqrt_vp = BUILTIN_FMA_F32(-_sqrt_sp, _sqrt_s, _sqrt_x); \
+        float _sqrt_vs = BUILTIN_FMA_F32(-_sqrt_ss, _sqrt_s, _sqrt_x); \
+        _sqrt_s = _sqrt_vp <= 0.0f ? _sqrt_sp : _sqrt_s; \
+        _sqrt_s = _sqrt_vs >  0.0f ? _sqrt_ss : _sqrt_s; \
+    } else { \
+        float _sqrt_r = BUILTIN_RSQRT_F32(_sqrt_x); \
+        _sqrt_s = _sqrt_x * _sqrt_r; \
+        float _sqrt_h = 0.5f * _sqrt_r; \
+        float _sqrt_e = BUILTIN_FMA_F32(-_sqrt_h, _sqrt_s, 0.5f); \
+        _sqrt_h = BUILTIN_FMA_F32(_sqrt_h, _sqrt_e, _sqrt_h); \
+        _sqrt_s = BUILTIN_FMA_F32(_sqrt_s, _sqrt_e, _sqrt_s); \
+        float _sqrt_d = BUILTIN_FMA_F32(-_sqrt_s, _sqrt_s, _sqrt_x); \
+        _sqrt_s = BUILTIN_FMA_F32(_sqrt_d, _sqrt_h, _sqrt_s); \
+    } \
+    _sqrt_s *= _sqrt_b ? 0x1.0p-16f : 1.0f; \
+    _sqrt_s = BUILTIN_CLASS_F32(_sqrt_x, CLASS_PZER|CLASS_NZER|CLASS_PINF) ? _sqrt_x : _sqrt_s; \
+    _sqrt_s; \
+})

--- a/host_math_funcs/privH.h
+++ b/host_math_funcs/privH.h
@@ -1,0 +1,31 @@
+/*===--------------------------------------------------------------------------
+ *                   ROCm Device Libraries
+ *
+ * This file is distributed under the University of Illinois Open Source
+ * License. See LICENSE.TXT for details.
+ *===------------------------------------------------------------------------*/
+
+#define MATH_CLZI(U) ({ \
+    uint _clzi_u = U; \
+    uint _clzi_z = BUILTIN_FIRSTBIT_U32(_clzi_u); \
+    uint _clzi_ret = _clzi_u == 0u ? 32u : _clzi_z; \
+    _clzi_ret; \
+})
+
+#define MATH_MAD(A,B,C) BUILTIN_FMA_F16(A, B, C)
+#define MATH_MAD2(A,B,C) BUILTIN_FMA_2F16(A, B, C)
+
+#define MATH_FAST_RCP(X) BUILTIN_RCP_F16(X)
+#define MATH_RCP(X) BUILTIN_DIV_F16(1.0h, X)
+
+#define MATH_FAST_DIV(X, Y) ({ \
+    half _fdiv_x = X; \
+    half _fdiv_y = Y; \
+    half _fdiv_ret = _fdiv_x * BUILTIN_RCP_F16(_fdiv_y); \
+    _fdiv_ret; \
+})
+#define MATH_DIV(X,Y) BUILTIN_DIV_F16(X, Y)
+
+#define MATH_FAST_SQRT(X) BUILTIN_SQRT_F16(X)
+#define MATH_SQRT(X) ((half)BUILTIN_SQRT_F32((float)(X)))
+

--- a/include/hip/devicelib/host_math_funcs.hh
+++ b/include/hip/devicelib/host_math_funcs.hh
@@ -1,0 +1,78 @@
+
+#ifndef HIP_INCLUDE_DEVICELIB_HOST_MATH_FUNCS_H
+#define HIP_INCLUDE_DEVICELIB_HOST_MATH_FUNCS_H
+
+#include <hip/devicelib/macros.hh>
+#include <algorithm>
+
+extern "C" {
+    extern float __ocml_cospi_f32(float x);
+    extern float __ocml_sinpi_f32(float x);
+    extern double __ocml_erfcinv_f64(double x);
+    extern float __ocml_erfcinv_f32(float x);
+    extern double __ocml_erfcx_f64(double x);
+    extern float __ocml_erfcx_f32(float x);
+    extern double __ocml_erfinv_f64(double x);
+    extern float __ocml_erfinv_f32(float x);
+    extern double __ocml_ncdf_f64(double x);
+    extern float __ocml_ncdf_f32(float x);
+    extern double __ocml_ncdfinv_f64(double x);
+    extern float __ocml_ncdfinv_f32(float x);
+    extern double __ocml_rcbrt_f64(double x);
+    extern float __ocml_rcbrt_f32(float x);
+    extern double __ocml_sincospi_f64(double x, double* pcos);
+    extern float __ocml_sincospi_f32(float x, float* pcos);
+    extern int __ocml_signbit_f64(double x);
+}
+
+// Trigonometric functions
+inline float cospi(float x) { return __ocml_cospi_f32(x); }
+inline float cospif(float x) { return __ocml_cospi_f32(x); }
+
+inline float sinpi(float x) { return __ocml_sinpi_f32(x); }
+inline float sinpif(float x) { return __ocml_sinpi_f32(x); }
+
+// Error functions
+inline double erfcinv(double x) { return __ocml_erfcinv_f64(x); }
+
+inline float erfcinvf(float x) { return __ocml_erfcinv_f32(x); }
+
+inline double erfcx(double x) { return __ocml_erfcx_f64(x); }
+
+inline float erfcxf(float x) { return __ocml_erfcx_f32(x); }
+
+inline double erfinv(double x) { return __ocml_erfinv_f64(x); }
+
+inline float erfinvf(float x) { return __ocml_erfinv_f32(x); }
+
+// Normal distribution functions
+inline double normcdf(double x) { return __ocml_ncdf_f64(x); }
+
+inline float normcdff(float x) { return __ocml_ncdf_f32(x); }
+
+inline double normcdfinv(double x) { return __ocml_ncdfinv_f64(x); }
+
+inline float normcdfinvf(float x) { return __ocml_ncdfinv_f32(x); }
+
+// Reciprocal cube root
+inline double rcbrt(double x) { return __ocml_rcbrt_f64(x); }
+
+inline float rcbrtf(float x) { return __ocml_rcbrt_f32(x); }
+
+// Sine and cosine of pi times x
+inline double sincospi(double x, double* pcos) { return __ocml_sincospi_f64(x, pcos); }
+
+inline float sincospif(float x, float* pcos) { return __ocml_sincospi_f32(x, pcos); }
+
+// Integer max/min functions
+inline long long llmax(long long a, long long b) { return std::max(a, b); }
+inline long long llmin(long long a, long long b) { return std::min(a, b); }
+inline unsigned long long ullmax(unsigned long long a, unsigned long long b) { return std::max(a, b); }
+inline unsigned long long ullmin(unsigned long long a, unsigned long long b) { return std::min(a, b); }
+inline unsigned int umax(unsigned int a, unsigned int b) { return std::max(a, b); }
+inline unsigned int umin(unsigned int a, unsigned int b) { return std::min(a, b); }
+
+// Sign bit
+inline int signbit(double x) { return __ocml_signbit_f64(x); }
+
+#endif // HIP_INCLUDE_DEVICELIB_HOST_MATH_FUNCS_H

--- a/include/hip/devicelib/host_math_funcs.hh
+++ b/include/hip/devicelib/host_math_funcs.hh
@@ -23,6 +23,8 @@ extern "C" {
     extern double __ocml_sincospi_f64(double x, double* pcos);
     extern float __ocml_sincospi_f32(float x, float* pcos);
     extern int __ocml_signbit_f64(double x);
+    extern double __ocml_rsqrt_f64(double x);
+    extern float __ocml_rsqrt_f32(float x);
 }
 
 // Trigonometric functions
@@ -58,11 +60,14 @@ inline float normcdfinvf(float x) { return __ocml_ncdfinv_f32(x); }
 inline double rcbrt(double x) { return __ocml_rcbrt_f64(x); }
 
 inline float rcbrtf(float x) { return __ocml_rcbrt_f32(x); }
-
 // Sine and cosine of pi times x
-inline double sincospi(double x, double* pcos) { return __ocml_sincospi_f64(x, pcos); }
+inline void sincospi(double x, double* psin, double* pcos) { 
+    *psin = __ocml_sincospi_f64(x, pcos);
+}
 
-inline float sincospif(float x, float* pcos) { return __ocml_sincospi_f32(x, pcos); }
+inline void sincospif(float x, float* psin, float* pcos) { 
+    *psin = __ocml_sincospi_f32(x, pcos);
+}
 
 // Integer max/min functions
 inline long long llmax(long long a, long long b) { return std::max(a, b); }
@@ -74,5 +79,10 @@ inline unsigned int umin(unsigned int a, unsigned int b) { return std::min(a, b)
 
 // Sign bit
 inline int signbit(double x) { return __ocml_signbit_f64(x); }
+
+inline double rsqrt(double x) { return __ocml_rsqrt_f64(x); }
+
+inline float rsqrtf(float x) { return __ocml_rsqrt_f32(x); }
+
 
 #endif // HIP_INCLUDE_DEVICELIB_HOST_MATH_FUNCS_H

--- a/include/hip/spirv_hip_devicelib.hh
+++ b/include/hip/spirv_hip_devicelib.hh
@@ -66,6 +66,8 @@ THE SOFTWARE.
 #include <hip/devicelib/integer/int_intrinsics.hh>
 #include <hip/devicelib/integer/int_math.hh>
 
+#include <hip/devicelib/host_math_funcs.hh>
+
 #pragma push_macro("__DEF_FLOAT_FUN")
 #pragma push_macro("__DEF_FLOAT_FUN2")
 #pragma push_macro("__HIP_OVERLOAD")

--- a/samples/cuda_samples/6_Advanced/mergeSort/mergeSort_host.cpp
+++ b/samples/cuda_samples/6_Advanced/mergeSort/mergeSort_host.cpp
@@ -37,10 +37,10 @@ static void checkOrder(uint *data, uint N, uint sortDir)
         }
 }
 
-static uint umin(uint a, uint b)
-{
-    return (a <= b) ? a : b;
-}
+// static uint umin(uint a, uint b)
+// {
+//     return (a <= b) ? a : b;
+// }
 
 static uint getSampleCount(uint dividend)
 {

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -122,4 +122,4 @@ add_hipcc_test(TestAlignAttr.hip HIPCC_OPTIONS -fsyntax-only)
 # Check __FAST_MATH__ is set for -ffast-math and preprocessor guards
 # using it are not hiding errors.
 add_hipcc_test(TestFastMath.hip HIPCC_OPTIONS -fsyntax-only -ffast-math)
-
+add_hipcc_test(invalid-bitwidth-128.hip)

--- a/tests/compiler/invalid-bitwidth-128.hip
+++ b/tests/compiler/invalid-bitwidth-128.hip
@@ -1,0 +1,51 @@
+#include <hip/hip_runtime.h>
+#include <iostream>
+#include <cmath>
+
+__global__ void rcbrtKernel(double* results) {
+    results[12] = rcbrt(8.0);
+}
+
+int main() {
+    const int numResults = 28;
+    double* deviceResults;
+    double hostResults[numResults];
+    const double epsilon = 1e-6;
+    bool all_passed = true;
+
+    // Allocate device memory
+    hipMalloc(&deviceResults, numResults * sizeof(double));
+
+    // Launch kernel
+    hipLaunchKernelGGL(rcbrtKernel, dim3(1), dim3(1), 0, 0, deviceResults);
+
+    // Copy results back to host
+    hipMemcpy(hostResults, deviceResults, numResults * sizeof(double), hipMemcpyDeviceToHost);
+
+    // Compute host results
+    double host_rcbrt_result = 1.0 / std::cbrt(8.0);
+    float host_rcbrtf_result = 1.0f / std::cbrt(27.0f);
+
+    // Compare results
+    if (std::abs(host_rcbrt_result - hostResults[12]) >= epsilon) {
+        std::cout << "FAIL: rcbrt test failed - Host: " << host_rcbrt_result << ", Device: " << hostResults[12] << ", Diff: " << std::abs(host_rcbrt_result - hostResults[12]) << std::endl;
+        all_passed = false;
+    }
+    if (std::abs(host_rcbrtf_result - hostResults[13]) >= epsilon) {
+        std::cout << "FAIL: rcbrtf test failed - Host: " << host_rcbrtf_result << ", Device: " << hostResults[13] << ", Diff: " << std::abs(host_rcbrtf_result - hostResults[13]) << std::endl;
+        all_passed = false;
+    }
+
+    // Free device memory
+    hipFree(deviceResults);
+
+    if (all_passed) {
+        std::cout << "PASS: All tests passed!" << std::endl;
+    } else {
+        std::cout << "FAIL: Some tests failed. Check the output above for details." << std::endl;
+    }
+
+    return all_passed ? 0 : 1;
+}
+
+

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -1,6 +1,8 @@
 TOTAL_TESTS: 1397
 ANY:
   ALL:
+    hipcc-invalid-bitwidth-128: 'InvalidBitWidth: Invalid bit width in input: 128'
+    host-math-funcs: 'host and dev results differ'
     shfl_sync: 'masks outside of 0xFFFFFFFF are not supported'
     # Invalid test (if it is the one from HIP/ submodule instead of hip-tests/).
     # The source allocation 'Ah' is not initialized (this is fixed in hip-tests/)

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -108,3 +108,9 @@ add_hip_runtime_test(TestPositiveHasNoIGBAs.hip)
 
 add_hip_runtime_test(CatchMemLeak1.hip)
 add_hip_runtime_test(TestBufferDevAddr.hip)
+
+add_hip_runtime_test(host-math-funcs.hip)
+set_tests_properties("host-math-funcs" PROPERTIES
+FAIL_REGULAR_EXPRESSION "FAIL")
+set_tests_properties("host-math-funcs" PROPERTIES
+PASS_REGULAR_EXPRESSION "PASS")

--- a/tests/runtime/host-math-funcs.hip
+++ b/tests/runtime/host-math-funcs.hip
@@ -73,9 +73,9 @@ int main() {
     double host_rcbrt_result = rcbrt(8.0);
     float host_rcbrtf_result = rcbrtf(27.0f);
     double host_sincos_result_sin, host_sincos_result_cos;
-    host_sincos_result_sin = sincospi(0.25, &host_sincos_result_cos);
+    sincospi(0.25, &host_sincos_result_sin, &host_sincos_result_cos);
     float host_sincosf_result_sin, host_sincosf_result_cos;
-    host_sincosf_result_sin = sincospif(0.75f, &host_sincosf_result_cos);
+    sincospif(0.75f, &host_sincosf_result_sin, &host_sincosf_result_cos);
     double host_sinpi_result = sinpi(0.5);
     float host_sinpif_result = sinpif(0.25f);
     long long host_llmax_result = llmax(10LL, 20LL);
@@ -85,6 +85,8 @@ int main() {
     unsigned int host_umax_result = umax(90U, 100U);
     unsigned int host_umin_result = umin(110U, 120U);
     int host_signbit_result = signbit(-1.5);
+    double host_rsqrt_result = rsqrt(4.0);
+    float host_rsqrtf_result = rsqrtf(9.0f);
     
     // Compare results
     const double epsilon = 1e-6;
@@ -196,6 +198,14 @@ int main() {
     }
     if (host_signbit_result != static_cast<int>(hostResults[26])) {
         std::cout << "signbit test failed - Host: " << host_signbit_result << ", Device: " << static_cast<int>(hostResults[26]) << ", Diff: " << std::abs(host_signbit_result - static_cast<int>(hostResults[26])) << std::endl;
+        all_passed = false;
+    
+    if (std::abs(host_rsqrt_result - hostResults[27]) >= epsilon) {
+        std::cout << "rsqrt test failed - Host: " << host_rsqrt_result << ", Device: " << hostResults[27] << ", Diff: " << std::abs(host_rsqrt_result - hostResults[27]) << std::endl;
+        all_passed = false;
+    }
+    if (std::abs(host_rsqrtf_result - hostResults[28]) >= epsilon) {
+        std::cout << "rsqrtf test failed - Host: " << host_rsqrtf_result << ", Device: " << hostResults[28] << ", Diff: " << std::abs(host_rsqrtf_result - hostResults[28]) << std::endl;
         all_passed = false;
     }
     

--- a/tests/runtime/host-math-funcs.hip
+++ b/tests/runtime/host-math-funcs.hip
@@ -44,7 +44,7 @@ __global__ void mathFunctionsKernel(double* results) {
 }
 
 int main() {
-    const int numResults = 27;
+    const int numResults = 29;
     double hostResults[numResults];
     double* deviceResults;
     
@@ -199,7 +199,7 @@ int main() {
     if (host_signbit_result != static_cast<int>(hostResults[26])) {
         std::cout << "signbit test failed - Host: " << host_signbit_result << ", Device: " << static_cast<int>(hostResults[26]) << ", Diff: " << std::abs(host_signbit_result - static_cast<int>(hostResults[26])) << std::endl;
         all_passed = false;
-    
+    }
     if (std::abs(host_rsqrt_result - hostResults[27]) >= epsilon) {
         std::cout << "rsqrt test failed - Host: " << host_rsqrt_result << ", Device: " << hostResults[27] << ", Diff: " << std::abs(host_rsqrt_result - hostResults[27]) << std::endl;
         all_passed = false;

--- a/tests/runtime/host-math-funcs.hip
+++ b/tests/runtime/host-math-funcs.hip
@@ -1,0 +1,212 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_runtime_api.h>
+#include <iostream>
+#include <cmath>
+#include <cassert>
+
+// GPU kernel to compute math functions
+__global__ void mathFunctionsKernel(double* results) {
+    results[0] = cospi(0.5);
+    results[1] = cospif(0.25f);
+    results[2] = erfcinv(0.1);
+    results[3] = erfcinvf(0.2f);
+    results[4] = erfcx(0.3);
+    results[5] = erfcxf(0.4f);
+    results[6] = erfinv(0.5);
+    results[7] = erfinvf(0.6f);
+    results[8] = normcdf(0.7);
+    results[9] = normcdff(0.8f);
+    results[10] = normcdfinv(0.9);
+    results[11] = normcdfinvf(0.95f);
+    // results[12] = rcbrt(8.0); // causes 128bit error
+    results[13] = rcbrtf(27.0f);
+    double sincos_result_cos;
+    double sincos_result_sin;
+    sincospi(0.25, &sincos_result_sin, &sincos_result_cos);
+    results[14] = sincos_result_sin;
+    results[15] = sincos_result_cos;
+    
+    float sincosf_result_cos;
+    float sincosf_result_sin;
+    sincospif(0.75f, &sincosf_result_sin, &sincosf_result_cos);
+    results[16] = sincosf_result_sin;
+    results[17] = sincosf_result_cos;
+    
+    results[18] = sinpi(0.5);
+    results[19] = sinpif(0.25f);
+    results[20] = llmax(10LL, 20LL);
+    results[21] = llmin(30LL, 40LL);
+    results[22] = ullmax(50ULL, 60ULL);
+    results[23] = ullmin(70ULL, 80ULL);
+    results[24] = umax(90U, 100U);
+    results[25] = umin(110U, 120U);
+    results[26] = signbit(-1.5);
+}
+
+int main() {
+    const int numResults = 27;
+    double hostResults[numResults];
+    double* deviceResults;
+    
+    // Allocate device memory
+    hipMalloc(&deviceResults, numResults * sizeof(double));
+    
+    // Launch kernel
+    hipLaunchKernelGGL(mathFunctionsKernel, dim3(1), dim3(1), 0, 0, deviceResults);
+    
+    // Copy results back to host
+    hipMemcpy(hostResults, deviceResults, numResults * sizeof(double), hipMemcpyDeviceToHost);
+    
+    // Compute host results
+    double host_cospi_result = cospi(0.5);
+    float host_cospif_result = cospif(0.25f);
+    double host_erfcinv_result = erfcinv(0.1); // segfaults
+    float host_erfcinvf_result = erfcinvf(0.2f);
+    double host_erfcx_result = erfcx(0.3);
+    float host_erfcxf_result = erfcxf(0.4f);
+    double host_erfinv_result = erfinv(0.5);
+    float host_erfinvf_result = erfinvf(0.6f);
+    double host_normcdf_result = normcdf(0.7);
+    float host_normcdff_result = normcdff(0.8f);
+    double host_normcdfinv_result = normcdfinv(0.9);
+    float host_normcdfinvf_result = normcdfinvf(0.95f);
+    double host_rcbrt_result = rcbrt(8.0);
+    float host_rcbrtf_result = rcbrtf(27.0f);
+    double host_sincos_result_sin, host_sincos_result_cos;
+    host_sincos_result_sin = sincospi(0.25, &host_sincos_result_cos);
+    float host_sincosf_result_sin, host_sincosf_result_cos;
+    host_sincosf_result_sin = sincospif(0.75f, &host_sincosf_result_cos);
+    double host_sinpi_result = sinpi(0.5);
+    float host_sinpif_result = sinpif(0.25f);
+    long long host_llmax_result = llmax(10LL, 20LL);
+    long long host_llmin_result = llmin(30LL, 40LL);
+    unsigned long long host_ullmax_result = ullmax(50ULL, 60ULL);
+    unsigned long long host_ullmin_result = ullmin(70ULL, 80ULL);
+    unsigned int host_umax_result = umax(90U, 100U);
+    unsigned int host_umin_result = umin(110U, 120U);
+    int host_signbit_result = signbit(-1.5);
+    
+    // Compare results
+    const double epsilon = 1e-6;
+    bool all_passed = true;
+    
+    if (std::abs(host_cospi_result - hostResults[0]) >= epsilon) {
+        std::cout << "cospi test failed - Host: " << host_cospi_result << ", Device: " << hostResults[0] << ", Diff: " << std::abs(host_cospi_result - hostResults[0]) << std::endl;
+        all_passed = false;
+    }
+    if (std::abs(host_cospif_result - hostResults[1]) >= epsilon) {
+        std::cout << "cospif test failed - Host: " << host_cospif_result << ", Device: " << hostResults[1] << ", Diff: " << std::abs(host_cospif_result - hostResults[1]) << std::endl;
+        all_passed = false;
+    }
+    if (std::abs(host_erfcinv_result - hostResults[2]) >= epsilon) {
+        std::cout << "erfcinv test failed - Host: " << host_erfcinv_result << ", Device: " << hostResults[2] << ", Diff: " << std::abs(host_erfcinv_result - hostResults[2]) << std::endl;
+        all_passed = false;
+    }
+    if (std::abs(host_erfcinvf_result - hostResults[3]) >= epsilon) {
+        std::cout << "erfcinvf test failed - Host: " << host_erfcinvf_result << ", Device: " << hostResults[3] << ", Diff: " << std::abs(host_erfcinvf_result - hostResults[3]) << std::endl;
+        all_passed = false;
+    }
+    if (std::abs(host_erfcx_result - hostResults[4]) >= epsilon) {
+        std::cout << "erfcx test failed - Host: " << host_erfcx_result << ", Device: " << hostResults[4] << ", Diff: " << std::abs(host_erfcx_result - hostResults[4]) << std::endl;
+        all_passed = false;
+    }
+    if (std::abs(host_erfcxf_result - hostResults[5]) >= epsilon) {
+        std::cout << "erfcxf test failed - Host: " << host_erfcxf_result << ", Device: " << hostResults[5] << ", Diff: " << std::abs(host_erfcxf_result - hostResults[5]) << std::endl;
+        all_passed = false;
+    }
+    if (std::abs(host_erfinv_result - hostResults[6]) >= epsilon) {
+        std::cout << "erfinv test failed - Host: " << host_erfinv_result << ", Device: " << hostResults[6] << ", Diff: " << std::abs(host_erfinv_result - hostResults[6]) << std::endl;
+        all_passed = false;
+    }
+    if (std::abs(host_erfinvf_result - hostResults[7]) >= epsilon) {
+        std::cout << "erfinvf test failed - Host: " << host_erfinvf_result << ", Device: " << hostResults[7] << ", Diff: " << std::abs(host_erfinvf_result - hostResults[7]) << std::endl;
+        all_passed = false;
+    }
+    if (std::abs(host_normcdf_result - hostResults[8]) >= epsilon) {
+        std::cout << "normcdf test failed - Host: " << host_normcdf_result << ", Device: " << hostResults[8] << ", Diff: " << std::abs(host_normcdf_result - hostResults[8]) << std::endl;
+        all_passed = false;
+    }
+    if (std::abs(host_normcdff_result - hostResults[9]) >= epsilon) {
+        std::cout << "normcdff test failed - Host: " << host_normcdff_result << ", Device: " << hostResults[9] << ", Diff: " << std::abs(host_normcdff_result - hostResults[9]) << std::endl;
+        all_passed = false;
+    }
+    if (std::abs(host_normcdfinv_result - hostResults[10]) >= epsilon) {
+        std::cout << "normcdfinv test failed - Host: " << host_normcdfinv_result << ", Device: " << hostResults[10] << ", Diff: " << std::abs(host_normcdfinv_result - hostResults[10]) << std::endl;
+        all_passed = false;
+    }
+    if (std::abs(host_normcdfinvf_result - hostResults[11]) >= epsilon) {
+        std::cout << "normcdfinvf test failed - Host: " << host_normcdfinvf_result << ", Device: " << hostResults[11] << ", Diff: " << std::abs(host_normcdfinvf_result - hostResults[11]) << std::endl;
+        all_passed = false;
+    }
+    if (std::abs(host_rcbrt_result - hostResults[12]) >= epsilon) {
+        std::cout << "rcbrt test failed - Host: " << host_rcbrt_result << ", Device: " << hostResults[12] << ", Diff: " << std::abs(host_rcbrt_result - hostResults[12]) << std::endl;
+        all_passed = false;
+    }
+    if (std::abs(host_rcbrtf_result - hostResults[13]) >= epsilon) {
+        std::cout << "rcbrtf test failed - Host: " << host_rcbrtf_result << ", Device: " << hostResults[13] << ", Diff: " << std::abs(host_rcbrtf_result - hostResults[13]) << std::endl;
+        all_passed = false;
+    }
+    if (std::abs(host_sincos_result_sin - hostResults[14]) >= epsilon) {
+        std::cout << "sincospi (sin) test failed - Host: " << host_sincos_result_sin << ", Device: " << hostResults[14] << ", Diff: " << std::abs(host_sincos_result_sin - hostResults[14]) << std::endl;
+        all_passed = false;
+    }
+    if (std::abs(host_sincos_result_cos - hostResults[15]) >= epsilon) {
+        std::cout << "sincospi (cos) test failed - Host: " << host_sincos_result_cos << ", Device: " << hostResults[15] << ", Diff: " << std::abs(host_sincos_result_cos - hostResults[15]) << std::endl;
+        all_passed = false;
+    }
+    if (std::abs(host_sincosf_result_sin - hostResults[16]) >= epsilon) {
+        std::cout << "sincospif (sin) test failed - Host: " << host_sincosf_result_sin << ", Device: " << hostResults[16] << ", Diff: " << std::abs(host_sincosf_result_sin - hostResults[16]) << std::endl;
+        all_passed = false;
+    }
+    if (std::abs(host_sincosf_result_cos - hostResults[17]) >= epsilon) {
+        std::cout << "sincospif (cos) test failed - Host: " << host_sincosf_result_cos << ", Device: " << hostResults[17] << ", Diff: " << std::abs(host_sincosf_result_cos - hostResults[17]) << std::endl;
+        all_passed = false;
+    }
+    if (std::abs(host_sinpi_result - hostResults[18]) >= epsilon) {
+        std::cout << "sinpi test failed - Host: " << host_sinpi_result << ", Device: " << hostResults[18] << ", Diff: " << std::abs(host_sinpi_result - hostResults[18]) << std::endl;
+        all_passed = false;
+    }
+    if (std::abs(host_sinpif_result - hostResults[19]) >= epsilon) {
+        std::cout << "sinpif test failed - Host: " << host_sinpif_result << ", Device: " << hostResults[19] << ", Diff: " << std::abs(host_sinpif_result - hostResults[19]) << std::endl;
+        all_passed = false;
+    }
+    if (host_llmax_result != static_cast<long long>(hostResults[20])) {
+        std::cout << "llmax test failed - Host: " << host_llmax_result << ", Device: " << static_cast<long long>(hostResults[20]) << ", Diff: " << std::abs(host_llmax_result - static_cast<long long>(hostResults[20])) << std::endl;
+        all_passed = false;
+    }
+    if (host_llmin_result != static_cast<long long>(hostResults[21])) {
+        std::cout << "llmin test failed - Host: " << host_llmin_result << ", Device: " << static_cast<long long>(hostResults[21]) << ", Diff: " << std::abs(host_llmin_result - static_cast<long long>(hostResults[21])) << std::endl;
+        all_passed = false;
+    }
+    if (host_ullmax_result != static_cast<unsigned long long>(hostResults[22])) {
+        std::cout << "ullmax test failed - Host: " << host_ullmax_result << ", Device: " << static_cast<unsigned long long>(hostResults[22]) << ", Diff: " << std::abs(static_cast<long long>(host_ullmax_result - static_cast<unsigned long long>(hostResults[22]))) << std::endl;
+        all_passed = false;
+    }
+    if (host_ullmin_result != static_cast<unsigned long long>(hostResults[23])) {
+        std::cout << "ullmin test failed - Host: " << host_ullmin_result << ", Device: " << static_cast<unsigned long long>(hostResults[23]) << ", Diff: " << std::abs(static_cast<long long>(host_ullmin_result - static_cast<unsigned long long>(hostResults[23]))) << std::endl;
+        all_passed = false;
+    }
+    if (host_umax_result != static_cast<unsigned int>(hostResults[24])) {
+        std::cout << "umax test failed - Host: " << host_umax_result << ", Device: " << static_cast<unsigned int>(hostResults[24]) << ", Diff: " << std::abs(static_cast<int>(host_umax_result - static_cast<unsigned int>(hostResults[24]))) << std::endl;
+        all_passed = false;
+    }
+    if (host_umin_result != static_cast<unsigned int>(hostResults[25])) {
+        std::cout << "umin test failed - Host: " << host_umin_result << ", Device: " << static_cast<unsigned int>(hostResults[25]) << ", Diff: " << std::abs(static_cast<int>(host_umin_result - static_cast<unsigned int>(hostResults[25]))) << std::endl;
+        all_passed = false;
+    }
+    if (host_signbit_result != static_cast<int>(hostResults[26])) {
+        std::cout << "signbit test failed - Host: " << host_signbit_result << ", Device: " << static_cast<int>(hostResults[26]) << ", Diff: " << std::abs(host_signbit_result - static_cast<int>(hostResults[26])) << std::endl;
+        all_passed = false;
+    }
+    
+    if (all_passed) {
+        std::cout << "PASS: All host and device results match within epsilon!" << std::endl;
+    } else {
+        std::cout << "FAIL: Some tests failed. Check the output above for details." << std::endl;
+    }
+    
+    // Free device memory
+    hipFree(deviceResults);
+    
+    return 0;
+}


### PR DESCRIPTION
    Implement missing host math funcs
    
    * Compiling the bitode library to host code leads to linking errors
    some of the OpenCL natives being used in the library code are not
    available for the CPU, resulting in linking errors
    
    * OCML does not meant to be compiled in C++ mode
    for this, we create a drop-in opencl header defining the missing
    datatypes
    
    * Since OCML uses headers in the same directory as the source files,
    we must copy the necessary source files into a new directory so that
    our replacement headers get picked up instead of the originals
    
    * Implement a new header for mapping math funcs to host-side ocml
    
    * Discover an additional way to trigger 128 bit error
    
    * Discover a discrepancy in host and device func results