### PR TITLE
Updating hip_sycl_interop examples to use ”#ifdef UR_API_H_INCLUDED” instead of "ifdef ur_native_handle_t"

### DIFF
--- a/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
@@ -27,7 +27,7 @@
 #if INTEL_MKL_VERSION >= 20250000
   #include <sycl/backend.hpp>
   // Check if ur_native_handle_t is defined
-  #ifdef ur_native_handle_t
+  #ifdef UR_API_H_INCLUDED
     #define HAS_UR_API 1
   #else
     #define HAS_UR_API 0

--- a/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
@@ -27,7 +27,7 @@
 #if INTEL_MKL_VERSION >= 20250000
   #include <sycl/backend.hpp>
   // Check if ur_native_handle_t is defined
-  #ifdef ur_native_handle_t
+  #ifdef UR_API_H_INCLUDED
     #define HAS_UR_API 1
   #else
     #define HAS_UR_API 0


### PR DESCRIPTION
With the 2025.0.5 compilers on Aurora, chipStar fails to build since it does not use the correct `sycl::detail::make_platform` etc. APIs.

It currently checks whether the UR API is used by checking `ifdef ur_native_handle_t` (https://github.com/CHIP-SPV/chipStar/blob/f0b992e2b7b9fc0c0f153e0e728ea0fd132d6de9/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp#L29). However, `ifdef` doesn't work to check if a typedef is defined, so it’s not working as expected (https://stackoverflow.com/questions/6772802/in-c-c-is-there-a-directive-similar-to-ifndef-for-typedefs)

I double checked this with a simple example:
```
> cat t.cpp
#include <stdio.h>


typedef int myint;

int main()
{
#ifdef myint
  printf(“DEF\n”);
#else
  printf(“NOT DEF\n”);
#endif
  return 0;
}

> icpx t.cpp
> ./a.out
NOT DEF
```

This PR changes it to ”#ifdef UR_API_H_INCLUDED” which is working on Aurora with both 2025.0.5 oneAPI SDK (which has the UR API) and 2025.0.0 (which does not have the UR API).
