### PR TITLE
Allow test discovery without devices

### DIFF
--- a/src/CHIPDriver.cc
+++ b/src/CHIPDriver.cc
@@ -117,17 +117,16 @@ static void createBackendObject() {
 
 void CHIPInitializeCallOnce() {
   logDebug("CHIPDriver Initialize");
-
-  createBackendObject();
-
-  Backend->initialize();
+  try {
+    createBackendObject();
+    Backend->initialize();
+  } catch (...) {
+    if (Backend) delete Backend, Backend = nullptr;
+  }
 }
 
 extern void CHIPInitialize() {
   std::call_once(Initialized, &CHIPInitializeCallOnce);
-  if (!Backend)
-    CHIPERR_LOG_AND_THROW("Backend not initialized",
-                          hipErrorInitializationError);
 }
 
 void CHIPUninitializeCallOnce() {

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1943,8 +1943,8 @@ void CHIPBackendLevel0::initializeImpl() {
   MinQueuePriority_ = ZE_COMMAND_QUEUE_PRIORITY_PRIORITY_HIGH;
   zeStatus = zeInit(0);
   if (zeStatus != ZE_RESULT_SUCCESS) {
-    logCritical("Level Zero failed to initialize any devices");
-    std::exit(1);
+    CHIPERR_LOG_AND_THROW("Level Zero failed to initialize any devices",
+                          hipErrorInitializationError);
   }
 
   bool AnyDeviceType = false;

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -2313,8 +2313,8 @@ void CHIPBackendOpenCL::initializeImpl() {
   std::vector<cl::Platform> Platforms;
   clStatus = cl::Platform::get(&Platforms);
   if (clStatus != CL_SUCCESS) {
-    logCritical("OpenCL failed to initialize any devices");
-    std::exit(1);
+    CHIPERR_LOG_AND_THROW("OpenCL failed to initialize any devices",
+                          hipErrorInitializationError);
   }
   std::stringstream StrStream;
   StrStream << "\nFound " << Platforms.size() << " OpenCL platforms:\n";
@@ -2332,9 +2332,8 @@ void CHIPBackendOpenCL::initializeImpl() {
     SelectedPlatformIdx = ChipEnvVars.getPlatformIdx();
     
     if (SelectedPlatformIdx >= Platforms.size()) {
-      logCritical("Selected OpenCL platform {} is out of range",
-                  SelectedPlatformIdx);
-      std::exit(1);
+      CHIPERR_LOG_AND_THROW("Selected OpenCL platform " + std::to_string(SelectedPlatformIdx) + " is out of range",
+                            hipErrorInitializationError);
     }
     
     SelectedPlatform = Platforms[SelectedPlatformIdx];
@@ -2444,9 +2443,9 @@ void CHIPBackendOpenCL::initializeImpl() {
     }
     
     if (foundPlatformIdx == -1) {
-      logCritical("No OpenCL platforms found with devices of type {} that support SPIR-V",
-                  ChipEnvVars.getDevice().str());
-      std::exit(1);
+      CHIPERR_LOG_AND_THROW("No OpenCL platforms found with devices of type " +
+                            std::string(ChipEnvVars.getDevice().str()) + " that support SPIR-V",
+                            hipErrorInitializationError);
     }
     
     SelectedPlatformIdx = foundPlatformIdx;
@@ -2458,9 +2457,8 @@ void CHIPBackendOpenCL::initializeImpl() {
   logInfo("{}", StrStream.str());
 
   if (ChipEnvVars.getDeviceIdx() >= SupportedDevices.size()) {
-    logCritical("Selected OpenCL device {} is out of range",
-                ChipEnvVars.getDeviceIdx());
-    std::exit(1);
+    CHIPERR_LOG_AND_THROW("Selected OpenCL device " + std::to_string(ChipEnvVars.getDeviceIdx()) + " is out of range",
+                          hipErrorInitializationError);
   }
 
   auto Device = SupportedDevices[ChipEnvVars.getDeviceIdx()];


### PR DESCRIPTION
- Replace std::exit(1) with CHIPERR_LOG_AND_THROW in backend initialization
- Catch exceptions in CHIPInitializeCallOnce and set Backend to nullptr on failure
- Catch exceptions from CHIPInitialize in __hipRegisterFatBinary
- Add Backend checks before accessing Backend in __hipRegisterFatBinary
  - PowerVR workaround: only apply if Backend available
  - Lazy JIT: only compile if Backend available

This allows Catch2 test discovery (--list-test-names-only) to succeed even
when no OpenCL/Level0 devices are available, fixing ninja build_tests failure.

Fixes #1085