### PR TITLE
Adding in handling for "-rdc=true" case for CUDA

### DIFF
--- a/bin/cucc.py
+++ b/bin/cucc.py
@@ -135,6 +135,7 @@ def prepare_argparser() -> argparse.ArgumentParser:
 
     # Add new arguments for relocatable device code and device compilation
     parser.add_argument("--relocatable-device-code", choices=['true', 'false'])
+    parser.add_argument("-rdc", choices=['true', 'false'])
     parser.add_argument("--device-c", action='store_true')
     parser.add_argument("-dc", action='store_true')
 


### PR DESCRIPTION
This is part of a fix for https://github.com/CHIP-SPV/chipStar/issues/1049. It looks like the `-rdc=true` flag wasn't being translated into the `-fgpu-rdc` flag. This PR just adds `-rdc` as something we can pass in now, since it is supported in CUDA (https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/#relocatable-device-code-true-false-rdc).
