### PR TITLE
Improve usability when dealing with codebase with inline assembly

### DIFF
--- a/llvm_passes/HipPrintf.cpp
+++ b/llvm_passes/HipPrintf.cpp
@@ -300,6 +300,10 @@ static Function *getCalledFunction(CallInst *CI) {
 
   // A call with mismatched call signature.
   auto *Callee = CI->getCalledOperand()->stripPointerCasts();
+  // ... is it inline asm?
+  if (isa<InlineAsm>(Callee))
+     return nullptr;
+
   assert(isa<Function>(Callee)); // ... or something more exotic?
   return cast<Function>(Callee);
 }

--- a/src/SPIRVFuncInfo.hh
+++ b/src/SPIRVFuncInfo.hh
@@ -23,6 +23,7 @@
 #ifndef SRC_SPIRV_FUNCINFO_H
 #define SRC_SPIRV_FUNCINFO_H
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <vector>


### PR DESCRIPTION
Not the proper solution, since it'd require proper check in clang's sema.

The goal of this change was to add some context and shed some light on what's really going on.
Without this changes `HipPrintf` will crash due to assert without much of a context.
Thus figuring it out what's wrong requires debugger session and `->dump()`'ing IR.

- Added check for `InlineAsm` `llvm::Value` to `HipSanityChecks` pass aborting issuing warning (and aborting  in debug)
- Fixed crasher in `HipPrintf` pass on `CallInst` with inline assembly

SPIRV translator will assert on `InlineAsm` still so validation will fail.

Also needed to add `<cstdint>` include since on this machine libstdc++ (gcc-14) needed it, didn't seem to be needed on 22.04 when compiled earlier.

I also had minor problem with cmake once I switched to llvm build in debug (using chips 20 llvm branch ATM)
Not really sure what's going on there, but this workaround with helped me:

``` diff
diff --git a/llvm_passes/CMakeLists.txt b/llvm_passes/CMakeLists.txt
index cac50c97..b6eb0699 100644
--- a/llvm_passes/CMakeLists.txt
+++ b/llvm_passes/CMakeLists.txt
@@ -58,6 +58,8 @@ else()
 
   get_target_property(LLVM_CONF LLVMCore IMPORTED_CONFIGURATIONS)
   string(REPLACE ";.*$" "" LLVM_CONF "${LLVM_CONF}")
+
+  set(LLVM_CONF "DEBUG")
   message(STATUS "LLVM CONFIG: ${LLVM_CONF}")
 
   get_target_property(LLVMCORE_PATH LLVMCore IMPORTED_LOCATION_${LLVM_CONF})
```
Value of `LLVM_CONF` was `DEBUG;RELEASE` for some reason which `get_target_property()` didn't like. 