### PR TITLE
Add launchHostFunc to CHIPBackend for executing host functions in stream order

### DIFF
--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -2445,6 +2445,13 @@ public:
 
   virtual void addCallback(hipStreamCallback_t Callback, void *UserData);
   /**
+   * @brief Launch a host function to be executed in stream order
+   *
+   * @param hostFunction function pointer for a host function
+   * @param userData user data to pass to the function
+   */
+  virtual void launchHostFunc(hipHostFn_t HostFunction, void *UserData);
+  /**
    * @brief Insert a memory prefetch
    *
    * @param ptr

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -876,7 +876,14 @@ hipError_t hipLaunchHostFunc(hipStream_t stream, hipHostFn_t fn,
   CHIP_TRY
   LOCK(ApiMtx);
   CHIPInitialize();
-  UNIMPLEMENTED(hipErrorNotSupported);
+
+  if (!fn)
+    RETURN(hipErrorInvalidValue);
+
+  auto ChipQueue = Backend->findQueue(static_cast<chipstar::Queue *>(stream));
+
+  ChipQueue->launchHostFunc(fn, userData);
+  RETURN(hipSuccess);
   CHIP_CATCH
 }
 hipError_t hipStreamIsCapturing(hipStream_t stream,

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -129,3 +129,4 @@ add_hip_runtime_test(TestEventRecordCircularDep.cpp)
 add_hip_runtime_test(TestDefaultStreamImplicitSync.hip)
 
 add_hip_runtime_test(TestTypeCastIntrinsics.hip)
+add_hip_runtime_test(TestHipLaunchHostFunc.cpp)

--- a/tests/runtime/TestHipLaunchHostFunc.cpp
+++ b/tests/runtime/TestHipLaunchHostFunc.cpp
@@ -1,0 +1,146 @@
+#include <hip/hip_runtime.h>
+#include <iostream>
+#include <atomic>
+#include <cassert>
+
+std::atomic<int> hostFuncCallCount{0};
+std::atomic<int> executionOrder{0};
+
+void testHostFunc(void* userData) {
+  int* order = static_cast<int*>(userData);
+  *order = executionOrder.fetch_add(1) + 1;
+  hostFuncCallCount.fetch_add(1);
+  std::cout << "testHostFunc called" << std::endl;
+  std::cout << "order: " << *order << std::endl; 
+  std::cout << "hostFuncCallCount: " << hostFuncCallCount.load() << std::endl;
+  std::cout << "executionOrder: " << executionOrder.load() << std::endl;
+}
+
+__global__ void dummyKernel(int* data) {
+  if (threadIdx.x == 0) {
+    *data = 42;
+  }
+}
+
+int testNullStream() {
+  hostFuncCallCount = 0;
+  executionOrder = 0;
+  
+  int order1 = 0, order2 = 0;
+  int* d_data;
+  int h_data = 0;
+
+  if (hipMalloc(&d_data, sizeof(int)) != hipSuccess) {
+    std::cerr << "FAIL: hipMalloc failed" << std::endl;
+    return 1;
+  }
+  
+  // Launch kernel on default stream (null stream)
+  dummyKernel<<<1, 1, 0, nullptr>>>(d_data);
+  
+  // Launch host function on default stream (null stream)
+  if (hipLaunchHostFunc(nullptr, testHostFunc, &order1) != hipSuccess) {
+    std::cerr << "FAIL: hipLaunchHostFunc with null stream failed" << std::endl;
+    hipFree(d_data);
+    return 1;
+  }
+  
+  // Launch another host function
+  if (hipLaunchHostFunc(nullptr, testHostFunc, &order2) != hipSuccess) {
+    std::cerr << "FAIL: second hipLaunchHostFunc with null stream failed" << std::endl;
+    hipFree(d_data);
+    return 1;
+  }
+  
+  // Synchronize to ensure all work completes
+  if (hipDeviceSynchronize() != hipSuccess) {
+    std::cerr << "FAIL: hipDeviceSynchronize failed" << std::endl;
+    hipFree(d_data);
+    return 1;
+  }
+  std::cout << "hipDeviceSynchronize completed" << std::endl;
+  
+  // Verify host functions were called
+  if (hostFuncCallCount.load() != 2) {
+    std::cerr << "FAIL: Expected 2 host function calls, got " << hostFuncCallCount.load() << std::endl;
+    hipFree(d_data);
+    return 1;
+  }
+  
+  // Verify execution order (host functions execute after kernel, in order)
+  if (order1 != 1 || order2 != 2) {
+    std::cerr << "FAIL: Execution order incorrect. order1=" << order1 << ", order2=" << order2 << std::endl;
+  }
+  
+  // Verify kernel completed
+  if (hipMemcpy(&h_data, d_data, sizeof(int), hipMemcpyDeviceToHost) != hipSuccess) {
+    std::cerr << "FAIL: hipMemcpy failed" << std::endl;
+  }
+  
+  if (h_data != 42) {
+    std::cerr << "FAIL: Kernel did not execute correctly. Expected 42, got " << h_data << std::endl;
+    hipFree(d_data);
+    return 1;
+  }
+  
+  hipFree(d_data);
+  return 0;
+}
+
+int testExplicitStream() {
+  hostFuncCallCount = 0;
+  executionOrder = 0;
+  
+  int order1 = 0;
+  hipStream_t stream;
+  
+  if (hipStreamCreate(&stream) != hipSuccess) {
+    std::cerr << "FAIL: hipStreamCreate failed" << std::endl;
+    return 1;
+  }
+  
+  // Launch host function on explicit stream
+  if (hipLaunchHostFunc(stream, testHostFunc, &order1) != hipSuccess) {
+    std::cerr << "FAIL: hipLaunchHostFunc with explicit stream failed" << std::endl;
+    hipStreamDestroy(stream);
+    return 1;
+  }
+  
+  // Synchronize stream
+  if (hipStreamSynchronize(stream) != hipSuccess) {
+    std::cerr << "FAIL: hipStreamSynchronize failed" << std::endl;
+    hipStreamDestroy(stream);
+    return 1;
+  }
+  
+  // Verify host function was called
+  if (hostFuncCallCount.load() != 1) {
+    std::cerr << "FAIL: Expected 1 host function call, got " << hostFuncCallCount.load() << std::endl;
+    hipStreamDestroy(stream);
+    return 1;
+  }
+  
+  if (order1 != 1) {
+    std::cerr << "FAIL: Host function execution order incorrect. order1=" << order1 << std::endl;
+    hipStreamDestroy(stream);
+    return 1;
+  }
+  
+  hipStreamDestroy(stream);
+  return 0;
+}
+
+int main() {
+  int result = 0;
+  
+  result |= testNullStream();
+  result |= testExplicitStream();
+  
+  if (result == 0) {
+    std::cout << "PASS" << std::endl;
+    return 0;
+  } else {
+    std::cout << "FAIL" << std::endl;
+    return 1;
+  }
+}


### PR DESCRIPTION
- Implemented a static wrapper function to adapt hipHostFn_t to hipStreamCallback_t.
- Added launchHostFunc method to CHIPBackend for launching host functions with user data.
- Introduced a new test file for runtime validation of the host function launch feature.
- Fixes #1067