### PR TITLE
[Level Zero] Optimize 3D Memset operations

### DIFF
--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1384,9 +1384,11 @@ void CHIPQueueLevel0::memFillAsync3D(hipPitchedPtr PitchedDevPtr, int Value,
       static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(
           ChipCtxZe, chipstar::EventFlags(), "memFillAsync3D_region");
   
+  // Get dependencies before acquiring command list lock to avoid deadlock
+  auto [EventHandles, EventLocks] = addDependenciesQueueSync(CopyEvent);
+  
   LOCK(CommandListMtx);
   auto CommandList = this->getCmdListImmCopy();
-  auto [EventHandles, EventLocks] = addDependenciesQueueSync(CopyEvent);
   
   // Wait for pattern buffer to be filled
   ze_event_handle_t PatternEventHandle = 

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1436,8 +1436,11 @@ void CHIPQueueLevel0::memFillAsync3D(hipPitchedPtr PitchedDevPtr, int Value,
           AllEventHandles.size(), AllEventHandles.data());
       CHIPERR_CHECK_LOG_AND_THROW_TABLE(zeCommandListAppendMemoryCopyRegion);
       
-      // Clear event dependencies after first copy
-      AllEventHandles.clear();
+      // Only clear queue sync dependencies after first copy, but keep pattern fill dependency
+      if (!AllEventHandles.empty() && AllEventHandles.size() > 1) {
+        // Keep only the pattern fill event dependency for subsequent copies
+        AllEventHandles = {PatternEventHandle};
+      }
       
       RemainingHeight -= CurrentHeight;
       DstOffsetY += CurrentHeight;

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -435,6 +435,9 @@ public:
                      size_t Spitch, size_t Sspitch, size_t Width, size_t Height,
                      size_t Depth, hipMemcpyKind Kind) override;
 
+  virtual void memFillAsync3D(hipPitchedPtr PitchedDevPtr, int Value,
+                              hipExtent Extent) override;
+
   virtual std::shared_ptr<chipstar::Event>
   memCopyToImage(ze_image_handle_t TexStorage, const void *Src,
                  const chipstar::RegionDesc &SrcRegion);


### PR DESCRIPTION
There is no memset for 3D regions in Level Zero, previously memset were done using looped 1D.

Implement 3D memset via region copy. 

Unit tests go from highly variable 10-120s range to ~2s