### PR TITLE
Make adjustments for LLVM-19

### DIFF
--- a/.github/workflows/check-unit-tests-intel.yml
+++ b/.github/workflows/check-unit-tests-intel.yml
@@ -77,3 +77,25 @@ jobs:
       - name: Run unit test checking script
         run: ./scripts/unit_tests.sh release llvm-18
         shell: bash
+  unit-tests-llvm-19-debug:
+    runs-on: X64
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          submodules: 'recursive'
+      - name: Run unit test checking script
+        run: ./scripts/unit_tests.sh debug llvm-19
+        shell: bash
+  unit-tests-llvm-19-release:
+    runs-on: X64
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          submodules: 'recursive'
+      - name: Run unit test checking script
+        run: ./scripts/unit_tests.sh release llvm-19
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For this you can use a script included in the chipStar repository:
 ```bash
 ./scripts/configure_llvm.sh
 Usage: ./configure_llvm.sh --version <version> --install-dir <dir> --link-type static(default)/dynamic --only-necessary-spirv-exts <on|off> --binutils-header-location <path>
---version: LLVM version 15, 16, 17, 18
+--version: LLVM version 15, 16, 17, 18, 19
 --install-dir: installation directory
 --link-type: static or dynamic (default: static)
 --only-necessary-spirv-exts: on or off (default: off)

--- a/cmake/FindLLVM.cmake
+++ b/cmake/FindLLVM.cmake
@@ -41,10 +41,6 @@ else() # if it was not defined, look for it
 endif()
 message(STATUS "Using llvm-config: ${LLVM_CONFIG_BIN}")
 
-get_filename_component(LLVM_CONFIG_BINARY_NAME ${LLVM_CONFIG_BIN} NAME)
-get_filename_component(LLVM_CONFIG_DIR ${LLVM_CONFIG_BIN} DIRECTORY)
-string(REGEX MATCH "[0-9]+" LLVM_VERSION_MAJOR "${LLVM_CONFIG_BINARY_NAME}")
-
 execute_process(COMMAND "${LLVM_CONFIG_BIN}" "--obj-root"
   RESULT_VARIABLE RES
   OUTPUT_VARIABLE CLANG_ROOT_PATH
@@ -57,6 +53,7 @@ execute_process(COMMAND "${LLVM_CONFIG_BIN}" "--version"
   OUTPUT_VARIABLE LLVM_VERSION
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 message(STATUS "Using LLVM_VERSION: ${LLVM_VERSION}")
+string(REGEX MATCH "[0-9]+" LLVM_VERSION_MAJOR "${LLVM_VERSION}")
 
 # Check if the LLVM_INCLUDE_DIR is already cached
 if(NOT LLVM_INCLUDE_DIRS)
@@ -105,8 +102,10 @@ if(NOT DEFINED LLVM_LINK)
 endif()
 message(STATUS "Using llvm-link: ${LLVM_LINK}")
 
+message(STATUS "XXX LLVM-version-major: ${LLVM_VERSION_MAJOR}") # DEBUG
+
 if(NOT DEFINED LLVM_SPIRV)
-  find_program(LLVM_SPIRV NAMES llvm-spirv llvm-spirv-${LLVM_VERSION_MAJOR} FIND_TARGET NO_DEFAULT_PATH PATHS ${CLANG_ROOT_PATH_BIN} ENV PATH)
+  find_program(LLVM_SPIRV NAMES llvm-spirv-${LLVM_VERSION_MAJOR} llvm-spirv FIND_TARGET NO_DEFAULT_PATH PATHS ${CLANG_ROOT_PATH_BIN} ENV PATH)
   if(NOT LLVM_SPIRV)
     message(FATAL_ERROR "Can't find llvm-spirv. Please provide CMake argument -DLLVM_SPIRV=/path/to/llvm-spirv<-version>")
   endif()

--- a/llvm_passes/HipAbort.cpp
+++ b/llvm_passes/HipAbort.cpp
@@ -48,6 +48,8 @@
 
 #include "../src/common.hh"
 
+#include "llvm/IR/Module.h"
+
 #include <set>
 #include <iostream>
 

--- a/llvm_passes/HipEmitLoweredNames.cpp
+++ b/llvm_passes/HipEmitLoweredNames.cpp
@@ -29,6 +29,7 @@
 
 #include "HipEmitLoweredNames.h"
 
+#include "llvm/IR/Module.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Support/CommandLine.h"

--- a/llvm_passes/HipGlobalVariables.cpp
+++ b/llvm_passes/HipGlobalVariables.cpp
@@ -45,6 +45,7 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
 
@@ -308,7 +309,11 @@ static void emitGlobalVarInitShadowKernel(Module &M, GlobalVariable *GVar,
 static bool shouldLower(const GlobalVariable &GVar) {
   if (!GVar.hasName()) return false;
 
+#if LLVM_VERSION_MAJOR < 19
   if (GVar.getName().startswith(ChipVarPrefix))
+#else
+  if (GVar.getName().starts_with(ChipVarPrefix))
+#endif
     return false;  // Already lowered.
 
   // All host accessible global device variables are marked to be externally

--- a/llvm_passes/HipIGBADetector.cpp
+++ b/llvm_passes/HipIGBADetector.cpp
@@ -39,6 +39,7 @@
 
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instructions.h>
+#include "llvm/IR/Module.h"
 #include <llvm/Passes/PassBuilder.h>
 #include <llvm/Passes/PassPlugin.h>
 

--- a/llvm_passes/HipKernelArgSpiller.cpp
+++ b/llvm_passes/HipKernelArgSpiller.cpp
@@ -49,6 +49,7 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Module.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Support/CommandLine.h"
@@ -107,7 +108,11 @@ bool isSpecial(const Argument &Arg) {
   // Only consider OpenCL and SPIR-V types - leave user defined opaque
   // structures alone (they are just plain pointers).
   StringRef Name = STy->getName();
+#if LLVM_VERSION_MAJOR < 19
   return (Name.startswith("opencl.") || Name.startswith("__spirv_"));
+#else
+  return (Name.starts_with("opencl.") || Name.starts_with("__spirv_"));
+#endif
 #endif
 }
 

--- a/llvm_passes/HipLowerZeroLengthArrays.cpp
+++ b/llvm_passes/HipLowerZeroLengthArrays.cpp
@@ -17,6 +17,7 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Module.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Support/CommandLine.h"

--- a/llvm_passes/HipPasses.cpp
+++ b/llvm_passes/HipPasses.cpp
@@ -30,6 +30,7 @@
 #include "HipLowerMemset.h"
 #include "HipIGBADetector.h"
 
+#include "llvm/IR/Module.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Transforms/IPO/Inliner.h"

--- a/llvm_passes/HipPrintf.cpp
+++ b/llvm_passes/HipPrintf.cpp
@@ -50,6 +50,7 @@
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
 #include "llvm/Pass.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"

--- a/llvm_passes/HipSanityChecks.cpp
+++ b/llvm_passes/HipSanityChecks.cpp
@@ -13,7 +13,9 @@
 #include "HipSanityChecks.h"
 
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
 #include "llvm/ADT/BitVector.h"
+#include "llvm/Support/Debug.h"
 
 using namespace llvm;
 
@@ -78,7 +80,11 @@ static void checkCallInst(CallInst *CI, BitVector &CaughtChecks) {
     const auto &Name = Callee->getName();
     // Catch use of unexpected atomic built-ins. All HIP atomic operations
     // should be mapped to corresponding OpenCL built-ins.
+#if LLVM_VERSION_MAJOR < 19
     if (Name.startswith("__atomic_") || Name.startswith("__hip_atomic_")) {
+#else
+    if (Name.starts_with("__atomic_") || Name.starts_with("__hip_atomic_")) {
+#endif
       dbgs() << "Warning: Use of unsupported built-in atomic function: "
              << Callee->getName() << "\n";
 

--- a/llvm_passes/HipStripUsedIntrinsics.cpp
+++ b/llvm_passes/HipStripUsedIntrinsics.cpp
@@ -23,6 +23,7 @@
 
 #include "HipStripUsedIntrinsics.h"
 
+#include "llvm/IR/Module.h"
 #if LLVM_VERSION_MAJOR >= 14
 #include "llvm/Pass.h"
 #endif

--- a/llvm_passes/HipTextureLowering.cpp
+++ b/llvm_passes/HipTextureLowering.cpp
@@ -22,6 +22,7 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Support/Compiler.h"

--- a/llvm_passes/HipWarps.cpp
+++ b/llvm_passes/HipWarps.cpp
@@ -25,6 +25,7 @@
 #include "HipWarps.h"
 
 #include <llvm/IR/Metadata.h>
+#include "llvm/IR/Module.h"
 #include <llvm/IR/Constants.h>
 
 #include "chipStarConfig.hh"

--- a/llvm_passes/SPIRVImageType.cc
+++ b/llvm_passes/SPIRVImageType.cc
@@ -31,6 +31,7 @@ llvm::Type *getSPIRVImageType(llvm::LLVMContext &Ctx, llvm::StringRef BaseType,
 
   // Choose the dimension of the image--this corresponds to the Dim enum in
   // SPIR-V (first integer parameter of OpTypeImage).
+#if LLVM_VERSION_MAJOR < 19
   if (OpenCLName.startswith("image2d"))
     IntParams[0] = 1; // 1D
   else if (OpenCLName.startswith("image3d"))
@@ -39,6 +40,16 @@ llvm::Type *getSPIRVImageType(llvm::LLVMContext &Ctx, llvm::StringRef BaseType,
     IntParams[0] = 5; // Buffer
   else
     assert(OpenCLName.startswith("image1d") && "Unknown image type");
+#else
+  if (OpenCLName.starts_with("image2d"))
+    IntParams[0] = 1; // 1D
+  else if (OpenCLName.starts_with("image3d"))
+    IntParams[0] = 2; // 2D
+  else if (OpenCLName == "image1d_buffer")
+    IntParams[0] = 5; // Buffer
+  else
+    assert(OpenCLName.starts_with("image1d") && "Unknown image type");
+#endif
 
   // Set the other integer parameters of OpTypeImage if necessary. Note that the
   // OpenCL image types don't provide any information for the Sampled or

--- a/scripts/configure_llvm.sh
+++ b/scripts/configure_llvm.sh
@@ -41,7 +41,7 @@ done
 # check mandatory argument version
 if [ -z "$VERSION" ]; then
   echo "Usage: $0 --version <version> --install-dir <dir> --link-type static(default)/dynamic --only-necessary-spirv-exts <on|off> --binutils-header-location <path>"
-  echo "--version: LLVM version 15, 16, 17, 18"
+  echo "--version: LLVM version 15, 16, 17, 18, 19"
   echo "--install-dir: installation directory"
   echo "--link-type: static or dynamic (default: static)"
   echo "--only-necessary-spirv-exts: on or off (default: off)"
@@ -55,8 +55,9 @@ if [ -z "$INSTALL_DIR" ]; then
 fi
 
 # validate version argument
-if [ "$VERSION" != "15" ] && [ "$VERSION" != "16" ] && [ "$VERSION" != "17" ] && [ "$VERSION" != "18" ]; then
-  echo "Invalid version. Must be 15, 16, 17 or 18."
+if [ "$VERSION" != "15" ] && [ "$VERSION" != "16" ] && [ "$VERSION" != "17" ] \
+       && [ "$VERSION" != "18" ] && [ "$VERSION" != "19" ]; then
+  echo "Invalid version. Must be 15, 16, 17, 18 or 19."
   exit 1
 fi
 

--- a/scripts/configure_llvm.sh
+++ b/scripts/configure_llvm.sh
@@ -182,8 +182,6 @@ if [ "$LINK_TYPE" == "static" ]; then
     -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="SPIRV" \
     -DCMAKE_CXX_COMPILER=g++ \
     -DCMAKE_C_COMPILER=gcc \
-    -DGCC_INSTALL_PREFIX=${gcc_base_path}\
-    -DCMAKE_CXX_LINK_FLAGS="-Wl,-rpath,${gcc_base_path}/lib64 -L${gcc_base_path}/lib64" \
     -DLLVM_ENABLE_ASSERTIONS=On \
     -DLLVM_BINUTILS_INCDIR=${BINUTILS_HEADER_DIR}
 elif [ "$LINK_TYPE" == "dynamic" ]; then
@@ -199,8 +197,6 @@ elif [ "$LINK_TYPE" == "dynamic" ]; then
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_CXX_COMPILER=g++ \
     -DCMAKE_C_COMPILER=gcc \
-    -DGCC_INSTALL_PREFIX=${gcc_base_path}\
-    -DCMAKE_CXX_LINK_FLAGS="-Wl,-rpath,${gcc_base_path}/lib64 -L${gcc_base_path}/lib64" \
     -DLLVM_BINUTILS_INCDIR=${BINUTILS_HEADER_DIR} \
     -DLLVM_ENABLE_ASSERTIONS=On
 else

--- a/scripts/unit_tests.sh
+++ b/scripts/unit_tests.sh
@@ -18,7 +18,7 @@ timeout=1800
 
 # Check if at least one argument is provided
 if [ "$#" -lt 2 ]; then
-  echo "Usage: $0 <debug|release> <llvm-15|llvm-16|llvm-17|llvm-18> [--skip-build] [--num-tries=$num_tries] [--num-threads=$num_threads] [--timeout=$timeout]"
+  echo "Usage: $0 <debug|release> <llvm-16|llvm-17|llvm-18|llvm-19> [--skip-build] [--num-tries=$num_tries] [--num-threads=$num_threads] [--timeout=$timeout]"
   exit 1
 fi
 
@@ -32,8 +32,8 @@ fi
 build_type=$(echo "$1" | tr '[:lower:]' '[:upper:]')
 
 # Check if the second argument starts with "llvm-" and is followed by a valid version number
-if [[ ! "$2" =~ ^llvm-(1[5-9]|[2-9][0-9])$ ]]; then
-  echo "Error: Invalid LLVM version. Must be llvm-15, llvm-16, llvm-17, llvm-18, or higher."
+if [[ ! "$2" =~ ^llvm-(1[6-9]|[2-9][0-9])$ ]]; then
+  echo "Error: Invalid LLVM version. Must be llvm-16, llvm-17, llvm-18, or higher."
   exit 1
 fi
 


### PR DESCRIPTION
* Fixed LLVM passes for LLVM-19.

* Changed chipStar configuration to prefer llvm-spirv with version suffix which matches to the chosen LLVM (e.g. `llvm-spirv-19`).

* Update README and scripts/configure_llvm.sh.

* New in clang-19: clang's SPIR-V and HIPSPV toolchain picks `llvm-spirv-XX` (when found in PATH or installed alongside the clang binary) where XX matches to the clang's major version. This should resolve the llvm-spirv issue reported in #824.

TODOs before the PR is ready for landing:

- [X] Make chipStar forks for LLVM 19.
- [x] Wait until https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/2657 lands and is backported to `llvm_release_190`.