### PR TITLE
Print JIT logs to Info, always

### DIFF
--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -2374,7 +2374,7 @@ static void dumpBuildLog(ze_module_build_log_handle_t &&Log) {
     std::vector<char> LogVec(LogSize);
     zeStatus = zeModuleBuildLogGetString(Log, &LogSize, LogVec.data());
     if (zeStatus == ZE_RESULT_SUCCESS)
-      logError("ZE Build Log:\n{}", std::string_view(LogVec.data(), LogSize));
+      logInfo("ZE Build Log:\n{}", std::string_view(LogVec.data(), LogSize));
   }
 
   CHIPERR_CHECK_LOG_AND_THROW_TABLE(zeModuleBuildLogDestroy);
@@ -2411,8 +2411,7 @@ void save(const ze_module_desc_t &desc, const ze_module_handle_t &module,
   std::string cacheDir = ChipEnvVars.getModuleCacheDir().value();
   // Create the cache directory if it doesn't exist
   std::filesystem::create_directories(cacheDir);
-  std::string fullPath =
-      cacheDir + std::to_string(hash);
+  std::string fullPath = cacheDir + std::to_string(hash);
 
   size_t binarySize;
   zeStatus = zeModuleGetNativeBinary(module, &binarySize, nullptr);
@@ -2505,8 +2504,7 @@ static ze_module_handle_t compileIL(ze_context_handle_t ZeCtx,
              elapsed.count());
   else
     logTrace("zeModulerCeate took {} seconds", elapsed.count());
-  if (zeStatus != ZE_RESULT_SUCCESS)
-    dumpBuildLog(std::move(Log));
+  dumpBuildLog(std::move(Log));
 
   CHIPERR_CHECK_LOG_AND_THROW_TABLE(zeModuleCreate);
   logTrace("LZ CREATE MODULE via calling zeModuleCreate {} ",

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -845,8 +845,8 @@ static void dumpProgramLog(CHIPDeviceOpenCL &ChipDev, cl::Program Prog) {
   std::string Log =
       Prog.getBuildInfo<CL_PROGRAM_BUILD_LOG>(*ChipDev.get(), &Err);
   if (Err == CL_SUCCESS)
-    logError("Program LOG for device #{}:{}:\n{}\n", ChipDev.getDeviceId(),
-             ChipDev.getName(), Log);
+    logInfo("Program LOG for device #{}:{}:\n{}\n", ChipDev.getDeviceId(),
+            ChipDev.getName(), Log);
 }
 
 static cl::Program compileIL(cl::Context Ctx, CHIPDeviceOpenCL &ChipDev,
@@ -869,10 +869,8 @@ static cl::Program compileIL(cl::Context Ctx, CHIPDeviceOpenCL &ChipDev,
   auto Duration =
       std::chrono::duration_cast<std::chrono::milliseconds>(End - Start);
   logTrace("clCompileProgram took {} ms", Duration.count());
-  if (Err != CL_SUCCESS) {
-    dumpProgramLog(ChipDev, Prog);
-    CHIPERR_LOG_AND_THROW("Compile step failed.", hipErrorInitializationError);
-  }
+  dumpProgramLog(ChipDev, Prog);
+  CHIPERR_CHECK_LOG_AND_THROW_TABLE(clCompileProgram);
 
   return Prog;
 }


### PR DESCRIPTION
Always print the JIT log result. It appears to be always empty upon success but warning might be printed also might be vendor specific. 