### PR TITLE
Properly annotate Intel USM kernels

### DIFF
--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -284,15 +284,24 @@ annotateIndirectPointers(const CHIPContextOpenCL &Ctx,
 
     if (Ctx.getAllocStrategy() == AllocationStrategy::IntelUSM) {
       cl_bool param = CL_TRUE;
-      clStatus = clSetKernelExecInfo(KernelAPIHandle, CL_KERNEL_EXEC_INFO_INDIRECT_HOST_ACCESS_INTEL,
-                                     sizeof(cl_bool), &param);
-      CHIPERR_CHECK_LOG_AND_THROW_TABLE(clSetKernelExecInfo);
-      clStatus = clSetKernelExecInfo(KernelAPIHandle, CL_KERNEL_EXEC_INFO_INDIRECT_DEVICE_ACCESS_INTEL,
-                                     sizeof(cl_bool), &param);
-      CHIPERR_CHECK_LOG_AND_THROW_TABLE(clSetKernelExecInfo);
-      clStatus = clSetKernelExecInfo(KernelAPIHandle, CL_KERNEL_EXEC_INFO_INDIRECT_SHARED_ACCESS_INTEL,
-                                     sizeof(cl_bool), &param);
-      CHIPERR_CHECK_LOG_AND_THROW_TABLE(clSetKernelExecInfo); 
+      if (Ctx.MemManager_.isHostAllocUsed()) {
+        clStatus = clSetKernelExecInfo(
+            KernelAPIHandle, CL_KERNEL_EXEC_INFO_INDIRECT_HOST_ACCESS_INTEL,
+            sizeof(cl_bool), &param);
+        CHIPERR_CHECK_LOG_AND_THROW_TABLE(clSetKernelExecInfo);
+      }
+      if (Ctx.MemManager_.isDeviceAllocUsed()) {
+        clStatus = clSetKernelExecInfo(
+            KernelAPIHandle, CL_KERNEL_EXEC_INFO_INDIRECT_DEVICE_ACCESS_INTEL,
+            sizeof(cl_bool), &param);
+        CHIPERR_CHECK_LOG_AND_THROW_TABLE(clSetKernelExecInfo);
+      }
+      if (Ctx.MemManager_.isSharedAllocUsed()) {
+        clStatus = clSetKernelExecInfo(
+            KernelAPIHandle, CL_KERNEL_EXEC_INFO_INDIRECT_SHARED_ACCESS_INTEL,
+            sizeof(cl_bool), &param);
+        CHIPERR_CHECK_LOG_AND_THROW_TABLE(clSetKernelExecInfo);
+      }
     }
   }
 

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -188,6 +188,11 @@ private:
   /// The allocation strategy to use.
   AllocationStrategy AllocStrategy_;
 
+  // Add these three bools
+  bool hostAllocUsed;
+  bool deviceAllocUsed;
+  bool sharedAllocUsed;
+
 public:
   void init(CHIPContextOpenCL *ChipCtxCl);
   MemoryManager &operator=(MemoryManager &&Rhs);
@@ -211,6 +216,11 @@ public:
   AllocationStrategy getAllocStrategy() const noexcept {
     return AllocStrategy_;
   }
+
+  // Add getter methods for the new bools
+  bool isHostAllocUsed() const { return hostAllocUsed; }
+  bool isDeviceAllocUsed() const { return deviceAllocUsed; }
+  bool isSharedAllocUsed() const { return sharedAllocUsed; }
 
   std::pair<cl_mem, size_t> translateDevPtrToBuffer(const void *DevPtr) const;
 

--- a/src/backend/OpenCL/MemoryManager.cc
+++ b/src/backend/OpenCL/MemoryManager.cc
@@ -106,6 +106,11 @@ void MemoryManager::init(CHIPContextOpenCL *ChipCtxCl_) {
   } else {
     std::memset(&USM_, 0, sizeof(USM_));
   }
+
+  // Initialize the allocation usage bools
+  hostAllocUsed = false;
+  deviceAllocUsed = false;
+  sharedAllocUsed = false;
 }
 
 MemoryManager &MemoryManager::operator=(MemoryManager &&Rhs) {
@@ -241,6 +246,25 @@ void *MemoryManager::allocate(size_t Size, size_t Alignment,
   logTrace("Memory allocated: {} / {}\n", Ptr.get(), Size);
   assert(Allocations_.find(Ptr) == Allocations_.end());
   Allocations_.emplace(Ptr, Size);
+
+  // Set the appropriate bool based on the MemType
+  switch (MemType) {
+  case hipMemoryTypeHost:
+    hostAllocUsed = true;
+    break;
+  case hipMemoryTypeDevice:
+    deviceAllocUsed = true;
+    break;
+  case hipMemoryTypeManaged:
+  case hipMemoryTypeUnified:
+    sharedAllocUsed = true;
+    break;
+  default:
+    // Handle unexpected memory type
+    assert(!"Unexpected memory type!");
+    break;
+  }
+
   return Ptr.get();
 }
 

--- a/src/backend/OpenCL/clHipErrorConversion.hh
+++ b/src/backend/OpenCL/clHipErrorConversion.hh
@@ -94,7 +94,8 @@ const std::unordered_map<void *, cl_hip_error_map_t> CL_HIP_ERROR_MAPS = {
       {CL_OUT_OF_RESOURCES, hipErrorOutOfMemory},
       {CL_MEM_OBJECT_ALLOCATION_FAILURE, hipErrorOutOfMemory},
       {CL_INVALID_EVENT_WAIT_LIST, hipErrorInvalidResourceHandle},
-      {CL_OUT_OF_HOST_MEMORY, hipErrorOutOfMemory}}},
+      {CL_OUT_OF_HOST_MEMORY, hipErrorOutOfMemory},
+      {CL_INVALID_OPERATION, hipErrorInvalidValue}}},
 
     {(void *)&clEnqueueReadBuffer,
      {{CL_SUCCESS, hipSuccess},
@@ -445,11 +446,6 @@ const std::unordered_map<void *, cl_hip_error_map_t> CL_HIP_ERROR_MAPS = {
      {{CL_SUCCESS, hipSuccess},
       {CL_INVALID_COMMAND_QUEUE, hipErrorInvalidResourceHandle},
       {CL_INVALID_EVENT_WAIT_LIST, hipErrorInvalidResourceHandle},
-      {CL_OUT_OF_HOST_MEMORY, hipErrorOutOfMemory}}},
-
-    {(void *)&clGetPlatformIDs,
-     {{CL_SUCCESS, hipSuccess},
-      {CL_INVALID_VALUE, hipErrorInvalidValue},
       {CL_OUT_OF_HOST_MEMORY, hipErrorOutOfMemory}}},
 
     {(void *)&clCreateProgramWithIL,


### PR DESCRIPTION
Once kernels are annotated with `CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL`, they need to be annotated with `CL_KERNEL_EXEC_INFO_INDIRECT_DEVICE_ACCESS_INTEL`, if the arguments inside the kernel which might see indirect access are allocated as `device`. If multiple types of allocations are used we have to have multiple calls to `clSetKernelExecInfo`.Optimally, we would inspect the kernel to figure out exactly what kind of allocations have been used but with indirect access it's complicated. 