### PR TITLE
Add Support for LLVM 20 

### DIFF
--- a/.github/workflows/check-unit-tests-intel.yml
+++ b/.github/workflows/check-unit-tests-intel.yml
@@ -20,54 +20,6 @@ jobs:
           workflow_id: nightly-tests.yml
           all_but_latest: false
 
-  unit-tests-llvm-16-debug:
-    needs: cancel-nightly
-    runs-on: X64
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-          submodules: 'recursive'
-      - name: Run unit test checking script
-        run: ./scripts/unit_tests.sh debug llvm-16
-        shell: bash
-  unit-tests-llvm-16-release:
-    needs: cancel-nightly
-    runs-on: X64
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-          submodules: 'recursive'
-      - name: Run unit test checking script
-        run: ./scripts/unit_tests.sh release llvm-16
-        shell: bash
-  unit-tests-llvm-17-debug:
-    needs: cancel-nightly
-    runs-on: X64
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-          submodules: 'recursive'
-      - name: Run unit test checking script
-        run: ./scripts/unit_tests.sh debug llvm-17
-        shell: bash
-  unit-tests-llvm-17-release:
-    needs: cancel-nightly
-    runs-on: X64
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-          submodules: 'recursive'
-      - name: Run unit test checking script
-        run: ./scripts/unit_tests.sh release llvm-17
-        shell: bash
   unit-tests-llvm-18-debug:
     needs: cancel-nightly
     runs-on: X64
@@ -115,4 +67,28 @@ jobs:
           submodules: 'recursive'
       - name: Run unit test checking script
         run: ./scripts/unit_tests.sh release llvm-19
+        shell: bash
+  unit-tests-llvm-20-debug:
+    needs: cancel-nightly
+    runs-on: X64
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          submodules: 'recursive'
+      - name: Run unit test checking script
+        run: ./scripts/unit_tests.sh debug llvm-20
+        shell: bash
+  unit-tests-llvm-20-release:
+    needs: cancel-nightly
+    runs-on: X64
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          submodules: 'recursive'
+      - name: Run unit test checking script
+        run: ./scripts/unit_tests.sh release llvm-20
         shell: bash

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -202,19 +202,19 @@ jobs:
       EXCLUDE: ${{ matrix.backend == 'intel' && '"`cat ./test_lists/OPENCL_POCL.txt`|`cat ./test_lists/ALL.txt`"' || '"`cat ./test_lists/OPENCL_POCL.txt`|`cat ./test_lists/ALL.txt`"' }}
     strategy:
       matrix:
-        pocl-version: [5, 6]
-        llvm-version: [18, 19, 20]
+        pocl-version: [4, 5, 6]
+        llvm-version: [16, 17, 18]
         backend: [pocl, intel]
         exclude:
           - backend: pocl
-            pocl-version: 5
+            pocl-version: 4
+            llvm-version: 17
+          - backend: pocl
+            pocl-version: 4
             llvm-version: 18
           - backend: pocl
             pocl-version: 5
-            llvm-version: 19
-          - backend: pocl
-            pocl-version: 5
-            llvm-version: 20
+            llvm-version: 18
           - backend: intel
             pocl-version: 4
           - backend: intel

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -202,19 +202,19 @@ jobs:
       EXCLUDE: ${{ matrix.backend == 'intel' && '"`cat ./test_lists/OPENCL_POCL.txt`|`cat ./test_lists/ALL.txt`"' || '"`cat ./test_lists/OPENCL_POCL.txt`|`cat ./test_lists/ALL.txt`"' }}
     strategy:
       matrix:
-        pocl-version: [4, 5, 6]
-        llvm-version: [16, 17, 18]
+        pocl-version: [5, 6]
+        llvm-version: [18, 19, 20]
         backend: [pocl, intel]
         exclude:
           - backend: pocl
-            pocl-version: 4
-            llvm-version: 17
-          - backend: pocl
-            pocl-version: 4
+            pocl-version: 5
             llvm-version: 18
           - backend: pocl
             pocl-version: 5
