### PR TITLE
Adding a corresponding free for an alloc in allocateDeviceVariablesNoLock

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -394,6 +394,8 @@ chipstar::Module::allocateDeviceVariablesNoLock(chipstar::Device *Device,
   Queue->finish();
   DeviceVariablesAllocated_ = true;
 
+  Ctx->free(VarInfoBufD);
+  
   return hipSuccess;
 }
 


### PR DESCRIPTION
This adds a free for an allocation of device memory in allocateDeviceVariablesNoLock.

We can see that memory on the device is allocated here: https://github.com/CHIP-SPV/chipStar/blob/c2d64dda33c8df7c064238003f37b637ffc5850c/src/CHIPBackend.cc#L361 but never freed before the function goes out of scope.

This was discovered from looking at a trace while debugging Issue https://github.com/CHIP-SPV/chipStar/issues/1035 