### PR TITLE
Fix 887

### DIFF
--- a/src/CHIPDriver.cc
+++ b/src/CHIPDriver.cc
@@ -125,6 +125,9 @@ void CHIPInitializeCallOnce() {
 
 extern void CHIPInitialize() {
   std::call_once(Initialized, &CHIPInitializeCallOnce);
+  if (!Backend)
+    CHIPERR_LOG_AND_THROW("Backend not initialized",
+                          hipErrorInitializationError);
 }
 
 void CHIPUninitializeCallOnce() {

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -108,3 +108,4 @@ add_hip_runtime_test(TestPositiveHasNoIGBAs.hip)
 
 add_hip_runtime_test(CatchMemLeak1.hip)
 add_hip_runtime_test(TestBufferDevAddr.hip)
+add_hip_runtime_test(Test887.hip)

--- a/tests/runtime/Test887.hip
+++ b/tests/runtime/Test887.hip
@@ -1,0 +1,28 @@
+#include <cstdio>
+#include <hip/hip_runtime.h>
+
+class Test {
+public:
+  float *output;
+  Test();
+  ~Test();
+};
+
+// Constructor
+Test::Test() {
+  output = NULL;
+  hipMalloc(&output, sizeof(float) * 100);
+}
+
+// Destructor
+Test::~Test() {
+  printf("destructor called\n");
+  hipFree(output);
+}
+
+Test test = Test();
+
+int main() {
+  printf("testing\n");
+  return 0;
+}


### PR DESCRIPTION
Once main thread exists `main()`, all HIP calls should have already been completed. It is up to the user to make sure that happens. When does doesn't happen, we should handle such case gracefully. 

Every HIP API call starts with `CHIPInitialize`. Check if backend has already been destroyed and if so, return error. 
Fixes https://github.com/CHIP-SPV/chipStar/issues/887 