-            llvm-version: 18
+            llvm-version: 19
+          - backend: pocl
+            pocl-version: 5
+            llvm-version: 20
           - backend: intel
             pocl-version: 4
           - backend: intel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,9 +436,10 @@ add_custom_target(hipInfoBin ALL
 )
 
 execute_process(
-  COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/scripts/manage_known_failures.py 
-  ${CMAKE_CURRENT_SOURCE_DIR}/tests/known_failures.yaml
-  --generate ${CMAKE_BINARY_DIR}/test_lists
+  COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/scripts/manage_known_failures.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/known_failures.yaml
+    --generate ${CMAKE_BINARY_DIR}/test_lists
+    --target-llvm-major-version ${LLVM_VERSION_MAJOR}
   RESULT_VARIABLE result_var
   ERROR_VARIABLE error_var
 )

--- a/llvm_passes/HipDynMem.cpp
+++ b/llvm_passes/HipDynMem.cpp
@@ -92,13 +92,10 @@ private:
   }
 
   static void recursivelyFindDirectUsers(Value *V, FSet &FS) {
-    for (auto *U : V->users()) {
-      if (Instruction *I = dyn_cast<Instruction>(U)) {
-        if (llvm::ReturnInst *RI [[maybe_unused]] = dyn_cast<ReturnInst>(U)) {
-          // ignore return instructions
-          continue;
-        }
-        Function *IF = I->getFunction();
+    for (auto U : V->users()) {
+      Instruction *Inst = dyn_cast<Instruction>(U);
+      if (Inst) {
+        Function *IF = Inst->getFunction();
         if (!IF)
           continue;
         FS.insert(IF);

--- a/llvm_passes/HipDynMem.cpp
+++ b/llvm_passes/HipDynMem.cpp
@@ -380,18 +380,11 @@ private:
     if (isGVarUsedInFunction(GV, NewF)) {
       B.SetInsertPoint(NewF->getEntryBlock().getFirstNonPHI());
 
-#if LLVM_VERSION_MAJOR >= 15
-#if LLVM_VERSION_MAJOR == 15
-      assert(M.getContext().hasSetOpaquePointersValue());
-#endif
-
 #if LLVM_VERSION_MAJOR >= 20
-      // LLVM 20+ only supports opaque pointers
-      // replace GVar references with the argument
+      // LLVM 20+ only supports opaque pointers: just replace GVar with the argument
       replaceGVarUsesWith(GV, NewF, last_arg);
 #else
       if (M.getContext().supportsTypedPointers()) {
-#endif
         // insert a bitcast of dyn mem argument to [N x Type] Array
         Value *BitcastV = B.CreateBitOrPointerCast(last_arg, GV->getType(), "casted_last_arg");
         Instruction *LastArgBitcast = dyn_cast<Instruction>(BitcastV);
@@ -399,23 +392,17 @@ private:
         // replace GVar references with the [N x Type] bitcast
         replaceGVarUsesWith(GV, NewF, BitcastV);
 
-        // now the code should be without GVar references, but still potentially
-        // contains [0 x ElemType] arrays; we need to get rid of those
-
         // replace all [N x Type]* bitcast uses with direct use of ElemT*-type dyn mem argument
         recursivelyReplaceArrayWithPointer(last_arg, LastArgBitcast, ElemT, B);
 
         // the bitcast to [N x Type] should now be unused
-        if(LastArgBitcast->getNumUses() != 0) llvm_unreachable("Something still uses LastArg bitcast - bug!");
+        if (LastArgBitcast->getNumUses() != 0)
+          llvm_unreachable("Something still uses LastArg bitcast - bug!");
         LastArgBitcast->eraseFromParent();
-#if LLVM_VERSION_MAJOR >= 20
-// No else branch needed for LLVM 20+
-#else
       } else {
         // replace GVar references with the argument
         replaceGVarUsesWith(GV, NewF, last_arg);
       }
-#endif
 #endif
     }
 
@@ -547,8 +534,10 @@ static RegisterPass<HipDynMemExternReplacePass>
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
 
-PreservedAnalyses
-HipDynMemExternReplaceNewPass::run(Module &M, ModuleAnalysisManager &AM) {
+PreservedAnalyses HipDynMemExternReplaceNewPass::run(Module &M, ModuleAnalysisManager &AM) {
+  // force the entire IR to be parsed before your pass runs
+  if (auto Err = M.materializeAll())
+    report_fatal_error("module materialization failed");
   if (HipDynMemExternReplacePass::transformDynamicShMemVars(M))
     return PreservedAnalyses::none();
   return PreservedAnalyses::all();

--- a/llvm_passes/HipIGBADetector.cpp
+++ b/llvm_passes/HipIGBADetector.cpp
@@ -47,6 +47,14 @@
 #define DEBUG_TYPE PASS_NAME
 
 using namespace llvm;
+
+// Iterates through all instructions in the module to find potential
+// Indirect Global Buffer Accesses (IGBAs).
+// An IGBA is considered potential if:
+//  1. An IntToPtrInst is found where the source operand is a true integer
+//     (not resulting from a PtrToIntInst, which often indicates an
+//     address-space cast or similar benign transformation).
+//  2. A LoadInst is found that loads a pointer type from memory.
 static bool hasPotentialIGBAs(Module &M) {
   for (auto &F : M) {
     for (auto &BB : F) {
@@ -54,9 +62,13 @@ static bool hasPotentialIGBAs(Module &M) {
         if (auto *ITP = dyn_cast<IntToPtrInst>(&I)) {
           Value *Op = ITP->getOperand(0);
           // Skip benign ptr→int→ptr sequences lowered from address-space casts
+          // or other pointer manipulations where an integer representation is
+          // temporarily used.
           if (isa<PtrToIntInst>(Op))
             continue;
-          // Only treat as IGBA if the source is a true integer, not a pointer type
+          // Only treat as IGBA if the source is a true integer, not a pointer
+          // type that was cast to integer and then back to pointer (which is
+          // covered by the above check typically, but this is an additional guard).
           if (!Op->getType()->isIntegerTy())
             continue;
           {
@@ -67,6 +79,7 @@ static bool hasPotentialIGBAs(Module &M) {
           // Old pointer-type check is now redundant and removed.
         }
         if (auto *LI = dyn_cast<LoadInst>(&I)) {
+          // If an instruction loads a pointer from memory, it's a potential IGBA.
           if (LI->getType()->isPointerTy()) {
             LLVM_DEBUG(dbgs() << "Found pointer LoadInst in function " << F.getName()
                               << ": " << *LI << "\n");
@@ -79,6 +92,12 @@ static bool hasPotentialIGBAs(Module &M) {
   return false;
 }
 
+// Detects potential IGBAs in the module and sets a magic global variable
+// "__chip_module_has_no_IGBAs" to indicate the result.
+// '1' means no potential IGBAs were found.
+// '0' means potential IGBAs were found.
+// Returns true if the module was modified (i.e., the global variable was added),
+// false otherwise (e.g., if the variable already existed).
 static bool detectIGBAs(Module &M) {
   constexpr auto *MagicVarName = "__chip_module_has_no_IGBAs";
 
@@ -88,6 +107,9 @@ static bool detectIGBAs(Module &M) {
   bool Result = hasPotentialIGBAs(M);
   LLVM_DEBUG(dbgs() << "Has IGBAs: " << Result << "\n");
 
+  // The magic variable stores the *opposite* of the detection result:
+  // If Result is true (IGBAs found), store 0.
+  // If Result is false (no IGBAs found), store 1.
   auto *Init = ConstantInt::get(IntegerType::get(M.getContext(), 8), !Result);
   (void)new GlobalVariable(
       M, Init->getType(), true,

--- a/scripts/configure_llvm.sh
+++ b/scripts/configure_llvm.sh
@@ -82,7 +82,7 @@ if [ "$4" == "on" ]; then
   TRANSLATOR_BRANCH="llvm_release_${VERSION}0"
 else
   LLVM_BRANCH="chipStar-llvm-${VERSION}"
-  TRANSLATOR_BRANCH="llvm_release_${VERSION}0"
+  TRANSLATOR_BRANCH="chipStar-llvm-${VERSION}"
 fi
 
 export LLVM_DIR=`pwd`/llvm-project/llvm
@@ -92,7 +92,7 @@ if [ ! -d llvm-project ]; then
   git clone https://github.com/CHIP-SPV/llvm-project.git -b ${LLVM_BRANCH} \
     --depth 1
   cd ${LLVM_DIR}/projects
-  git clone https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git \
+  git clone https://github.com/CHIP-SPV/SPIRV-LLVM-Translator.git \
     -b ${TRANSLATOR_BRANCH} --depth 1
   cd ${LLVM_DIR}
 else

--- a/scripts/configure_llvm.sh
+++ b/scripts/configure_llvm.sh
@@ -41,7 +41,7 @@ done
 # check mandatory argument version
 if [ -z "$VERSION" ]; then
   echo "Usage: $0 --version <version> --install-dir <dir> --link-type static(default)/dynamic --only-necessary-spirv-exts <on|off> --binutils-header-location <path>"
-  echo "--version: LLVM version 15, 16, 17, 18, 19"
+  echo "--version: LLVM version 17, 18, 19 or 20"
   echo "--install-dir: installation directory"
   echo "--link-type: static or dynamic (default: static)"
   echo "--only-necessary-spirv-exts: on or off (default: off)"
@@ -55,9 +55,9 @@ if [ -z "$INSTALL_DIR" ]; then
 fi
 
 # validate version argument
-if [ "$VERSION" != "15" ] && [ "$VERSION" != "16" ] && [ "$VERSION" != "17" ] \
-       && [ "$VERSION" != "18" ] && [ "$VERSION" != "19" ]; then
-  echo "Invalid version. Must be 15, 16, 17, 18 or 19."
+if [ "$VERSION" != "17" ] && [ "$VERSION" != "18" ] && [ "$VERSION" != "19" ] \
+       && [ "$VERSION" != "20" ]; then
+  echo "Invalid version. Must be 17, 18, 19 or 20."
   exit 1
 fi
 

--- a/scripts/configure_llvm.sh
+++ b/scripts/configure_llvm.sh
@@ -198,8 +198,9 @@ COMMON_CMAKE_OPTIONS=(
   -DLLVM_TARGETS_TO_BUILD=host \
   -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="SPIRV" \
   -DLLVM_ENABLE_ASSERTIONS=On \
-  -DLLVM_BINUTILS_INCDIR=${BINUTILS_HEADER_DIR}
-  -DCMAKE_CXX_LINK_FLAGS="-Wl,-rpath,${gcc_base_path}/lib64 -L${gcc_base_path}/lib64"
+  -DLLVM_BINUTILS_INCDIR=${BINUTILS_HEADER_DIR} \
+  -DCMAKE_CXX_LINK_FLAGS="-Wl,-rpath,${gcc_base_path}/lib64 -L${gcc_base_path}/lib64" \
+  -DCLANG_DEFAULT_PIE_ON_LINUX=off
 )
 
 if [ "$LINK_TYPE" == "static" ]; then

--- a/scripts/unit_tests.sh
+++ b/scripts/unit_tests.sh
@@ -35,7 +35,7 @@ build_type=$(echo "$1" | tr '[:lower:]' '[:upper:]')
 
 # Check if the second argument starts with "llvm-" and is followed by a valid version number
 if [[ ! "$2" =~ ^llvm-(1[6-9]|[2-9][0-9])$ ]]; then
-  echo "Error: Invalid LLVM version. Must be llvm-16, llvm-17, llvm-18, or higher."
+  echo "Error: Invalid LLVM version. Must be llvm-16, llvm-17, llvm-18, llvm-19, or higher."
   exit 1
 fi
 

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -414,6 +414,7 @@ salami:
   LEVEL0_GPU:
   OPENCL_CPU:
   OPENCL_GPU:
+    TestStaticLibRDC: 'Compiler without static library support'
     TestBallot: 'Unsupported SPIR-V capability: SubgroupDispatch'
     hipDynamicShared: 'flaky'
     clock: 'timing dependent, flaky'

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -1,6 +1,14 @@
 TOTAL_TESTS: 1397
 ANY:
   ALL:
+    Unit_hipGraphMemcpyNodeSetParamsToSymbol_Functional: 'LLVM-20'
+    hipTestDeviceSymbol: 'LLVM-20'
+    hipConstantTestDeviceSymbol: 'LLVM-20'
+    hipTestSymbolReset: 'LLVM-20'
+    cuda-convolutionSeparable: 'LLVM-20'
+    cuda-binomialoptions: 'LLVM-20'
+    cuda-FDTD3d: 'LLVM-20'
+    cuda-qrng: 'LLVM-20'
     Unit_hipGraph_SimpleGraphWithKernel: 'Temp disabled graphs'
     Unit_hipStreamBeginCapture_BasicFunctional: 'Temp disabled graphs'
     Unit_hipStreamBeginCapture_Negative: 'Temp disabled graphs'

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -1,14 +1,6 @@
 TOTAL_TESTS: 1397
 ANY:
   ALL:
-    Unit_hipGraphMemcpyNodeSetParamsToSymbol_Functional: 'LLVM-20'
-    hipTestDeviceSymbol: 'LLVM-20'
-    hipConstantTestDeviceSymbol: 'LLVM-20'
-    hipTestSymbolReset: 'LLVM-20'
-    cuda-convolutionSeparable: 'LLVM-20'
-    cuda-binomialoptions: 'LLVM-20'
-    cuda-FDTD3d: 'LLVM-20'
-    cuda-qrng: 'LLVM-20'
     Unit_hipGraph_SimpleGraphWithKernel: 'Temp disabled graphs'
     Unit_hipStreamBeginCapture_BasicFunctional: 'Temp disabled graphs'
     Unit_hipStreamBeginCapture_Negative: 'Temp disabled graphs'
@@ -376,6 +368,7 @@ ANY:
     hipKernelLaunchIsNonBlocking: ''
     Unit_hipEvent: 'calling hipEventGetElapsed time on (start, start) and (stop, stop) causes subsequent call to be ready instread of hipErrorNotReady'
   OPENCL_POCL:
+    TestStaticLibRDC: 'LLVM-16 still being tested but not recompiled to include the static library fix'
     cuda-reduction: 'timeout on LLVM16, enable to reproduce anywhere other than github runne'
     TestRecordEventBlocking: 'Segfault in the PoCL driver with module caching on'
     Unit_ballot: ''
@@ -501,3 +494,14 @@ x1921.*b0n0: # sunspot
   OPENCL_CPU:
   OPENCL_GPU:
   OPENCL_POCL:
+
+LLVM_MAJOR_VERSION_20:
+  ALL:
+    Unit_hipGraphMemcpyNodeSetParamsToSymbol_Functional: 'Fails with LLVM 20'
+    hipTestDeviceSymbol: 'Fails with LLVM 20'
+    hipConstantTestDeviceSymbol: 'Fails with LLVM 20'
+    hipTestSymbolReset: 'Fails with LLVM 20'
+    cuda-convolutionSeparable: 'Fails with LLVM 20'
+    cuda-binomialoptions: 'Fails with LLVM 20'
+    cuda-FDTD3d: 'Fails with LLVM 20'
+    cuda-qrng: 'Fails with LLVM 20'


### PR DESCRIPTION
This PR introduces support for LLVM 20.
Key changes include:
* Updated GitHub Actions workflows to test with LLVM 18, 19, and 20, removing LLVM 16.
* Modified LLVM passes (HipDynMem.cpp, HipIGBADetector.cpp, HipPrintf.cpp) to adapt to LLVM 20 API changes, particularly around opaque and typed pointers, and updated IGBA detection logic.
* Updated CMakeLists.txt to pass the target LLVM major version to the manage_known_failures.py script.
* Updated scripts/configure_llvm.sh to:
* Add support for LLVM 20 and remove support for LLVM 15 and 16.
* Introduce an -N option to print the CMake configuration command without execution.
* Switch to using the CHIP-SPV fork of SPIRV-LLVM-Translator and update branch logic.
* Add CLANG_DEFAULT_PIE_ON_LINUX=off to CMake options.
* Updated the H4I-MKLShim subproject commit.