### PR TITLE
Adding runtime error conversion for Level0 backend

### DIFF
--- a/src/CHIPException.hh
+++ b/src/CHIPException.hh
@@ -36,7 +36,9 @@
 #include "hip/hip_runtime_api.h"
 #include "CHIPBindingsInternal.hh"
 #include "logging.hh"
+#include "ze_api.h"
 #include <string>
+#include <unordered_map>
 class CHIPError {
   std::string Msg_;
   hipError_t Err_;
@@ -49,6 +51,30 @@ public:
   std::string getMsgStr() { return Msg_.c_str(); }
   std::string getErrStr() { return std::string(hipGetErrorNameInternal(Err_)); }
 };
+
+typedef std::unordered_map<ze_result_t, hipError_t> ze_hip_error_map_t;
+
+// default table for ze to hip error conversion
+#define DEFAULT_ZE_HIP_ERROR_MAP ze_hip_error_map_t{}
+inline hipError_t default_ze_hip_error_convert(ze_result_t status) {
+  switch (status) {
+    case ZE_RESULT_ERROR_INVALID_MODULE_UNLINKED:
+      return hipErrorInvalidKernelFile;
+    default:
+      return hipErrorTbd;
+    // to be added
+  }
+}
+
+inline hipError_t hip_convert_error(ze_result_t status, ze_hip_error_map_t map) {
+  if (map.empty()) {
+    return default_ze_hip_error_convert(status);
+  }
+  if (map.find(status) != map.end()) {
+    return map[status];
+  }
+  return hipErrorTbd;
+}
 
 #define CHIPERR_LOG_AND_THROW(msg, errtype)                                    \
   do {                                                                         \
@@ -68,13 +94,25 @@ public:
     }                                                                          \
   } while (0)
 
+#define CHIPERR_CHECK_LOG_AND_THROW_TABLE(status, success,                     \
+                                          ze_errors_hip_errors_map, ...)       \
+do {                                                                           \
+  if (status != success) {                                                     \
+    hipError_t err = hip_convert_error(status, ze_errors_hip_errors_map);      \
+    std::string error_msg = std::string(resultToString(status));               \
+    std::string custom_msg = std::string(__VA_ARGS__);                         \
+    std::string msg_ = error_msg + " " + custom_msg;                           \
+    CHIPERR_LOG_AND_THROW(msg_, err);                                          \
+  }                                                                            \
+} while (0)
+
 #define CHIPERR_CHECK_LOG_AND_ABORT(status, success, errtype, ...)             \
   do {                                                                         \
     if (status != success) {                                                   \
       std::string error_msg = std::string(resultToString(status));             \
       std::string custom_msg = std::string(__VA_ARGS__);                       \
       std::string msg_ = error_msg + " " + custom_msg;                         \
-      std::cout << msg_ << std::endl;                                           \
+      std::cout << msg_ << std::endl;                                          \
       std::abort();                                                            \
     }                                                                          \
   } while (0)

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -22,6 +22,7 @@
 
 #include "CHIPBackendLevel0.hh"
 #include "Utils.hh"
+#include "zeHipErrorConversion.hh"
 
 // Auto-generated header that lives in <build-dir>/bitcode.
 #include "rtdevlib-modules.h"
