### PR TITLE
updating hip_sycl_interop to pass in devices properly

### DIFF
--- a/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
@@ -149,10 +149,10 @@ int oneMKLGemmTest(uintptr_t *nativeHandlers, float *A,
 
     std::vector<sycl::device> sycl_devices(1);
     sycl_devices[0] = sycl_device;
-    // this passes in all devices to make the context since it looks like MKL needs all devices in the context
+    // Use the specific device from CHIP-SPV, not all system devices
     sycl::context sycl_context = 
         sycl::detail::make_context((ur_native_handle_t)hContext, {}, sycl::backend::ext_oneapi_level_zero, false,
-        sycl::device::get_devices());
+	 sycl_platform.get_devices());
 
     if (isImmCmdList) {
         sycl_queue = sycl::detail::make_queue((ur_native_handle_t)hCommandList, true, sycl_context, &sycl_device, true, 

--- a/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
@@ -147,10 +147,10 @@ int oneMKLGemmTest(uintptr_t *nativeHandlers, float *A,
 
       std::vector<sycl::device> sycl_devices(1);
       sycl_devices[0] = sycl_device;
-      // this passes in all devices to make the context since it looks like MKL needs all devices in the context
+      // Use the specific device from CHIP-SPV, not all system devices
       sycl::context sycl_context = 
           sycl::detail::make_context((ur_native_handle_t)hContext, {}, sycl::backend::ext_oneapi_level_zero, false,
-          sycl::device::get_devices());
+          sycl_platform.get_devices());
 
       if (isImmCmdList) {
           sycl_queue = sycl::detail::make_queue((ur_native_handle_t)hCommandList, true, sycl_context, &sycl_device, true, 


### PR DESCRIPTION
As discussed in https://github.com/CHIP-SPV/H4I-MKLShim/issues/43, we need to update onemkl_gemm_wrapper.cpp to use the devices from the input handle to `make_context`. This PR changes that in the two hip_sycl_interop tests.