### PR TITLE
Set HipVerifyPass off by default

### DIFF
--- a/llvm_passes/HipPasses.cpp
+++ b/llvm_passes/HipPasses.cpp
@@ -104,12 +104,16 @@ public:
 
 // Insert a helper that adds a pass with HipVerify validation
 template <typename PassT>
-static void addPassWithVerification(ModulePassManager &MPM, PassT &&P,
-                                    const std::string &Name) {
+static void
+addPassWithVerification(ModulePassManager &MPM, PassT &&P,
+                        const std::string &Name,
+                        bool Verify = HipVerifyPass::isVerificationEnabled()) {
   MPM.addPass(std::forward<PassT>(P));
-  // Use HipVerify pass with the name of the pass that just ran (no summary printing)
-  // This will always run even if the previous pass failed
-  MPM.addPass(HipVerifyPass(Name, false));
+  if (Verify) {
+    // Use HipVerify pass with the name of the pass that just ran (no summary printing)
+    // This will always run even if the previous pass failed
+    MPM.addPass(HipVerifyPass(Name, false));
+  }
 }
 
 static void addFullLinkTimePasses(ModulePassManager &MPM) {

--- a/llvm_passes/HipVerify.cpp
+++ b/llvm_passes/HipVerify.cpp
@@ -100,24 +100,28 @@ PreservedAnalyses HipVerifyPass::run(Module &M, ModuleAnalysisManager &AM) {
 std::string HipVerifyPass::getVerificationMode() {
   // Check environment variable
   const char* env = std::getenv("CHIP_VERIFY_MODE");
-  if (!env) {
-    // Default to "failures" if not specified
-    return "failures";
-  }
-  
+
+  // Default to "off" due to pathological compilation time issue
+  // (CHIP-SPV/chipStar#1047).
+  const std::string DefaultMode = "off";
+
+  if (!env)
+    return DefaultMode;
+
   std::string value(env);
   std::transform(value.begin(), value.end(), value.begin(), ::tolower);
-  
-  if (value == "off" || value == "0" || value == "false" || value == "no") {
+
+  if (value == "off" || value == "0" || value == "false" || value == "no")
     return "off";
-  } else if (value == "all" || value == "always" || value == "1" || value == "true" || value == "yes") {
+
+  if (value == "all" || value == "always" || value == "1" || value == "true" ||
+      value == "yes")
     return "all";
-  } else if (value == "failures" || value == "fail" || value == "errors") {
+
+  if (value == "failures" || value == "fail" || value == "errors")
     return "failures";
-  } else {
-    // Default to "failures" for unknown values
-    return "failures";
-  }
+
+  return DefaultMode;
 }
 
 bool HipVerifyPass::isVerificationEnabled() {

--- a/llvm_passes/HipVerify.h
+++ b/llvm_passes/HipVerify.h
@@ -49,13 +49,14 @@ public:
   // Clear all collected results (call at start of pipeline)
   static void clearResults() { AllResults.clear(); }
 
+  static bool isVerificationEnabled();
+
 private:
   std::string PassName;
   bool PrintSummary;
   
   // Verification methods
   static std::string getVerificationMode();
-  bool isVerificationEnabled();
   bool runIRVerification(Module &M, VerificationResult &result);
   bool runSPIRVConversion(Module &M, std::vector<uint32_t> &spirvBinary, VerificationResult &result);
   bool runSPIRVValidation(const std::vector<uint32_t> &spirvBinary, VerificationResult &result);


### PR DESCRIPTION
... due to pathological compilation time seen in CHIP-SPV/chipStar#1047. The pass can still be enabled through the CHIP_VERIFY_MODE environment variable regardless of build mode.

Note: it's not yet confirmed that this patch helps the issue.