### PR TITLE
Adding back in event destruction in the LZEventPool destructor

### DIFF
--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1805,10 +1805,10 @@ LZEventPool::~LZEventPool() {
   if (Backend->Events.size())
     logWarn("CHIPEventLevel0 objects still exist at the time of EventPool "
             "destruction");
-  // while (Events_.size()) {
-  //   delete Events_.top();
-  //   Events_.pop();
-  // }
+  while (Events_.size()) {
+    delete Events_.top();
+    Events_.pop();
+  }
 
   // The application must not call this function from
   // simultaneous threads with the same event pool handle.


### PR DESCRIPTION
This uncomments the event destruction in the LZEventPool destructor. We can get UB and segfaults if the zeEventPool or zeContext is destroyed before the zeEvents in the pool are destroyed (From https://oneapi-src.github.io/level-zero-spec/level-zero/latest/core/api.html#zeeventpooldestroy, `The application must destroy all event handles created from the pool before destroying the pool itself.`). I saw some segfaults on Aurora indeed with this commented out.

Is there a reason they are commented out or something I missed? 