### PR TITLE
Updates for UR API with LevelZero backend for MKL

### DIFF
--- a/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
@@ -149,8 +149,10 @@ int oneMKLGemmTest(uintptr_t *nativeHandlers, float *A,
 
     std::vector<sycl::device> sycl_devices(1);
     sycl_devices[0] = sycl_device;
+    // this passes in all devices to make the context since it looks like MKL needs all devices in the context
     sycl::context sycl_context = 
-        sycl::detail::make_context((ur_native_handle_t)hContext, {}, sycl::backend::ext_oneapi_level_zero, false, sycl::device::get_devices());
+        sycl::detail::make_context((ur_native_handle_t)hContext, {}, sycl::backend::ext_oneapi_level_zero, false,
+        sycl::device::get_devices());
 
     if (isImmCmdList) {
         sycl_queue = sycl::detail::make_queue((ur_native_handle_t)hCommandList, true, sycl_context, &sycl_device, false, 

--- a/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
@@ -155,10 +155,10 @@ int oneMKLGemmTest(uintptr_t *nativeHandlers, float *A,
         sycl::device::get_devices());
 
     if (isImmCmdList) {
-        sycl_queue = sycl::detail::make_queue((ur_native_handle_t)hCommandList, true, sycl_context, &sycl_device, false, 
+        sycl_queue = sycl::detail::make_queue((ur_native_handle_t)hCommandList, true, sycl_context, &sycl_device, true, 
                                              {sycl::property::queue::in_order()}, {}, sycl::backend::ext_oneapi_level_zero);
     } else {
-        sycl_queue = sycl::detail::make_queue((ur_native_handle_t)hQueue, false, sycl_context, &sycl_device, false, 
+        sycl_queue = sycl::detail::make_queue((ur_native_handle_t)hQueue, false, sycl_context, &sycl_device, true, 
                                              {sycl::property::queue::in_order()}, {}, sycl::backend::ext_oneapi_level_zero);
     }
 #elif __INTEL_LLVM_COMPILER >= 20240000

--- a/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
@@ -150,7 +150,7 @@ int oneMKLGemmTest(uintptr_t *nativeHandlers, float *A,
     std::vector<sycl::device> sycl_devices(1);
     sycl_devices[0] = sycl_device;
     sycl::context sycl_context = 
-        sycl::detail::make_context((ur_native_handle_t)hContext, {}, sycl::backend::ext_oneapi_level_zero, false, sycl_devices);
+        sycl::detail::make_context((ur_native_handle_t)hContext, {}, sycl::backend::ext_oneapi_level_zero, false, sycl::device::get_devices());
 
     if (isImmCmdList) {
         sycl_queue = sycl::detail::make_queue((ur_native_handle_t)hCommandList, true, sycl_context, &sycl_device, false, 

--- a/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
@@ -147,8 +147,10 @@ int oneMKLGemmTest(uintptr_t *nativeHandlers, float *A,
 
       std::vector<sycl::device> sycl_devices(1);
       sycl_devices[0] = sycl_device;
+      // this passes in all devices to make the context since it looks like MKL needs all devices in the context
       sycl::context sycl_context = 
-          sycl::detail::make_context((ur_native_handle_t)hContext, {}, sycl::backend::ext_oneapi_level_zero, false, sycl::device::get_devices());
+          sycl::detail::make_context((ur_native_handle_t)hContext, {}, sycl::backend::ext_oneapi_level_zero, false,
+          sycl::device::get_devices());
 
       if (isImmCmdList) {
           sycl_queue = sycl::detail::make_queue((ur_native_handle_t)hCommandList, true, sycl_context, &sycl_device, false, 

--- a/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
@@ -153,10 +153,10 @@ int oneMKLGemmTest(uintptr_t *nativeHandlers, float *A,
           sycl::device::get_devices());
 
       if (isImmCmdList) {
-          sycl_queue = sycl::detail::make_queue((ur_native_handle_t)hCommandList, true, sycl_context, &sycl_device, false, 
+          sycl_queue = sycl::detail::make_queue((ur_native_handle_t)hCommandList, true, sycl_context, &sycl_device, true, 
                                                {sycl::property::queue::in_order()}, {}, sycl::backend::ext_oneapi_level_zero);
       } else {
-          sycl_queue = sycl::detail::make_queue((ur_native_handle_t)hQueue, false, sycl_context, &sycl_device, false, 
+          sycl_queue = sycl::detail::make_queue((ur_native_handle_t)hQueue, false, sycl_context, &sycl_device, true, 
                                                {sycl::property::queue::in_order()}, {}, sycl::backend::ext_oneapi_level_zero);
       }
 #elif __INTEL_LLVM_COMPILER >= 20240000

--- a/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
@@ -148,7 +148,7 @@ int oneMKLGemmTest(uintptr_t *nativeHandlers, float *A,
       std::vector<sycl::device> sycl_devices(1);
       sycl_devices[0] = sycl_device;
       sycl::context sycl_context = 
-          sycl::detail::make_context((ur_native_handle_t)hContext, {}, sycl::backend::ext_oneapi_level_zero, false, sycl_devices);
+          sycl::detail::make_context((ur_native_handle_t)hContext, {}, sycl::backend::ext_oneapi_level_zero, false, sycl::device::get_devices());
 
       if (isImmCmdList) {
           sycl_queue = sycl::detail::make_queue((ur_native_handle_t)hCommandList, true, sycl_context, &sycl_device, false, 


### PR DESCRIPTION
With MKL version 20250001 on Aurora, it looks like the Level Zero backend needs all devices to be in the context for the MKLshim and interop with MKL layer to work.

It will run regular parallel_for kernels fine, but I see this error for calling hipBlas functions:
```
MKL Warning: Incompatible OpenCL driver version. GPU performance may be reduced.
                Caught synchronous SYCL exception during GEMM:
Level-Zero error:700000041879048196
On device: 'Intel(R) Data Center GPU Max 1550'
in kernel: oneapi::mkl::blas::sgemm_incopy
```
From looking at the trace, the MKL module is failing at build time from: 
```
01:29:51.286082254 - x4204c0s1b0n0 - vpid: 177150, vtid: 177150 - lttng_ust_ze_build:log: { buildLog: "error: Kernel compiled with required subgroup size 8, which is unsupported on this platform in kernel: 'sgemm_incopy'error: backend compiler failed build.\n" }
```
If I try with 2025.1 SDK, I get:
```
MKL Warning: Incompatible OpenCL driver version. GPU performance may be reduced.
                Caught synchronous SYCL exception during GEMM:
Not all devices are associated with the context or vector of devices is empty
OpenCL status: 8
```
Because of this error message, I made a change to send all available devices `sycl::device::get_devices()` to the sycl_context creation instead of the device object we got from `make_device`. It seems that MKL now needs the context to have all GPUs available in it, possibly since it is querying all the GPUs via OpenCL and comparing the the queue givent ot it via LZ. Note that the `make_queue` call still uses just one sycl device, so we still only use one device. This change worked for me, and I confirmed that it called sgemm on the GPU indeed.

This also changes make_queue to use keepOwnership=true, since if we create a second queue from the same context, it will delete the previous queue. (we saw this with https://github.com/CHIP-SPV/H4I-MKLShim/pull/27)

If there's a better solution, we can use that instead.