### PR TITLE
ChipStar-1.2-rc1 fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,13 @@
 #
 # =============================================================================
 
+execute_process(
+  COMMAND uname -m
+  OUTPUT_VARIABLE DETECTED_ARCHITECTURE
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+message(STATUS "Detected architecture: ${DETECTED_ARCHITECTURE}")
+
 # temporary
 add_compile_options(-Wno-format-extra-args)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,21 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-duplicate-decl-specifier \
 -Wno-tautological-constant-compare  -Wno-c++20-extensions -Wno-unused-result \
 -Wno-delete-abstract-non-virtual-dtor -Wno-deprecated-declarations -Wunused-command-line-argument -gdwarf-4")
 
+# Find GCC installation path
+execute_process(
+  COMMAND which gcc
+  OUTPUT_VARIABLE GCC_PATH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Extract the base path (removing /bin/gcc from the end)
+get_filename_component(GCC_BASE_PATH ${GCC_PATH} DIRECTORY)
+get_filename_component(GCC_BASE_PATH ${GCC_BASE_PATH} DIRECTORY)
+
+message(STATUS "GCC base path: ${GCC_BASE_PATH}")
+# Necessary on some systems with nonstandard GCC installations
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --gcc-toolchain=${GCC_BASE_PATH}")
+
 # end temporary
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ CHIP_LOGLEVEL=<trace/debug/info/warn/err/crit>  # Sets the log level. If compile
 CHIP_DUMP_SPIRV=<ON/OFF(default)>               # Dumps the generated SPIR-V code to a file
 CHIP_JIT_FLAGS_OVERRIDE=<flags>                 # String to override the default JIT flags. Defaults to -cl-kernel-arg-info -cl-std=CL3.0
 CHIP_L0_COLLECT_EVENTS_TIMEOUT=<N(30s default)> # Timeout in seconds for collecting Level Zero events
+CHIP_L0_EVENT_TIMEOUT=<N(0 default)             # Timeout in seconds for how long Level Zero should wait on an event before timing out
 CHIP_SKIP_UNINIT=<ON/OFF(default)>              # If enabled, skips the uninitialization of chipStar's backend objects at program termination
 ```
 

--- a/bin/cucc.py
+++ b/bin/cucc.py
@@ -26,13 +26,12 @@
 #=============================================================================
 """Compiler wrapper aiming to be a drop-in replacement for nvcc."""
 # Enable v3.9+ type annotations in older versions (down to 3.7).
-from __future__ import annotations
 import argparse
 import os
 import subprocess
 import sys
 from shlex import quote
-
+from typing import List, Set, Optional
 
 # If true, we change the behavior of this tool so that the CMake
 # considers this tool to be NVvidia's nvcc. This allows us to compile
@@ -165,7 +164,7 @@ def get_cuda_library_dir() -> str:
     """
     return get_hip_path() + "/lib"
 
-def determine_input_languages(arg_list : list[str], xmode=None) -> set[str]:
+def determine_input_languages(arg_list: List[str], xmode: Optional[str] = None) -> Set[str]:
     """Determine input language modes from the argument list
 
     The 'xmode' specifies value of the last '-x' option if it was specified.
@@ -201,7 +200,7 @@ def determine_input_languages(arg_list : list[str], xmode=None) -> set[str]:
 
     return modes
 
-def filter_args_for_hipcc(arg_list : list[str]) -> list[str]:
+def filter_args_for_hipcc(arg_list: List[str]) -> List[str]:
     """Filter out arguments on the way to hipcc.
     """
     filtered = []

--- a/cmake/FindLLVM.cmake
+++ b/cmake/FindLLVM.cmake
@@ -109,6 +109,11 @@ if(NOT DEFINED LLVM_SPIRV)
   if(NOT LLVM_SPIRV)
     message(FATAL_ERROR "Can't find llvm-spirv. Please provide CMake argument -DLLVM_SPIRV=/path/to/llvm-spirv<-version>")
   endif()
+else()
+  # Check if the provided LLVM_SPIRV file exists
+  if(NOT EXISTS ${LLVM_SPIRV})
+    message(FATAL_ERROR "Provided LLVM_SPIRV (${LLVM_SPIRV}) does not exist")
+  endif()
 endif()
 message(STATUS "Using llvm-spirv: ${LLVM_SPIRV}")
 

--- a/docker/DockerfileBase
+++ b/docker/DockerfileBase
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/docker/DockerfileBase
+++ b/docker/DockerfileBase
@@ -1,19 +1,22 @@
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
 SHELL ["/bin/bash", "-ci"]
 
+# Set timezone non-interactively
+ENV TZ=Etc/UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 # Get the basic stuff and create chipStarUser user with sudo privileges
 RUN apt-get update && \
-    apt-get -y upgrade && \
-    apt-get install -y sudo; \
+    apt-get install -y sudo tzdata && \
     useradd -ms /bin/bash chipStarUser && \
     groupadd -f video && groupadd -f render && \
     usermod -aG sudo,video,render chipStarUser; \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-# Set as default user
+
 USER chipStarUser
 WORKDIR /home/chipStarUser
 
@@ -113,7 +116,8 @@ RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -
 # Set up conda environment
 ENV PATH="/apps/conda/bin:${PATH}"
 RUN conda init bash && \
-    conda config --add channels intel && \
+    conda config --add channels https://software.repos.intel.com/python/conda/ && \
+    conda config --add channels conda-forge && \
     conda create -n oneapi-2024.1.0 -y
 
 # Install OneAPI packages
@@ -139,24 +143,36 @@ RUN conda run -n oneapi-2024.1.0 conda install -y \
     onemkl-sycl-sparse=2024.1.0=intel_691 \
     onemkl-sycl-stats=2024.1.0=intel_691 \
     onemkl-sycl-vm=2024.1.0=intel_691 \
-    tbb=2021.12.0=intel_495 \
-    level-zero=1.17.6
+    tbb=2021.12.0=intel_495
 
-# RUN conda config --add channels conda-forge && conda run -n oneapi-2024.1.0 conda install -y intel-compute-runtime
-RUN sudo apt install -y intel-opencl-icd vim
+USER root
+# Install level-zero and other dependencies
+RUN sudo apt-get update && \
+    sudo apt-get install -y intel-opencl-icd vim
 
-# Install Level Zero headers system-wide
-RUN mkdir -p /tmp/level-zero-headers && \
-    cd /tmp/level-zero-headers && \
-    git clone https://github.com/oneapi-src/level-zero.git && \
+# Install dependencies for building Level Zero
+RUN apt-get update && apt-get install -y \
+    cmake \
+    pkg-config \
+    build-essential \
+    git
+
+# Clone, build, and install Level Zero
+RUN git clone https://github.com/oneapi-src/level-zero.git && \
     cd level-zero && \
     mkdir build && \
     cd build && \
     cmake .. && \
-    make -j && \
-    sudo make install && \
-    cd ~/ && \
-    rm -rf /tmp/level-zero-headers
+    make -j$(nproc) && \
+    make install && \
+    cd ../.. && \
+    rm -rf level-zero
+
+# Update library cache
+RUN ldconfig
+
+# Optional: If you encounter solver issues, set the following environment variable
+ENV CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # Delete Intel OpenCL Loader
 RUN rm -f /apps/conda/envs/oneapi-2024.1.0/lib/libOpenCL.so.1
@@ -179,8 +195,16 @@ RUN mkdir -p /apps/modulefiles/Core/oneapi && \
     echo 'setenv("ONEAPI_ROOT", base)' >> /apps/modulefiles/Core/oneapi/2024.1.0.lua && \
     echo 'setenv("ONEAPI_VERSION", version)' >> /apps/modulefiles/Core/oneapi/2024.1.0.lua
 
-# Set permissionst to enable non-root access to GPUs
+RUN pip install pyyaml
+
+RUN apt-get update && apt-get install -y vim-common # for xxd
+
+# Set permissions to enable non-root access to GPUs
 RUN echo 'sudo chmod 666 /dev/dri/* 2>/dev/null || true' >> /home/chipStarUser/.bashrc
+
+# Set as default user
+USER chipStarUser
+WORKDIR /home/chipStarUser
 
 #////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #//                                                                                                                                        //

--- a/docker/DockerfileLatest
+++ b/docker/DockerfileLatest
@@ -14,7 +14,7 @@ RUN clinfo -l
 
 RUN pip install pyyaml
 
-RUN sudo apt-get install vim-common -y # for xxd
+RUN sudo apt update && sudo apt install vim-common -y # for xxd
 
 ENV CHIP_BE=opencl
 ENV CHIP_DEVICE_TYPE=cpu

--- a/docker/DockerfileLatest
+++ b/docker/DockerfileLatest
@@ -12,10 +12,6 @@ SHELL ["/bin/bash", "-ci"]
 
 RUN clinfo -l
 
-RUN pip install pyyaml
-
-RUN apt-get update && apt-get install -y vim-common # for xxd
-
 ENV CHIP_BE=opencl
 ENV CHIP_DEVICE_TYPE=cpu
 ENV CHIP_LOGLEVEL=info

--- a/docker/DockerfileLatest
+++ b/docker/DockerfileLatest
@@ -14,7 +14,7 @@ RUN clinfo -l
 
 RUN pip install pyyaml
 
-RUN sudo apt update && sudo apt install vim-common -y # for xxd
+RUN apt-get update && apt-get install -y vim-common # for xxd
 
 ENV CHIP_BE=opencl
 ENV CHIP_DEVICE_TYPE=cpu

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -131,8 +131,11 @@ set(SAMPLES
     ccompat
     hipComplex
     hipHostMallocSample
-    hipDeviceLink
 )
+
+if (NOT "${DETECTED_ARCHITECTURE}" STREQUAL "riscv64")
+  list(APPEND SAMPLES hipDeviceLink)
+endif()
 
 include(mkl_and_icpx)
 # Add samples that depend on Intel's oneAPI compiler - if available.

--- a/samples/fp16/CMakeLists.txt
+++ b/samples/fp16/CMakeLists.txt
@@ -1,6 +1,7 @@
-
-add_chip_test(fp16 fp16 PASSED haxpy-base.cpp)
-
-add_chip_test(fp16_math fp16_math PASSED half_math.cpp)
-
-add_chip_test(fp16_half2_math fp16_half2_math PASSED half2_math.cpp)
+if(DETECTED_ARCHITECTURE STREQUAL "riscv64")
+  message(STATUS "RISC-V 64-bit architecture detected. Skipping fp16 tests.")
+else()
+  add_chip_test(fp16 fp16 PASSED haxpy-base.cpp)
+  add_chip_test(fp16_math fp16_math PASSED half_math.cpp)
+  add_chip_test(fp16_half2_math fp16_half2_math PASSED half2_math.cpp)
+endif()

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -177,13 +177,18 @@ void chipstar::AllocationTracker::recordAllocation(
   AllocInfos_.insert(AllocInfo);
 
   if (DevPtr) {
-    assert(!PtrToAllocInfo_.count(DevPtr) &&
-           "Device pointer already recorded!");
-    PtrToAllocInfo_[DevPtr] = AllocInfo;
+    if (!PtrToAllocInfo_.count(DevPtr))
+      PtrToAllocInfo_[DevPtr] = AllocInfo;
+    else
+      CHIPERR_LOG_AND_ABORT("Device pointer already recorded: 0x" +
+                            std::to_string((uintptr_t)DevPtr));
   }
   if (HostPtr) {
-    assert(!PtrToAllocInfo_.count(DevPtr) && "Host pointer already recorded!");
-    PtrToAllocInfo_[HostPtr] = AllocInfo;
+    if (!PtrToAllocInfo_.count(HostPtr))
+      PtrToAllocInfo_[HostPtr] = AllocInfo;
+    else
+      CHIPERR_LOG_AND_ABORT("Host pointer already recorded: 0x" +
+                            std::to_string((uintptr_t)HostPtr));
   }
 
   logDebug("chipstar::AllocationTracker::recordAllocation size: {} HOST {} DEV "
@@ -423,7 +428,7 @@ SPVFuncInfo *chipstar::Module::findFunctionInfo(const std::string &FName) {
 //*************************************************************************************
 chipstar::Kernel::Kernel(std::string HostFName, SPVFuncInfo *FuncInfo)
     : HostFName_(HostFName), FuncInfo_(FuncInfo) {}
-chipstar::Kernel::~Kernel(){};
+chipstar::Kernel::~Kernel() {};
 std::string chipstar::Kernel::getName() { return HostFName_; }
 const void *chipstar::Kernel::getHostPtr() { return HostFPtr_; }
 const void *chipstar::Kernel::getDevPtr() { return DevFPtr_; }
@@ -483,7 +488,7 @@ void *chipstar::ArgSpillBuffer ::allocate(const SPVFuncInfo::Arg &Arg) {
 chipstar::ExecItem::ExecItem(dim3 GridDim, dim3 BlockDim, size_t SharedMem,
                              hipStream_t ChipQueue)
     : SharedMem_(SharedMem), GridDim_(GridDim), BlockDim_(BlockDim),
-      ChipQueue_(static_cast<chipstar::Queue *>(ChipQueue)){};
+      ChipQueue_(static_cast<chipstar::Queue *>(ChipQueue)) {};
 
 dim3 chipstar::ExecItem::getBlock() { return BlockDim_; }
 dim3 chipstar::ExecItem::getGrid() { return GridDim_; }
@@ -1465,7 +1470,7 @@ chipstar::Queue::Queue(chipstar::Device *ChipDevice, chipstar::QueueFlags Flags,
 };
 
 chipstar::Queue::Queue(chipstar::Device *ChipDevice, chipstar::QueueFlags Flags)
-    : Queue(ChipDevice, Flags, 0){};
+    : Queue(ChipDevice, Flags, 0) {};
 
 chipstar::Queue::~Queue() {
   updateLastEvent(nullptr);

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -2185,6 +2185,13 @@ public:
     return LastEvent_;
   }
 
+  virtual std::shared_ptr<chipstar::Event> getLastEventNoLock() {
+    if (LastEvent_)
+      LastEvent_->isDeletedSanityCheck();
+    return LastEvent_;
+  }
+
+
   /**
    * @brief Construct a new Queue object
    *

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -269,7 +269,7 @@ class HostAllocFlags {
   unsigned int FlagsRaw_;
 
 public:
-  HostAllocFlags() : FlagsRaw_(hipHostMallocDefault){};
+  HostAllocFlags() : FlagsRaw_(hipHostMallocDefault) {};
   HostAllocFlags(unsigned int FlagsRaw) : FlagsRaw_(FlagsRaw) {
     if (FlagsRaw & hipHostMallocDefault) {
       Default_ = true;
@@ -384,7 +384,7 @@ public:
     Monitor->monitor();
     return 0;
   }
-  virtual void monitor(){};
+  virtual void monitor() {};
 
   void start() {
     logDebug("Starting chipstar::Event Monitor Thread");
@@ -2190,7 +2190,6 @@ public:
       LastEvent_->isDeletedSanityCheck();
     return LastEvent_;
   }
-
 
   /**
    * @brief Construct a new Queue object

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2749,8 +2749,7 @@ hipError_t hipEventSynchronize(hipEvent_t Event) {
   NULLCHECK(Event);
   chipstar::Event *ChipEvent = static_cast<chipstar::Event *>(Event);
 
-  if (ChipEvent->isRecordingOrRecorded())
-    ChipEvent->wait();
+  ChipEvent->wait();
 
   RETURN(hipSuccess);
 
@@ -2778,11 +2777,6 @@ hipError_t hipEventElapsedTime(float *Ms, hipEvent_t Start, hipEvent_t Stop) {
     CHIPERR_LOG_AND_THROW("One of the events was not recorded",
                           hipErrorInvalidHandle);
   }
-
-  if (!ChipEventStart->getEventStatus() == EVENT_STATUS_RECORDING)
-    RETURN(hipErrorNotReady);
-  if (!ChipEventStop->getEventStatus() == EVENT_STATUS_RECORDING)
-    RETURN(hipErrorNotReady);
 
   *Ms = ChipEventStart->getElapsedTime(ChipEventStop);
   RETURN(hipSuccess);

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2749,7 +2749,8 @@ hipError_t hipEventSynchronize(hipEvent_t Event) {
   NULLCHECK(Event);
   chipstar::Event *ChipEvent = static_cast<chipstar::Event *>(Event);
 
-  ChipEvent->wait();
+  if (ChipEvent->isRecordingOrRecorded())
+    ChipEvent->wait();
 
   RETURN(hipSuccess);
 

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -472,9 +472,9 @@ float CHIPEventLevel0::getElapsedTime(chipstar::Event *OtherIn) {
   Other->updateFinishStatus(false);
   if (this->getEventStatus() != EVENT_STATUS_RECORDED) {
     if (Other->getEventStatus() != EVENT_STATUS_RECORDED) {
-      CHIPERR_LOG_AND_THROW(
-          "CHIPEventLevel0::getElapsedTime() neither start nor stop event is recorded",
-          hipErrorNotReady);
+      CHIPERR_LOG_AND_THROW("CHIPEventLevel0::getElapsedTime() neither start "
+                            "nor stop event is recorded",
+                            hipErrorNotReady);
     } else {
       CHIPERR_LOG_AND_THROW(
           "CHIPEventLevel0::getElapsedTime() this(start) event is not recorded",
@@ -1471,10 +1471,13 @@ void CHIPQueueLevel0::finish() {
   if (LastEvent)
     LastEvent->wait();
 
-  zeStatus =
-      zeCommandQueueSynchronize(ZeCmdQ_, ChipEnvVars.getL0EventTimeout());
+  if (zeCmdQOwnership_) {
+    zeStatus =
+        zeCommandQueueSynchronize(ZeCmdQ_, ChipEnvVars.getL0EventTimeout());
   CHIPERR_CHECK_LOG_AND_THROW_TABLE(zeCommandQueueSynchronize,
                                     "zeCommandQueueSynchronize timeout out");
+  }
+
   this->LastEvent_ = nullptr;
   return;
 }

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1474,8 +1474,8 @@ void CHIPQueueLevel0::finish() {
   if (zeCmdQOwnership_) {
     zeStatus =
         zeCommandQueueSynchronize(ZeCmdQ_, ChipEnvVars.getL0EventTimeout());
-  CHIPERR_CHECK_LOG_AND_THROW_TABLE(zeCommandQueueSynchronize,
-                                    "zeCommandQueueSynchronize timeout out");
+    CHIPERR_CHECK_LOG_AND_THROW_TABLE(zeCommandQueueSynchronize,
+                                      "zeCommandQueueSynchronize timeout out");
   }
 
   this->LastEvent_ = nullptr;

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1456,7 +1456,8 @@ CHIPQueueLevel0::memCopyAsyncImpl(void *Dst, const void *Src, size_t Size,
 }
 
 void CHIPQueueLevel0::finish() {
-  auto LastEvent = getLastEvent();
+  LOCK(LastEventMtx); // Queue::LastEvent_
+  auto LastEvent = getLastEventNoLock();
   if (LastEvent)
     LastEvent->wait();
 

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -1,6 +1,7 @@
 TOTAL_TESTS: 1397
 ANY:
   ALL:
+    hipStreamSemantics: 'timing dependent, flaky when ctest -j'
     Unit_AnyAll_CompileTest: 'Failed'
     Unit_funnelshift: 'Failed'
     Unit_threadfence_system: 'SEGFAULT'

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -551,11 +551,18 @@ salami:
     cuda-matrixMul: '' 
     cuda-bandwidthTest: '' 
   OPENCL_POCL:
-x4\d\d\dc\ds\db0n0: # aurora
+x4\d\d\dc\ds\db0n0: # aurora intel_compute_runtime/release/775.20
   ALL:
   LEVEL0_GPU:
+  	firstTouch: 'Runtime bug'
+  	TestIndirectMappedHostAlloc: '*OutH = 0'
+  	hip_async_binomial: '[2] inf 0x7f800000  5.398513 0x40acc09e'
+  	cuda-lambda: 'OutH == 2'
   OPENCL_CPU:
   OPENCL_GPU:
+    Unit_hipStreamAddCallback_WithDefaultStream: 'timeout'
+	  hip_sycl_interop: 'pi::getPlugin couldn't find plugin -59 (PI_ERROR_INVALID_OPERATION)'
+	  hip_sycl_interop_no_buffers: 'pi::getPlugin couldn't find plugin -59 (PI_ERROR_INVALID_OPERATION)'
   OPENCL_POCL:
 x1921.*b0n0: # sunspot
   ALL:

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -551,3 +551,15 @@ salami:
     cuda-matrixMul: '' 
     cuda-bandwidthTest: '' 
   OPENCL_POCL:
+x4\d\d\dc\ds\db0n0: # aurora
+  ALL:
+  LEVEL0_GPU:
+  OPENCL_CPU:
+  OPENCL_GPU:
+  OPENCL_POCL:
+x1921.*b0n0: # sunspot
+  ALL:
+  LEVEL0_GPU:
+  OPENCL_CPU:
+  OPENCL_GPU:
+  OPENCL_POCL:

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -484,6 +484,7 @@ salami:
   LEVEL0_GPU:
   OPENCL_CPU:
   OPENCL_GPU:
+    clock: 'timing dependent, flaky'
     hipStreamSemantics: 'TestStreamSemantics_2 (non-blocking stream):  Failed, then timeout'
     Unit_hipGraphAddEventRecordNode_Functional_ElapsedTime: 'Timeout'
     Unit_hipGraphEventRecordNodeSetEvent_SetEventProperty: 'Timeout'

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -484,6 +484,7 @@ salami:
   LEVEL0_GPU:
   OPENCL_CPU:
   OPENCL_GPU:
+    hipDynamicShared: 'flaky'
     clock: 'timing dependent, flaky'
     hipStreamSemantics: 'TestStreamSemantics_2 (non-blocking stream):  Failed, then timeout'
     Unit_hipGraphAddEventRecordNode_Functional_ElapsedTime: 'Timeout'

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -554,15 +554,15 @@ salami:
 x4\d\d\dc\ds\db0n0: # aurora intel_compute_runtime/release/775.20
   ALL:
   LEVEL0_GPU:
-  	firstTouch: 'Runtime bug'
-  	TestIndirectMappedHostAlloc: '*OutH = 0'
-  	hip_async_binomial: '[2] inf 0x7f800000  5.398513 0x40acc09e'
-  	cuda-lambda: 'OutH == 2'
+    firstTouch: 'Runtime bug'
+    TestIndirectMappedHostAlloc: '*OutH = 0'
+    hip_async_binomial: '[2] inf 0x7f800000  5.398513 0x40acc09e'
+    cuda-lambda: 'OutH == 2'
   OPENCL_CPU:
   OPENCL_GPU:
     Unit_hipStreamAddCallback_WithDefaultStream: 'timeout'
-	  hip_sycl_interop: 'pi::getPlugin couldn't find plugin -59 (PI_ERROR_INVALID_OPERATION)'
-	  hip_sycl_interop_no_buffers: 'pi::getPlugin couldn't find plugin -59 (PI_ERROR_INVALID_OPERATION)'
+    hip_sycl_interop: 'pi::getPlugin couldnt find plugin'
+    hip_sycl_interop_no_buffers: 'pi::getPlugin couldnt find plugin'
   OPENCL_POCL:
 x1921.*b0n0: # sunspot
   ALL:


### PR DESCRIPTION
* Remove unnecessary __future__ import from cucc
* Update configure_llvm.sh
* Disable some samples/tests for RISC-V
* Dump trace on abort
* HIP - SYCL interop Level Zero: queue sync only upon ownership. Required on ALCF systems
* various format & small fixes, cleanup

Fixes #920