@@ -2493,7 +2494,6 @@ void CHIPModuleLevel0::compile(chipstar::Device *ChipDev) {
       KernelDesc.flags |= ZE_KERNEL_FLAG_FORCE_RESIDENCY;
 
     Status = zeKernelCreate(ZeModule_, &KernelDesc, &ZeKernel);
-    //CHIPERR_CHECK_LOG_AND_THROW(Status, ZE_RESULT_SUCCESS, hipErrorTbd);
     CHIPERR_CHECK_LOG_AND_THROW_TABLE(Status, ZE_RESULT_SUCCESS, DEFAULT_ZE_HIP_ERROR_MAP);
     logTrace("LZ KERNEL CREATION via calling zeKernelCreate {} ", Status);
     CHIPKernelLevel0 *ChipZeKernel =

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -2494,7 +2494,8 @@ void CHIPModuleLevel0::compile(chipstar::Device *ChipDev) {
       KernelDesc.flags |= ZE_KERNEL_FLAG_FORCE_RESIDENCY;
 
     Status = zeKernelCreate(ZeModule_, &KernelDesc, &ZeKernel);
-    CHIPERR_CHECK_LOG_AND_THROW_TABLE(Status, ZE_RESULT_SUCCESS, DEFAULT_ZE_HIP_ERROR_MAP);
+    CHIPERR_CHECK_LOG_AND_THROW_TABLE(Status, ZE_RESULT_SUCCESS,
+                                      DEFAULT_ZE_HIP_ERROR_MAP);
     logTrace("LZ KERNEL CREATION via calling zeKernelCreate {} ", Status);
     CHIPKernelLevel0 *ChipZeKernel =
         new CHIPKernelLevel0(ZeKernel, LzDev, HostFName, FuncInfo, this);

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -2493,7 +2493,8 @@ void CHIPModuleLevel0::compile(chipstar::Device *ChipDev) {
       KernelDesc.flags |= ZE_KERNEL_FLAG_FORCE_RESIDENCY;
 
     Status = zeKernelCreate(ZeModule_, &KernelDesc, &ZeKernel);
-    CHIPERR_CHECK_LOG_AND_THROW(Status, ZE_RESULT_SUCCESS, hipErrorTbd);
+    //CHIPERR_CHECK_LOG_AND_THROW(Status, ZE_RESULT_SUCCESS, hipErrorTbd);
+    CHIPERR_CHECK_LOG_AND_THROW_TABLE(Status, ZE_RESULT_SUCCESS, DEFAULT_ZE_HIP_ERROR_MAP);
     logTrace("LZ KERNEL CREATION via calling zeKernelCreate {} ", Status);
     CHIPKernelLevel0 *ChipZeKernel =
         new CHIPKernelLevel0(ZeKernel, LzDev, HostFName, FuncInfo, this);

--- a/src/backend/Level0/zeHipErrorConversion.hh
+++ b/src/backend/Level0/zeHipErrorConversion.hh
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021-24 chipStar developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
 #ifndef ZE_HIP_ERROR_CONVERSION_HH
 #define ZE_HIP_ERROR_CONVERSION_HH
 

--- a/src/backend/Level0/zeHipErrorConversion.hh
+++ b/src/backend/Level0/zeHipErrorConversion.hh
@@ -1,0 +1,45 @@
+#ifndef ZE_HIP_ERROR_CONVERSION_HH
+#define ZE_HIP_ERROR_CONVERSION_HH
+
+#include "../../CHIPException.hh"
+#include "ze_api.h"
+#include <string>
+#include <unordered_map>
+
+typedef std::unordered_map<ze_result_t, hipError_t> ze_hip_error_map_t;
+
+// default table for ze to hip error conversion
+#define DEFAULT_ZE_HIP_ERROR_MAP ze_hip_error_map_t{}
+inline hipError_t default_ze_hip_error_convert(ze_result_t status) {
+  switch (status) {
+    case ZE_RESULT_ERROR_INVALID_MODULE_UNLINKED:
+      return hipErrorInvalidKernelFile;
+    default:
+      return hipErrorTbd;
+    // to be added
+  }
+}
+
+inline hipError_t hip_convert_error(ze_result_t status, ze_hip_error_map_t map) {
+  if (map.empty()) {
+    return default_ze_hip_error_convert(status);
+  }
+  if (map.find(status) != map.end()) {
+    return map[status];
+  }
+  return hipErrorTbd;
+}
+
+#define CHIPERR_CHECK_LOG_AND_THROW_TABLE(status, success,                     \
+                                          ze_errors_hip_errors_map, ...)       \
+do {                                                                           \
+  if (status != success) {                                                     \
+    hipError_t err = hip_convert_error(status, ze_errors_hip_errors_map);      \
+    std::string error_msg = std::string(resultToString(status));               \
+    std::string custom_msg = std::string(__VA_ARGS__);                         \
+    std::string msg_ = error_msg + " " + custom_msg;                           \
+    CHIPERR_LOG_AND_THROW(msg_, err);                                          \
+  }                                                                            \
+} while (0)
+
+#endif // ifdef guard

--- a/src/backend/Level0/zeHipErrorConversion.hh
+++ b/src/backend/Level0/zeHipErrorConversion.hh
@@ -6,40 +6,42 @@
 #include <string>
 #include <unordered_map>
 
-typedef std::unordered_map<ze_result_t, hipError_t> ze_hip_error_map_t;
+using ze_hip_error_map_t = std::unordered_map<ze_result_t, hipError_t>;
 
-// default table for ze to hip error conversion
-#define DEFAULT_ZE_HIP_ERROR_MAP ze_hip_error_map_t{}
-inline hipError_t default_ze_hip_error_convert(ze_result_t status) {
-  switch (status) {
-    case ZE_RESULT_ERROR_INVALID_MODULE_UNLINKED:
-      return hipErrorInvalidKernelFile;
-    default:
-      return hipErrorTbd;
-    // to be added
+// default table for ze to hip error conversion (empty map)
+#define DEFAULT_ZE_HIP_ERROR_MAP                                               \
+  ze_hip_error_map_t {}
+inline hipError_t default_ze_hip_error_convert(ze_result_t Status) {
+  switch (Status) {
+  case ZE_RESULT_ERROR_INVALID_MODULE_UNLINKED:
+    return hipErrorInvalidKernelFile;
+  default:
+    return hipErrorTbd;
   }
 }
 
-inline hipError_t hip_convert_error(ze_result_t status, ze_hip_error_map_t map) {
-  if (map.empty()) {
-    return default_ze_hip_error_convert(status);
+// function converting ze_result_t into hipError_t based on provided map
+inline hipError_t hip_convert_error(ze_result_t Status,
+                                    ze_hip_error_map_t Map) {
+  if (Map.empty()) {
+    return default_ze_hip_error_convert(Status);
   }
-  if (map.find(status) != map.end()) {
-    return map[status];
+  if (Map.find(Status) != Map.end()) {
+    return Map[Status];
   }
   return hipErrorTbd;
 }
 
 #define CHIPERR_CHECK_LOG_AND_THROW_TABLE(status, success,                     \
                                           ze_errors_hip_errors_map, ...)       \
-do {                                                                           \
-  if (status != success) {                                                     \
-    hipError_t err = hip_convert_error(status, ze_errors_hip_errors_map);      \
-    std::string error_msg = std::string(resultToString(status));               \
-    std::string custom_msg = std::string(__VA_ARGS__);                         \
-    std::string msg_ = error_msg + " " + custom_msg;                           \
-    CHIPERR_LOG_AND_THROW(msg_, err);                                          \
-  }                                                                            \
-} while (0)
+  do {                                                                         \
+    if (status != success) {                                                   \
+      hipError_t err = hip_convert_error(status, ze_errors_hip_errors_map);    \
+      std::string error_msg = std::string(resultToString(status));             \
+      std::string custom_msg = std::string(__VA_ARGS__);                       \
+      std::string msg_ = error_msg + " " + custom_msg;                         \
+      CHIPERR_LOG_AND_THROW(msg_, err);                                        \
+    }                                                                          \
+  } while (0)
 
 #endif // ifdef guard


### PR DESCRIPTION
The zeHipErrorConversion.hh header file was created to support ze_result_t to hipError_t runtime error conversion. The header file provides the following components:

(1) A type alias that defines  `ze_hip_error_map_t` type as an unordered_map that maps ze_result_t to hipError_t

(2) A macro, `CHIPERR_CHECK_LOG_AND_THROW_TABLE`, that does exactly what `CHIPERR_CHECK_LOG_AND_THROW` does, but instead of taking a specific errtype to throw, `CHIPERR_CHECK_LOG_AND_THROW_TABLE ` takes a map of type `ze_hip_error_map_t` and use it to convert ze_result_t to corresponding hipError_t. Either the default map (`DEFAULT_ZE_HIP_ERROR_MAP`) or a custom map can be used.
An example to create a custom map:
```
ze_hip_error_map_t myMap = {
    {SOME_ZE_RESULT_T, SOME_HIPERROR_T},
    {SOME_ZE_RESULT_T, SOME_HIPERROR_T}
};
```
(3) Functions used by the `CHIPERR_CHECK_LOG_AND_THROW_TABLE` macro to conduct actual conversions

*** Notes ***
Only one mapping is added to the default map for now, but this is expected to be expanded as we discover more appropriate conversions.