### PR TITLE
Support specifying include directories (`-I`) through hipRTC

### DIFF
--- a/src/spirv_hiprtc.cc
+++ b/src/spirv_hiprtc.cc
@@ -115,7 +115,7 @@ static bool processOptions(chipstar::Program &Program, int NumOptions,
       continue; // Consider NULL pointers are empty.
     auto OptionIn = trim(std::string_view(Options[OptIdx]));
 
-    if (Match(OptionIn, "-D.*") || Match(OptionIn, "--?std=[cC][+][+][0-9]*")) {
+    if (Match(OptionIn, "-D.*") || Match(OptionIn, "--?std=[cC][+][+][0-9]*") || Match(OptionIn, "-I.*")) {
       logDebug("hiprtc: accept option '{}'", std::string(OptionIn));
       OptionsOut.Options.emplace_back(OptionIn);
       continue;


### PR DESCRIPTION
Thank you for maintaining the awesome project! This PR adds support for `-I` option in hipRTC API to support specifying include directories.

To share the context: I was trying to use chipStar in CuPy (https://github.com/cupy/cupy/pull/8700). CuPy compiles generated kernels through NVRTC/hipRTC, which require headers from directories specified by `-I`.