### PR TITLE
skip kernel annotation on CPU

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -28,7 +28,6 @@ jobs:
 
   push:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: build
     runs-on: [self-hosted, Linux, X64]
     steps:
     - uses: actions/checkout@v3
@@ -49,7 +48,7 @@ jobs:
     
   
   cleanup:
-    needs: [build, push]
+    needs: [push]
     runs-on: [self-hosted, Linux, X64]
     steps:
     - name: Clean up old Docker images

--- a/scripts/unit_tests.sh
+++ b/scripts/unit_tests.sh
@@ -172,9 +172,11 @@ run_tests() {
 function check_tests {
   file="$1"
   if ! grep -q "The following tests FAILED" "$file"; then
+    echo "PASSED"
     return 0
   else
     grep -q -E "The following tests FAILED:" -A 1000 "$file" | sed '/^$/q' | tail -n +2
+    echo "FAILED"
     return 1
   fi
 }
@@ -193,5 +195,7 @@ run_tests dgpu level0
 dgpu_level0_result=$(check_tests dgpu_level0_make_check_result.txt)
 run_tests dgpu opencl
 dgpu_opencl_result=$(check_tests dgpu_opencl_make_check_result.txt)
+run_tests cpu opencl
+cpu_opencl_result=$(check_tests cpu_opencl_make_check_result.txt)
+exit $((igpu_opencl_result || dgpu_opencl_result || igpu_level0_result || dgpu_level0_result || cpu_opencl_result))
 
-exit $((igpu_opencl_result || dgpu_opencl_result || igpu_level0_result || dgpu_level0_result))

--- a/scripts/unit_tests.sh
+++ b/scripts/unit_tests.sh
@@ -172,11 +172,9 @@ run_tests() {
 function check_tests {
   file="$1"
   if ! grep -q "The following tests FAILED" "$file"; then
-    echo "PASSED"
     return 0
   else
-    grep -q -E "The following tests FAILED:" -A 1000 "$file" | sed '/^$/q' | tail -n +2
-    echo "FAILED"
+    grep -E "The following tests FAILED:" -A 1000 "$file" | sed '/^$/q' | tail -n +2
     return 1
   fi
 }
@@ -185,17 +183,25 @@ set +e # disable exit on error
 
 # Run tests for different configurations
 run_tests igpu opencl
-igpu_opencl_result=$(check_tests igpu_opencl_make_check_result.txt)
 if [ "$host" = "salami" ]; then
-  exit $igpu_opencl_result
+  check_tests igpu_opencl_make_check_result.txt
+  igpu_opencl_exit_code=$?
+  exit $igpu_opencl_exit_code
 fi
 run_tests igpu level0
-igpu_level0_result=$(check_tests igpu_level0_make_check_result.txt)
 run_tests dgpu level0
-dgpu_level0_result=$(check_tests dgpu_level0_make_check_result.txt)
 run_tests dgpu opencl
-dgpu_opencl_result=$(check_tests dgpu_opencl_make_check_result.txt)
 run_tests cpu opencl
-cpu_opencl_result=$(check_tests cpu_opencl_make_check_result.txt)
-exit $((igpu_opencl_result || dgpu_opencl_result || igpu_level0_result || dgpu_level0_result || cpu_opencl_result))
 
+check_tests igpu_opencl_make_check_result.txt
+igpu_opencl_exit_code=$?
+check_tests cpu_opencl_make_check_result.txt
+cpu_opencl_exit_code=$?
+check_tests dgpu_opencl_make_check_result.txt
+dgpu_opencl_exit_code=$?
+check_tests dgpu_level0_make_check_result.txt
+dgpu_level0_exit_code=$?
+check_tests igpu_level0_make_check_result.txt
+igpu_level0_exit_code=$?
+
+exit $((igpu_opencl_exit_code || dgpu_opencl_exit_code || igpu_level0_exit_code || dgpu_level0_exit_code || cpu_opencl_exit_code))

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -412,6 +412,7 @@ ANY:
     CatchMemLeak1: ''
     hipMemset_Unit_hipMemsetAsync_SetMemoryWithOffset_Helgrind: 'False positives from L0 helper thread'
   OPENCL_CPU:
+    hipBlas-sgemm: 'GEMM SYCL exception: Backends mismatch'
     2d_shuffle: ''
     Unit_hipClassKernel_Value: ''
     Unit_hipMemsetFunctional_PartialSet_1D: ''
@@ -419,6 +420,12 @@ ANY:
     hipConstantTestDeviceSymbol: ''
     hipDynamicShared2: ''
     unroll: ''
+    Unit_hipMemsetAsync_VerifyExecutionWithKernel: 'Failed'
+    Unit_hipDeviceSynchronize_Functional: 'Failed'
+    Unit_hipTextureObj1DCheckRGBAModes - array: 'Timeout'
+    Unit_hipTextureObj1DCheckRGBAModes - buffer: 'Timeout'
+    Unit_hipTextureObj2DCheckRGBAModes: 'Failed'
+    hipMemset_Unit_hipMemsetAsync_SetMemoryWithOffset_Helgrind: 'Failed'
   OPENCL_GPU:
     Unit_hipEvent: ''
     TestStlFunctionsDouble: ''

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -482,6 +482,15 @@ cupcake:
   OPENCL_CPU:
   OPENCL_GPU:
   OPENCL_POCL:
+meatloaf:
+  ALL:
+    Unit_hipMultiStream_sameDevice: 'Started randomly failing on CI node with CL_OUT_OF_RESOURCES'
+    Unit_hipStreamCreate_MultistreamBasicFunctionalities: 'Started randomly failing on CI node with CL_OUT_OF_RESOURCES'
+    Unit_hipDeviceSynchronize_Functional: 'Started randomly failing on CI node with CL_OUT_OF_RESOURCES'
+  LEVEL0_GPU:
+  OPENCL_CPU:
+  OPENCL_GPU:
+  OPENCL_POCL:
 salami:
   ALL:
   LEVEL0_GPU:


### PR DESCRIPTION
Fixes #859

* Kernel annotation is skipped - seems like an OpenCL CPU runtime issue
https://community.intel.com/t5/OpenCL-for-CPU/OpenCL-Using-USM-on-Intel-CPU-Runtime-along-with/m-p/1621136#M7350
https://github.com/intel/compute-runtime/issues/748
* Remove LLVM15 Testing from CI
* Re-enable OpenCL CPU CI