### PR TITLE
Remove redundant shared_ptr wrapping in Queue methods

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1982,13 +1982,13 @@ void chipstar::Queue::launch(chipstar::ExecItem *ExItem) {
 std::shared_ptr<chipstar::Event> chipstar::Queue::enqueueBarrier(
     const std::vector<std::shared_ptr<chipstar::Event>> &EventsToWaitFor) {
   std::shared_ptr<chipstar::Event> ChipEvent =
-      std::shared_ptr<chipstar::Event>(enqueueBarrierImpl(EventsToWaitFor));
+      enqueueBarrierImpl(EventsToWaitFor);
   ChipEvent->Msg = "enqueueBarrier";
   return ChipEvent;
 }
 std::shared_ptr<chipstar::Event> chipstar::Queue::enqueueMarker() {
   std::shared_ptr<chipstar::Event> ChipEvent =
-      std::shared_ptr<chipstar::Event>(enqueueMarkerImpl());
+      enqueueMarkerImpl();
   ChipEvent->Msg = "enqueueMarker";
   return ChipEvent;
 }
@@ -1996,7 +1996,7 @@ std::shared_ptr<chipstar::Event> chipstar::Queue::enqueueMarker() {
 void chipstar::Queue::memPrefetch(const void *Ptr, size_t Count) {
 
   std::shared_ptr<chipstar::Event> ChipEvent =
-      std::shared_ptr<chipstar::Event>(memPrefetchImpl(Ptr, Count));
+      memPrefetchImpl(Ptr, Count);
   ChipEvent->Msg = "memPrefetch";
 }
 


### PR DESCRIPTION
enqueueBarrierImpl, enqueueMarkerImpl, and memPrefetchImpl already return shared_ptr so no need to wrap again

Fixes #1077