### PR TITLE
Small modification to CMakeLists to link with SPIRV-Tools with a private scope

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,8 +512,7 @@ else()
   message(STATUS "spirv-tools: ${SPIRV-Tools_FOUND}")
 endif()
 
-list(APPEND CHIP_INTERFACE_LIBS SPIRV-Tools)
-
+target_link_libraries(CHIP PRIVATE SPIRV-Tools)
 
 target_link_libraries(CHIP PUBLIC ${CHIP_INTERFACE_LIBS})
 


### PR DESCRIPTION
This changes CMakeLists.txt so that SPIRV-Tools is linked with CHIP target with a private scope. This avoids the case of dependencies of CHIP also needing libSPIRV-Tools.a to be linked in (but leaves CHIP target itself still needing SPIRV-Tools).