### PR TITLE
Rename spdlog namespace to chipStar_spdlog to avoid symbol conflicts

### DIFF
--- a/include/spdlog/async.h
+++ b/include/spdlog/async.h
@@ -24,7 +24,7 @@
 #include <memory>
 #include <mutex>
 
-namespace spdlog {
+namespace chipStar_spdlog {
 
 namespace details {
 static const size_t default_async_q_size = 8192;
@@ -61,13 +61,13 @@ using async_factory = async_factory_impl<async_overflow_policy::block>;
 using async_factory_nonblock = async_factory_impl<async_overflow_policy::overrun_oldest>;
 
 template<typename Sink, typename... SinkArgs>
-inline std::shared_ptr<spdlog::logger> create_async(std::string logger_name, SinkArgs &&... sink_args)
+inline std::shared_ptr<chipStar_spdlog::logger> create_async(std::string logger_name, SinkArgs &&... sink_args)
 {
     return async_factory::create<Sink>(std::move(logger_name), std::forward<SinkArgs>(sink_args)...);
 }
 
 template<typename Sink, typename... SinkArgs>
-inline std::shared_ptr<spdlog::logger> create_async_nb(std::string logger_name, SinkArgs &&... sink_args)
+inline std::shared_ptr<chipStar_spdlog::logger> create_async_nb(std::string logger_name, SinkArgs &&... sink_args)
 {
     return async_factory_nonblock::create<Sink>(std::move(logger_name), std::forward<SinkArgs>(sink_args)...);
 }
@@ -80,8 +80,8 @@ inline void init_thread_pool(size_t q_size, size_t thread_count)
 }
 
 // get the global thread pool.
-inline std::shared_ptr<spdlog::details::thread_pool> thread_pool()
+inline std::shared_ptr<chipStar_spdlog::details::thread_pool> thread_pool()
 {
     return details::registry::instance().get_tp();
 }
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/async_logger.h
+++ b/include/spdlog/async_logger.h
@@ -26,7 +26,7 @@
 #include <memory>
 #include <string>
 
-namespace spdlog {
+namespace chipStar_spdlog {
 
 // Async overflow policy - block by default.
 enum class async_overflow_policy
@@ -68,6 +68,6 @@ private:
     std::weak_ptr<details::thread_pool> thread_pool_;
     async_overflow_policy overflow_policy_;
 };
-} // namespace spdlog
+} // namespace chipStar_spdlog
 
 #include "details/async_logger_impl.h"

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -64,7 +64,7 @@
 #define SPDLOG_FILE_BASENAME(file) SPDLOG_STRRCHR("/" file, '/') + 1
 #endif
 
-namespace spdlog {
+namespace chipStar_spdlog {
 
 class formatter;
 
@@ -122,16 +122,16 @@ enum level_enum {
 static string_view_t level_string_views[] SPDLOG_LEVEL_NAMES;
 static const char *short_level_names[]{"T", "D", "I", "W", "E", "C", "O"};
 
-inline string_view_t &to_string_view(spdlog::level::level_enum l)
+inline string_view_t &to_string_view(chipStar_spdlog::level::level_enum l)
     SPDLOG_NOEXCEPT {
   return level_string_views[l];
 }
 
-inline const char *to_short_c_str(spdlog::level::level_enum l) SPDLOG_NOEXCEPT {
+inline const char *to_short_c_str(chipStar_spdlog::level::level_enum l) SPDLOG_NOEXCEPT {
   return short_level_names[l];
 }
 
-inline spdlog::level::level_enum from_str(const std::string &name)
+inline chipStar_spdlog::level::level_enum from_str(const std::string &name)
     SPDLOG_NOEXCEPT {
   int level = 0;
   for (const auto &level_str : level_string_views) {

--- a/include/spdlog/details/async_logger_impl.h
+++ b/include/spdlog/details/async_logger_impl.h
@@ -15,7 +15,7 @@
 #include <string>
 
 template<typename It>
-inline spdlog::async_logger::async_logger(
+inline chipStar_spdlog::async_logger::async_logger(
     std::string logger_name, It begin, It end, std::weak_ptr<details::thread_pool> tp, async_overflow_policy overflow_policy)
     : logger(std::move(logger_name), begin, end)
     , thread_pool_(std::move(tp))
@@ -23,20 +23,20 @@ inline spdlog::async_logger::async_logger(
 {
 }
 
-inline spdlog::async_logger::async_logger(
+inline chipStar_spdlog::async_logger::async_logger(
     std::string logger_name, sinks_init_list sinks_list, std::weak_ptr<details::thread_pool> tp, async_overflow_policy overflow_policy)
     : async_logger(std::move(logger_name), sinks_list.begin(), sinks_list.end(), std::move(tp), overflow_policy)
 {
 }
 
-inline spdlog::async_logger::async_logger(
+inline chipStar_spdlog::async_logger::async_logger(
     std::string logger_name, sink_ptr single_sink, std::weak_ptr<details::thread_pool> tp, async_overflow_policy overflow_policy)
     : async_logger(std::move(logger_name), {std::move(single_sink)}, std::move(tp), overflow_policy)
 {
 }
 
 // send the log message to the thread pool
-inline void spdlog::async_logger::sink_it_(details::log_msg &msg)
+inline void chipStar_spdlog::async_logger::sink_it_(details::log_msg &msg)
 {
 #if defined(SPDLOG_ENABLE_MESSAGE_COUNTER)
     incr_msg_counter_(msg);
@@ -52,7 +52,7 @@ inline void spdlog::async_logger::sink_it_(details::log_msg &msg)
 }
 
 // send flush request to the thread pool
-inline void spdlog::async_logger::flush_()
+inline void chipStar_spdlog::async_logger::flush_()
 {
     if (auto pool_ptr = thread_pool_.lock())
     {
@@ -67,7 +67,7 @@ inline void spdlog::async_logger::flush_()
 //
 // backend functions - called from the thread pool to do the actual job
 //
-inline void spdlog::async_logger::backend_log_(const details::log_msg &incoming_log_msg)
+inline void chipStar_spdlog::async_logger::backend_log_(const details::log_msg &incoming_log_msg)
 {
     try
     {
@@ -87,7 +87,7 @@ inline void spdlog::async_logger::backend_log_(const details::log_msg &incoming_
     }
 }
 
-inline void spdlog::async_logger::backend_flush_()
+inline void chipStar_spdlog::async_logger::backend_flush_()
 {
     try
     {
@@ -99,9 +99,9 @@ inline void spdlog::async_logger::backend_flush_()
     SPDLOG_CATCH_AND_HANDLE
 }
 
-inline std::shared_ptr<spdlog::logger> spdlog::async_logger::clone(std::string new_name)
+inline std::shared_ptr<chipStar_spdlog::logger> chipStar_spdlog::async_logger::clone(std::string new_name)
 {
-    auto cloned = std::make_shared<spdlog::async_logger>(std::move(new_name), sinks_.begin(), sinks_.end(), thread_pool_, overflow_policy_);
+    auto cloned = std::make_shared<chipStar_spdlog::async_logger>(std::move(new_name), sinks_.begin(), sinks_.end(), thread_pool_, overflow_policy_);
 
     cloned->set_level(this->level());
     cloned->flush_on(this->flush_level());

--- a/include/spdlog/details/circular_q.h
+++ b/include/spdlog/details/circular_q.h
@@ -8,7 +8,7 @@
 
 #include <vector>
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace details {
 template<typename T>
 class circular_q
@@ -69,4 +69,4 @@ private:
     size_t overrun_counter_ = 0;
 };
 } // namespace details
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/details/console_globals.h
+++ b/include/spdlog/details/console_globals.h
@@ -21,7 +21,7 @@
 #include <windows.h>
 #endif
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace details {
 struct console_stdout
 {
@@ -71,4 +71,4 @@ struct console_nullmutex
     }
 };
 } // namespace details
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/details/file_helper.h
+++ b/include/spdlog/details/file_helper.h
@@ -19,7 +19,7 @@
 #include <thread>
 #include <tuple>
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace details {
 
 class file_helper
@@ -122,7 +122,7 @@ public:
     // ".mylog" => (".mylog". "")
     // "my_folder/.mylog" => ("my_folder/.mylog", "")
     // "my_folder/.mylog.txt" => ("my_folder/.mylog", ".txt")
-    static std::tuple<filename_t, filename_t> split_by_extenstion(const spdlog::filename_t &fname)
+    static std::tuple<filename_t, filename_t> split_by_extenstion(const chipStar_spdlog::filename_t &fname)
     {
         auto ext_index = fname.rfind('.');
 
@@ -130,14 +130,14 @@ public:
         // extension
         if (ext_index == filename_t::npos || ext_index == 0 || ext_index == fname.size() - 1)
         {
-            return std::make_tuple(fname, spdlog::filename_t());
+            return std::make_tuple(fname, chipStar_spdlog::filename_t());
         }
 
         // treat casese like "/etc/rc.d/somelogfile or "/abc/.hiddenfile"
         auto folder_index = fname.rfind(details::os::folder_sep);
         if (folder_index != filename_t::npos && folder_index >= ext_index - 1)
         {
-            return std::make_tuple(fname, spdlog::filename_t());
+            return std::make_tuple(fname, chipStar_spdlog::filename_t());
         }
 
         // finally - return a valid base and extension tuple
@@ -149,4 +149,4 @@ private:
     filename_t _filename;
 };
 } // namespace details
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/details/fmt_helper.h
+++ b/include/spdlog/details/fmt_helper.h
@@ -9,14 +9,14 @@
 #include "spdlog/fmt/fmt.h"
 
 // Some fmt helpers to efficiently format and pad ints and strings
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace details {
 namespace fmt_helper {
 
 template<size_t Buffer_Size>
-inline spdlog::string_view_t to_string_view(const fmt::basic_memory_buffer<char, Buffer_Size> &buf) SPDLOG_NOEXCEPT
+inline chipStar_spdlog::string_view_t to_string_view(const fmt::basic_memory_buffer<char, Buffer_Size> &buf) SPDLOG_NOEXCEPT
 {
-    return spdlog::string_view_t(buf.data(), buf.size());
+    return chipStar_spdlog::string_view_t(buf.data(), buf.size());
 }
 
 template<size_t Buffer_Size1, size_t Buffer_Size2>
@@ -27,7 +27,7 @@ inline void append_buf(const fmt::basic_memory_buffer<char, Buffer_Size1> &buf, 
 }
 
 template<size_t Buffer_Size>
-inline void append_string_view(spdlog::string_view_t view, fmt::basic_memory_buffer<char, Buffer_Size> &dest)
+inline void append_string_view(chipStar_spdlog::string_view_t view, fmt::basic_memory_buffer<char, Buffer_Size> &dest)
 {
     auto *buf_ptr = view.data();
     if (buf_ptr != nullptr)
@@ -119,4 +119,4 @@ inline ToDuration time_fraction(const log_clock::time_point &tp)
 
 } // namespace fmt_helper
 } // namespace details
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -11,7 +11,7 @@
 #include <string>
 #include <utility>
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace details {
 struct log_msg
 {
@@ -52,4 +52,4 @@ struct log_msg
     const string_view_t payload;
 };
 } // namespace details
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/details/logger_impl.h
+++ b/include/spdlog/details/logger_impl.h
@@ -23,27 +23,27 @@
 // create logger with given name, sinks and the default pattern formatter
 // all other ctors will call this one
 template<typename It>
-inline spdlog::logger::logger(std::string logger_name, It begin, It end)
+inline chipStar_spdlog::logger::logger(std::string logger_name, It begin, It end)
     : name_(std::move(logger_name))
     , sinks_(begin, end)
 {
 }
 
 // ctor with sinks as init list
-inline spdlog::logger::logger(std::string logger_name, sinks_init_list sinks_list)
+inline chipStar_spdlog::logger::logger(std::string logger_name, sinks_init_list sinks_list)
     : logger(std::move(logger_name), sinks_list.begin(), sinks_list.end())
 {
 }
 
 // ctor with single sink
-inline spdlog::logger::logger(std::string logger_name, spdlog::sink_ptr single_sink)
+inline chipStar_spdlog::logger::logger(std::string logger_name, chipStar_spdlog::sink_ptr single_sink)
     : logger(std::move(logger_name), {std::move(single_sink)})
 {
 }
 
-inline spdlog::logger::~logger() = default;
+inline chipStar_spdlog::logger::~logger() = default;
 
-inline void spdlog::logger::set_formatter(std::unique_ptr<spdlog::formatter> f)
+inline void chipStar_spdlog::logger::set_formatter(std::unique_ptr<chipStar_spdlog::formatter> f)
 {
     for (auto &sink : sinks_)
     {
@@ -51,14 +51,14 @@ inline void spdlog::logger::set_formatter(std::unique_ptr<spdlog::formatter> f)
     }
 }
 
-inline void spdlog::logger::set_pattern(std::string pattern, pattern_time_type time_type)
+inline void chipStar_spdlog::logger::set_pattern(std::string pattern, pattern_time_type time_type)
 {
-    auto new_formatter = details::make_unique<spdlog::pattern_formatter>(std::move(pattern), time_type);
+    auto new_formatter = details::make_unique<chipStar_spdlog::pattern_formatter>(std::move(pattern), time_type);
     set_formatter(std::move(new_formatter));
 }
 
 template<typename... Args>
-inline void spdlog::logger::log(source_loc source, level::level_enum lvl, const char *fmt, const Args &... args)
+inline void chipStar_spdlog::logger::log(source_loc source, level::level_enum lvl, const char *fmt, const Args &... args)
 {
     if (!should_log(lvl))
     {
@@ -77,12 +77,12 @@ inline void spdlog::logger::log(source_loc source, level::level_enum lvl, const 
 }
 
 template<typename... Args>
-inline void spdlog::logger::log(level::level_enum lvl, const char *fmt, const Args &... args)
+inline void chipStar_spdlog::logger::log(level::level_enum lvl, const char *fmt, const Args &... args)
 {
     log(source_loc{}, lvl, fmt, args...);
 }
 
-inline void spdlog::logger::log(source_loc source, level::level_enum lvl, const char *msg)
+inline void chipStar_spdlog::logger::log(source_loc source, level::level_enum lvl, const char *msg)
 {
     if (!should_log(lvl))
     {
@@ -91,19 +91,19 @@ inline void spdlog::logger::log(source_loc source, level::level_enum lvl, const 
 
     try
     {
-        details::log_msg log_msg(source, &name_, lvl, spdlog::string_view_t(msg));
+        details::log_msg log_msg(source, &name_, lvl, chipStar_spdlog::string_view_t(msg));
         sink_it_(log_msg);
     }
     SPDLOG_CATCH_AND_HANDLE
 }
 
-inline void spdlog::logger::log(level::level_enum lvl, const char *msg)
+inline void chipStar_spdlog::logger::log(level::level_enum lvl, const char *msg)
 {
     log(source_loc{}, lvl, msg);
 }
 
-template<class T, typename std::enable_if<std::is_convertible<T, spdlog::string_view_t>::value, T>::type *>
-inline void spdlog::logger::log(source_loc source, level::level_enum lvl, const T &msg)
+template<class T, typename std::enable_if<std::is_convertible<T, chipStar_spdlog::string_view_t>::value, T>::type *>
+inline void chipStar_spdlog::logger::log(source_loc source, level::level_enum lvl, const T &msg)
 {
     if (!should_log(lvl))
     {
@@ -117,14 +117,14 @@ inline void spdlog::logger::log(source_loc source, level::level_enum lvl, const 
     SPDLOG_CATCH_AND_HANDLE
 }
 
-template<class T, typename std::enable_if<std::is_convertible<T, spdlog::string_view_t>::value, T>::type *>
-inline void spdlog::logger::log(level::level_enum lvl, const T &msg)
+template<class T, typename std::enable_if<std::is_convertible<T, chipStar_spdlog::string_view_t>::value, T>::type *>
+inline void chipStar_spdlog::logger::log(level::level_enum lvl, const T &msg)
 {
     log(source_loc{}, lvl, msg);
 }
 
-template<class T, typename std::enable_if<!std::is_convertible<T, spdlog::string_view_t>::value, T>::type *>
-inline void spdlog::logger::log(source_loc source, level::level_enum lvl, const T &msg)
+template<class T, typename std::enable_if<!std::is_convertible<T, chipStar_spdlog::string_view_t>::value, T>::type *>
+inline void chipStar_spdlog::logger::log(source_loc source, level::level_enum lvl, const T &msg)
 {
     if (!should_log(lvl))
     {
@@ -141,80 +141,80 @@ inline void spdlog::logger::log(source_loc source, level::level_enum lvl, const 
     SPDLOG_CATCH_AND_HANDLE
 }
 
-template<class T, typename std::enable_if<!std::is_convertible<T, spdlog::string_view_t>::value, T>::type *>
-inline void spdlog::logger::log(level::level_enum lvl, const T &msg)
+template<class T, typename std::enable_if<!std::is_convertible<T, chipStar_spdlog::string_view_t>::value, T>::type *>
+inline void chipStar_spdlog::logger::log(level::level_enum lvl, const T &msg)
 {
     log(source_loc{}, lvl, msg);
 }
 
 template<typename... Args>
-inline void spdlog::logger::trace(const char *fmt, const Args &... args)
+inline void chipStar_spdlog::logger::trace(const char *fmt, const Args &... args)
 {
     log(level::trace, fmt, args...);
 }
 
 template<typename... Args>
-inline void spdlog::logger::debug(const char *fmt, const Args &... args)
+inline void chipStar_spdlog::logger::debug(const char *fmt, const Args &... args)
 {
     log(level::debug, fmt, args...);
 }
 
 template<typename... Args>
-inline void spdlog::logger::info(const char *fmt, const Args &... args)
+inline void chipStar_spdlog::logger::info(const char *fmt, const Args &... args)
 {
     log(level::info, fmt, args...);
 }
 
 template<typename... Args>
-inline void spdlog::logger::warn(const char *fmt, const Args &... args)
+inline void chipStar_spdlog::logger::warn(const char *fmt, const Args &... args)
 {
     log(level::warn, fmt, args...);
 }
 
 template<typename... Args>
-inline void spdlog::logger::error(const char *fmt, const Args &... args)
+inline void chipStar_spdlog::logger::error(const char *fmt, const Args &... args)
 {
     log(level::err, fmt, args...);
 }
 
 template<typename... Args>
-inline void spdlog::logger::critical(const char *fmt, const Args &... args)
+inline void chipStar_spdlog::logger::critical(const char *fmt, const Args &... args)
 {
     log(level::critical, fmt, args...);
 }
 
 template<typename T>
-inline void spdlog::logger::trace(const T &msg)
+inline void chipStar_spdlog::logger::trace(const T &msg)
 {
     log(level::trace, msg);
 }
 
 template<typename T>
-inline void spdlog::logger::debug(const T &msg)
+inline void chipStar_spdlog::logger::debug(const T &msg)
 {
     log(level::debug, msg);
 }
 
 template<typename T>
-inline void spdlog::logger::info(const T &msg)
+inline void chipStar_spdlog::logger::info(const T &msg)
 {
     log(level::info, msg);
 }
 
 template<typename T>
-inline void spdlog::logger::warn(const T &msg)
+inline void chipStar_spdlog::logger::warn(const T &msg)
 {
     log(level::warn, msg);
 }
 
 template<typename T>
-inline void spdlog::logger::error(const T &msg)
+inline void chipStar_spdlog::logger::error(const T &msg)
 {
     log(level::err, msg);
 }
 
 template<typename T>
-inline void spdlog::logger::critical(const T &msg)
+inline void chipStar_spdlog::logger::critical(const T &msg)
 {
     log(level::critical, msg);
 }
@@ -238,12 +238,12 @@ inline void wbuf_to_utf8buf(const fmt::wmemory_buffer &wbuf, fmt::memory_buffer 
     }
     else
     {
-        throw spdlog::spdlog_ex(fmt::format("WideCharToMultiByte failed. Last error: {}", ::GetLastError()));
+        throw chipStar_spdlog::spdlog_ex(fmt::format("WideCharToMultiByte failed. Last error: {}", ::GetLastError()));
     }
 }
 
 template<typename... Args>
-inline void spdlog::logger::log(source_loc source, level::level_enum lvl, const wchar_t *fmt, const Args &... args)
+inline void chipStar_spdlog::logger::log(source_loc source, level::level_enum lvl, const wchar_t *fmt, const Args &... args)
 {
     if (!should_log(lvl))
     {
@@ -265,43 +265,43 @@ inline void spdlog::logger::log(source_loc source, level::level_enum lvl, const 
 }
 
 template<typename... Args>
-inline void spdlog::logger::log(level::level_enum lvl, const wchar_t *fmt, const Args &... args)
+inline void chipStar_spdlog::logger::log(level::level_enum lvl, const wchar_t *fmt, const Args &... args)
 {
     log(source_loc{}, lvl, fmt, args...);
 }
 
 template<typename... Args>
-inline void spdlog::logger::trace(const wchar_t *fmt, const Args &... args)
+inline void chipStar_spdlog::logger::trace(const wchar_t *fmt, const Args &... args)
 {
     log(level::trace, fmt, args...);
 }
 
 template<typename... Args>
-inline void spdlog::logger::debug(const wchar_t *fmt, const Args &... args)
+inline void chipStar_spdlog::logger::debug(const wchar_t *fmt, const Args &... args)
 {
     log(level::debug, fmt, args...);
 }
 
 template<typename... Args>
-inline void spdlog::logger::info(const wchar_t *fmt, const Args &... args)
+inline void chipStar_spdlog::logger::info(const wchar_t *fmt, const Args &... args)
 {
     log(level::info, fmt, args...);
 }
 
 template<typename... Args>
-inline void spdlog::logger::warn(const wchar_t *fmt, const Args &... args)
+inline void chipStar_spdlog::logger::warn(const wchar_t *fmt, const Args &... args)
 {
     log(level::warn, fmt, args...);
 }
 
 template<typename... Args>
-inline void spdlog::logger::error(const wchar_t *fmt, const Args &... args)
+inline void chipStar_spdlog::logger::error(const wchar_t *fmt, const Args &... args)
 {
     log(level::err, fmt, args...);
 }
 
 template<typename... Args>
-inline void spdlog::logger::critical(const wchar_t *fmt, const Args &... args)
+inline void chipStar_spdlog::logger::critical(const wchar_t *fmt, const Args &... args)
 {
     log(level::critical, fmt, args...);
 }
@@ -311,27 +311,27 @@ inline void spdlog::logger::critical(const wchar_t *fmt, const Args &... args)
 //
 // name and level
 //
-inline const std::string &spdlog::logger::name() const
+inline const std::string &chipStar_spdlog::logger::name() const
 {
     return name_;
 }
 
-inline void spdlog::logger::set_level(spdlog::level::level_enum log_level)
+inline void chipStar_spdlog::logger::set_level(chipStar_spdlog::level::level_enum log_level)
 {
     level_.store(log_level);
 }
 
-inline void spdlog::logger::set_error_handler(spdlog::log_err_handler err_handler)
+inline void chipStar_spdlog::logger::set_error_handler(chipStar_spdlog::log_err_handler err_handler)
 {
     err_handler_ = std::move(err_handler);
 }
 
-inline spdlog::log_err_handler spdlog::logger::error_handler() const
+inline chipStar_spdlog::log_err_handler chipStar_spdlog::logger::error_handler() const
 {
     return err_handler_;
 }
 
-inline void spdlog::logger::flush()
+inline void chipStar_spdlog::logger::flush()
 {
     try
     {
@@ -340,33 +340,33 @@ inline void spdlog::logger::flush()
     SPDLOG_CATCH_AND_HANDLE
 }
 
-inline void spdlog::logger::flush_on(level::level_enum log_level)
+inline void chipStar_spdlog::logger::flush_on(level::level_enum log_level)
 {
     flush_level_.store(log_level);
 }
 
-inline spdlog::level::level_enum spdlog::logger::flush_level() const
+inline chipStar_spdlog::level::level_enum chipStar_spdlog::logger::flush_level() const
 {
-    return static_cast<spdlog::level::level_enum>(flush_level_.load(std::memory_order_relaxed));
+    return static_cast<chipStar_spdlog::level::level_enum>(flush_level_.load(std::memory_order_relaxed));
 }
 
-inline bool spdlog::logger::should_flush_(const details::log_msg &msg)
+inline bool chipStar_spdlog::logger::should_flush_(const details::log_msg &msg)
 {
     auto flush_level = flush_level_.load(std::memory_order_relaxed);
     return (msg.level >= flush_level) && (msg.level != level::off);
 }
 
-inline spdlog::level::level_enum spdlog::logger::default_level()
+inline chipStar_spdlog::level::level_enum chipStar_spdlog::logger::default_level()
 {
-    return static_cast<spdlog::level::level_enum>(SPDLOG_ACTIVE_LEVEL);
+    return static_cast<chipStar_spdlog::level::level_enum>(SPDLOG_ACTIVE_LEVEL);
 }
 
-inline spdlog::level::level_enum spdlog::logger::level() const
+inline chipStar_spdlog::level::level_enum chipStar_spdlog::logger::level() const
 {
-    return static_cast<spdlog::level::level_enum>(level_.load(std::memory_order_relaxed));
+    return static_cast<chipStar_spdlog::level::level_enum>(level_.load(std::memory_order_relaxed));
 }
 
-inline bool spdlog::logger::should_log(spdlog::level::level_enum msg_level) const
+inline bool chipStar_spdlog::logger::should_log(chipStar_spdlog::level::level_enum msg_level) const
 {
     return msg_level >= level_.load(std::memory_order_relaxed);
 }
@@ -375,7 +375,7 @@ inline bool spdlog::logger::should_log(spdlog::level::level_enum msg_level) cons
 // protected virtual called at end of each user log call (if enabled) by the
 // line_logger
 //
-inline void spdlog::logger::sink_it_(details::log_msg &msg)
+inline void chipStar_spdlog::logger::sink_it_(details::log_msg &msg)
 {
 #if defined(SPDLOG_ENABLE_MESSAGE_COUNTER)
     incr_msg_counter_(msg);
@@ -394,7 +394,7 @@ inline void spdlog::logger::sink_it_(details::log_msg &msg)
     }
 }
 
-inline void spdlog::logger::flush_()
+inline void chipStar_spdlog::logger::flush_()
 {
     for (auto &sink : sinks_)
     {
@@ -402,7 +402,7 @@ inline void spdlog::logger::flush_()
     }
 }
 
-inline void spdlog::logger::default_err_handler_(const std::string &msg)
+inline void chipStar_spdlog::logger::default_err_handler_(const std::string &msg)
 {
     auto now = time(nullptr);
     if (now - last_err_time_ < 60)
@@ -416,24 +416,24 @@ inline void spdlog::logger::default_err_handler_(const std::string &msg)
     fmt::print(stderr, "[*** LOG ERROR ***] [{}] [{}] {}\n", date_buf, name(), msg);
 }
 
-inline void spdlog::logger::incr_msg_counter_(details::log_msg &msg)
+inline void chipStar_spdlog::logger::incr_msg_counter_(details::log_msg &msg)
 {
     msg.msg_id = msg_counter_.fetch_add(1, std::memory_order_relaxed);
 }
 
-inline const std::vector<spdlog::sink_ptr> &spdlog::logger::sinks() const
+inline const std::vector<chipStar_spdlog::sink_ptr> &chipStar_spdlog::logger::sinks() const
 {
     return sinks_;
 }
 
-inline std::vector<spdlog::sink_ptr> &spdlog::logger::sinks()
+inline std::vector<chipStar_spdlog::sink_ptr> &chipStar_spdlog::logger::sinks()
 {
     return sinks_;
 }
 
-inline std::shared_ptr<spdlog::logger> spdlog::logger::clone(std::string logger_name)
+inline std::shared_ptr<chipStar_spdlog::logger> chipStar_spdlog::logger::clone(std::string logger_name)
 {
-    auto cloned = std::make_shared<spdlog::logger>(std::move(logger_name), sinks_.begin(), sinks_.end());
+    auto cloned = std::make_shared<chipStar_spdlog::logger>(std::move(logger_name), sinks_.begin(), sinks_.end());
     cloned->set_level(this->level());
     cloned->flush_on(this->flush_level());
     cloned->set_error_handler(this->error_handler());

--- a/include/spdlog/details/mpmc_blocking_q.h
+++ b/include/spdlog/details/mpmc_blocking_q.h
@@ -17,7 +17,7 @@
 #include <condition_variable>
 #include <mutex>
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace details {
 
 template<typename T>
@@ -115,7 +115,7 @@ private:
     std::mutex queue_mutex_;
     std::condition_variable push_cv_;
     std::condition_variable pop_cv_;
-    spdlog::details::circular_q<T> q_;
+    chipStar_spdlog::details::circular_q<T> q_;
 };
 } // namespace details
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/details/null_mutex.h
+++ b/include/spdlog/details/null_mutex.h
@@ -8,7 +8,7 @@
 #include <atomic>
 // null, no cost dummy "mutex" and dummy "atomic" int
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace details {
 struct null_mutex
 {
@@ -42,4 +42,4 @@ struct null_atomic_int
 };
 
 } // namespace details
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -53,11 +53,11 @@
 #define __has_feature(x) 0 // Compatibility with non-clang compilers.
 #endif
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace details {
 namespace os {
 
-inline spdlog::log_clock::time_point now() SPDLOG_NOEXCEPT
+inline chipStar_spdlog::log_clock::time_point now() SPDLOG_NOEXCEPT
 {
 
 #if defined __linux__ && defined SPDLOG_CLOCK_COARSE
@@ -258,7 +258,7 @@ inline int utc_minutes_offset(const std::tm &tm = details::os::localtime())
     auto rv = GetDynamicTimeZoneInformation(&tzinfo);
 #endif
     if (rv == TIME_ZONE_ID_INVALID)
-        throw spdlog::spdlog_ex("Failed getting timezone info. ", errno);
+        throw chipStar_spdlog::spdlog_ex("Failed getting timezone info. ", errno);
 
     int offset = -tzinfo.Bias;
     if (tm.tm_isdst)
@@ -418,4 +418,4 @@ inline bool in_terminal(FILE *file) SPDLOG_NOEXCEPT
 }
 } // namespace os
 } // namespace details
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/details/pattern_formatter.h
+++ b/include/spdlog/details/pattern_formatter.h
@@ -22,7 +22,7 @@
 #include <utility>
 #include <vector>
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace details {
 
 // padding information.
@@ -79,7 +79,7 @@ public:
         }
     }
 
-    scoped_pad(spdlog::string_view_t txt, padding_info &padinfo, fmt::memory_buffer &dest)
+    scoped_pad(chipStar_spdlog::string_view_t txt, padding_info &padinfo, fmt::memory_buffer &dest)
         : scoped_pad(txt.size(), padinfo, dest)
     {
     }
@@ -998,7 +998,7 @@ class pattern_formatter final : public formatter
 {
 public:
     explicit pattern_formatter(
-        std::string pattern, pattern_time_type time_type = pattern_time_type::local, std::string eol = spdlog::details::os::default_eol)
+        std::string pattern, pattern_time_type time_type = pattern_time_type::local, std::string eol = chipStar_spdlog::details::os::default_eol)
         : pattern_(std::move(pattern))
         , eol_(std::move(eol))
         , pattern_time_type_(time_type)
@@ -1009,7 +1009,7 @@ public:
     }
 
     // use by default full formatter for if pattern is not given
-    explicit pattern_formatter(pattern_time_type time_type = pattern_time_type::local, std::string eol = spdlog::details::os::default_eol)
+    explicit pattern_formatter(pattern_time_type time_type = pattern_time_type::local, std::string eol = chipStar_spdlog::details::os::default_eol)
         : pattern_("%+")
         , eol_(std::move(eol))
         , pattern_time_type_(time_type)
@@ -1312,4 +1312,4 @@ private:
         }
     }
 };
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/details/periodic_worker.h
+++ b/include/spdlog/details/periodic_worker.h
@@ -17,7 +17,7 @@
 #include <functional>
 #include <mutex>
 #include <thread>
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace details {
 
 class periodic_worker
@@ -68,4 +68,4 @@ private:
     std::condition_variable cv_;
 };
 } // namespace details
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -29,7 +29,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace details {
 class thread_pool;
 
@@ -78,9 +78,9 @@ public:
     }
 
     // Return raw ptr to the default logger.
-    // To be used directly by the spdlog default api (e.g. spdlog::info)
+    // To be used directly by the spdlog default api (e.g. chipStar_spdlog::info)
     // This make the default API faster, but cannot be used concurrently with set_default_logger().
-    // e.g do not call set_default_logger() from one thread while calling spdlog::info() from another.
+    // e.g do not call set_default_logger() from one thread while calling chipStar_spdlog::info() from another.
     logger *get_default_raw()
     {
         return default_logger_.get();
@@ -245,7 +245,7 @@ private:
 #endif
 
         const char *default_logger_name = "";
-        default_logger_ = std::make_shared<spdlog::logger>(default_logger_name, std::move(color_sink));
+        default_logger_ = std::make_shared<chipStar_spdlog::logger>(default_logger_name, std::move(color_sink));
         loggers_[default_logger_name] = default_logger_;
 
 #endif // SPDLOG_DISABLE_DEFAULT_LOGGER
@@ -272,7 +272,7 @@ private:
     std::recursive_mutex tp_mutex_;
     std::unordered_map<std::string, std::shared_ptr<logger>> loggers_;
     std::unique_ptr<formatter> formatter_;
-    level::level_enum level_ = spdlog::logger::default_level();
+    level::level_enum level_ = chipStar_spdlog::logger::default_level();
     level::level_enum flush_level_ = level::off;
     log_err_handler err_handler_;
     std::shared_ptr<thread_pool> tp_;
@@ -282,4 +282,4 @@ private:
 };
 
 } // namespace details
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/details/thread_pool.h
+++ b/include/spdlog/details/thread_pool.h
@@ -10,10 +10,10 @@
 #include <thread>
 #include <vector>
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace details {
 
-using async_logger_ptr = std::shared_ptr<spdlog::async_logger>;
+using async_logger_ptr = std::shared_ptr<chipStar_spdlog::async_logger>;
 
 enum class async_msg_type
 {
@@ -128,7 +128,7 @@ public:
         // "\tthreads_n: " << threads_n << std::endl;
         if (threads_n == 0 || threads_n > 1000)
         {
-            throw spdlog_ex("spdlog::thread_pool(): invalid threads_n param (valid "
+            throw spdlog_ex("chipStar_spdlog::thread_pool(): invalid threads_n param (valid "
                             "range is 1-1000)");
         }
         for (size_t i = 0; i < threads_n; i++)
@@ -235,4 +235,4 @@ private:
 };
 
 } // namespace details
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/fmt/bin_to_hex.h
+++ b/include/spdlog/fmt/bin_to_hex.h
@@ -17,11 +17,11 @@
 // Examples:
 //
 // std::vector<char> v(200, 0x0b);
-// logger->info("Some buffer {}", spdlog::to_hex(v));
+// logger->info("Some buffer {}", chipStar_spdlog::to_hex(v));
 // char buf[128];
-// logger->info("Some buffer {:X}", spdlog::to_hex(std::begin(buf), std::end(buf)));
+// logger->info("Some buffer {:X}", chipStar_spdlog::to_hex(std::begin(buf), std::end(buf)));
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace details {
 
 template<typename It>
@@ -64,12 +64,12 @@ inline details::bytes_range<It> to_hex(const It range_begin, const It range_end)
     return details::bytes_range<It>(range_begin, range_end);
 }
 
-} // namespace spdlog
+} // namespace chipStar_spdlog
 
 namespace fmt {
 
 template<typename T>
-struct formatter<spdlog::details::bytes_range<T>>
+struct formatter<chipStar_spdlog::details::bytes_range<T>>
 {
     const std::size_t line_size = 100;
     const char delimiter = ' ';
@@ -109,7 +109,7 @@ struct formatter<spdlog::details::bytes_range<T>>
 
     // format the given bytes range as hex
     template<typename FormatContext, typename Container>
-    auto format(const spdlog::details::bytes_range<Container> &the_range, FormatContext &ctx) -> decltype(ctx.out())
+    auto format(const chipStar_spdlog::details::bytes_range<Container> &the_range, FormatContext &ctx) -> decltype(ctx.out())
     {
         SPDLOG_CONSTEXPR const char *hex_upper = "0123456789ABCDEF";
         SPDLOG_CONSTEXPR const char *hex_lower = "0123456789abcdef";

--- a/include/spdlog/formatter.h
+++ b/include/spdlog/formatter.h
@@ -8,7 +8,7 @@
 #include "fmt/fmt.h"
 #include "spdlog/details/log_msg.h"
 
-namespace spdlog {
+namespace chipStar_spdlog {
 
 class formatter
 {
@@ -17,4 +17,4 @@ public:
     virtual void format(const details::log_msg &msg, fmt::memory_buffer &dest) = 0;
     virtual std::unique_ptr<formatter> clone() const = 0;
 };
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-namespace spdlog {
+namespace chipStar_spdlog {
 
 class logger
 {
@@ -101,19 +101,19 @@ public:
 #endif // SPDLOG_WCHAR_TO_UTF8_SUPPORT
 
     // T can be statically converted to string_view
-    template<class T, typename std::enable_if<std::is_convertible<T, spdlog::string_view_t>::value, T>::type * = nullptr>
+    template<class T, typename std::enable_if<std::is_convertible<T, chipStar_spdlog::string_view_t>::value, T>::type * = nullptr>
     void log(level::level_enum lvl, const T &);
 
     // T can be statically converted to string_view
-    template<class T, typename std::enable_if<std::is_convertible<T, spdlog::string_view_t>::value, T>::type * = nullptr>
+    template<class T, typename std::enable_if<std::is_convertible<T, chipStar_spdlog::string_view_t>::value, T>::type * = nullptr>
     void log(source_loc loc, level::level_enum lvl, const T &);
 
     // T cannot be statically converted to string_view
-    template<class T, typename std::enable_if<!std::is_convertible<T, spdlog::string_view_t>::value, T>::type * = nullptr>
+    template<class T, typename std::enable_if<!std::is_convertible<T, chipStar_spdlog::string_view_t>::value, T>::type * = nullptr>
     void log(level::level_enum lvl, const T &);
 
     // T cannot be statically converted to string_view
-    template<class T, typename std::enable_if<!std::is_convertible<T, spdlog::string_view_t>::value, T>::type * = nullptr>
+    template<class T, typename std::enable_if<!std::is_convertible<T, chipStar_spdlog::string_view_t>::value, T>::type * = nullptr>
     void log(source_loc loc, level::level_enum lvl, const T &);
 
     template<typename T>
@@ -177,12 +177,12 @@ protected:
 
     const std::string name_;
     std::vector<sink_ptr> sinks_;
-    spdlog::level_t level_{spdlog::logger::default_level()};
-    spdlog::level_t flush_level_{level::off};
+    chipStar_spdlog::level_t level_{chipStar_spdlog::logger::default_level()};
+    chipStar_spdlog::level_t flush_level_{level::off};
     log_err_handler err_handler_{[this](const std::string &msg) { this->default_err_handler_(msg); }};
     std::atomic<time_t> last_err_time_{0};
     std::atomic<size_t> msg_counter_{1};
 };
-} // namespace spdlog
+} // namespace chipStar_spdlog
 
 #include "details/logger_impl.h"

--- a/include/spdlog/sinks/android_sink.h
+++ b/include/spdlog/sinks/android_sink.h
@@ -24,7 +24,7 @@
 #define SPDLOG_ANDROID_RETRIES 2
 #endif
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace sinks {
 
 /*
@@ -75,21 +75,21 @@ protected:
     void flush_() override {}
 
 private:
-    static android_LogPriority convert_to_android_(spdlog::level::level_enum level)
+    static android_LogPriority convert_to_android_(chipStar_spdlog::level::level_enum level)
     {
         switch (level)
         {
-        case spdlog::level::trace:
+        case chipStar_spdlog::level::trace:
             return ANDROID_LOG_VERBOSE;
-        case spdlog::level::debug:
+        case chipStar_spdlog::level::debug:
             return ANDROID_LOG_DEBUG;
-        case spdlog::level::info:
+        case chipStar_spdlog::level::info:
             return ANDROID_LOG_INFO;
-        case spdlog::level::warn:
+        case chipStar_spdlog::level::warn:
             return ANDROID_LOG_WARN;
-        case spdlog::level::err:
+        case chipStar_spdlog::level::err:
             return ANDROID_LOG_ERROR;
-        case spdlog::level::critical:
+        case chipStar_spdlog::level::critical:
             return ANDROID_LOG_FATAL;
         default:
             return ANDROID_LOG_DEFAULT;
@@ -118,4 +118,4 @@ inline std::shared_ptr<logger> android_logger_st(const std::string &logger_name,
     return Factory::template create<sinks::android_sink_st>(logger_name, tag);
 }
 
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -19,7 +19,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace sinks {
 
 /**
@@ -124,10 +124,10 @@ public:
     void set_pattern(const std::string &pattern) final
     {
         std::lock_guard<mutex_t> lock(mutex_);
-        formatter_ = std::unique_ptr<spdlog::formatter>(new pattern_formatter(pattern));
+        formatter_ = std::unique_ptr<chipStar_spdlog::formatter>(new pattern_formatter(pattern));
     }
 
-    void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) override
+    void set_formatter(std::unique_ptr<chipStar_spdlog::formatter> sink_formatter) override
     {
         std::lock_guard<mutex_t> lock(mutex_);
         formatter_ = std::move(sink_formatter);
@@ -158,4 +158,4 @@ using ansicolor_stderr_sink_st = ansicolor_sink<details::console_stderr, details
 
 } // namespace sinks
 
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/sinks/base_sink.h
+++ b/include/spdlog/sinks/base_sink.h
@@ -16,7 +16,7 @@
 #include "spdlog/formatter.h"
 #include "spdlog/sinks/sink.h"
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace sinks {
 template<typename Mutex>
 class base_sink : public sink
@@ -44,7 +44,7 @@ public:
         set_pattern_(pattern);
     }
 
-    void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) final
+    void set_formatter(std::unique_ptr<chipStar_spdlog::formatter> sink_formatter) final
     {
         std::lock_guard<Mutex> lock(mutex_);
         set_formatter_(std::move(sink_formatter));
@@ -56,14 +56,14 @@ protected:
 
     virtual void set_pattern_(const std::string &pattern)
     {
-        set_formatter_(details::make_unique<spdlog::pattern_formatter>(pattern));
+        set_formatter_(details::make_unique<chipStar_spdlog::pattern_formatter>(pattern));
     }
 
-    virtual void set_formatter_(std::unique_ptr<spdlog::formatter> sink_formatter)
+    virtual void set_formatter_(std::unique_ptr<chipStar_spdlog::formatter> sink_formatter)
     {
         formatter_ = std::move(sink_formatter);
     }
     Mutex mutex_;
 };
 } // namespace sinks
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/sinks/basic_file_sink.h
+++ b/include/spdlog/sinks/basic_file_sink.h
@@ -16,7 +16,7 @@
 #include <mutex>
 #include <string>
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace sinks {
 /*
  * Trivial file sink with single file as target
@@ -67,4 +67,4 @@ inline std::shared_ptr<logger> basic_logger_st(const std::string &logger_name, c
     return Factory::template create<sinks::basic_file_sink_st>(logger_name, filename, truncate);
 }
 
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -20,7 +20,7 @@
 #include <mutex>
 #include <string>
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace sinks {
 
 /*
@@ -86,7 +86,7 @@ private:
     tm now_tm(log_clock::time_point tp)
     {
         time_t tnow = log_clock::to_time_t(tp);
-        return spdlog::details::os::localtime(tnow);
+        return chipStar_spdlog::details::os::localtime(tnow);
     }
 
     log_clock::time_point next_rotation_tp_()
@@ -133,4 +133,4 @@ inline std::shared_ptr<logger> daily_logger_st(
 {
     return Factory::template create<sinks::daily_file_sink_st>(logger_name, filename, hour, minute, truncate);
 }
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/sinks/dist_sink.h
+++ b/include/spdlog/sinks/dist_sink.h
@@ -21,7 +21,7 @@
 // Distribution sink (mux). Stores a vector of sinks which get called when log
 // is called
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace sinks {
 
 template<typename Mutex>
@@ -73,10 +73,10 @@ protected:
 
     void set_pattern_(const std::string &pattern) override
     {
-        set_formatter_(details::make_unique<spdlog::pattern_formatter>(pattern));
+        set_formatter_(details::make_unique<chipStar_spdlog::pattern_formatter>(pattern));
     }
 
-    void set_formatter_(std::unique_ptr<spdlog::formatter> sink_formatter) override
+    void set_formatter_(std::unique_ptr<chipStar_spdlog::formatter> sink_formatter) override
     {
         base_sink<Mutex>::formatter_ = std::move(sink_formatter);
         for (auto &sink : sinks_)
@@ -91,4 +91,4 @@ using dist_sink_mt = dist_sink<std::mutex>;
 using dist_sink_st = dist_sink<details::null_mutex>;
 
 } // namespace sinks
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/sinks/msvc_sink.h
+++ b/include/spdlog/sinks/msvc_sink.h
@@ -19,7 +19,7 @@
 #include <mutex>
 #include <string>
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace sinks {
 /*
  * MSVC sink (logging using OutputDebugStringA)
@@ -49,6 +49,6 @@ using windebug_sink_mt = msvc_sink_mt;
 using windebug_sink_st = msvc_sink_st;
 
 } // namespace sinks
-} // namespace spdlog
+} // namespace chipStar_spdlog
 
 #endif

--- a/include/spdlog/sinks/null_sink.h
+++ b/include/spdlog/sinks/null_sink.h
@@ -14,7 +14,7 @@
 
 #include <mutex>
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace sinks {
 
 template<typename Mutex>
@@ -46,4 +46,4 @@ inline std::shared_ptr<logger> null_logger_st(const std::string &logger_name)
     return null_logger;
 }
 
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/sinks/ostream_sink.h
+++ b/include/spdlog/sinks/ostream_sink.h
@@ -15,7 +15,7 @@
 #include <mutex>
 #include <ostream>
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace sinks {
 template<typename Mutex>
 class ostream_sink final : public base_sink<Mutex>
@@ -54,4 +54,4 @@ using ostream_sink_mt = ostream_sink<std::mutex>;
 using ostream_sink_st = ostream_sink<details::null_mutex>;
 
 } // namespace sinks
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/sinks/rotating_file_sink.h
+++ b/include/spdlog/sinks/rotating_file_sink.h
@@ -21,7 +21,7 @@
 #include <string>
 #include <tuple>
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace sinks {
 
 //
@@ -152,4 +152,4 @@ inline std::shared_ptr<logger> rotating_logger_st(
 {
     return Factory::template create<sinks::rotating_file_sink_st>(logger_name, filename, max_file_size, max_files);
 }
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/sinks/sink.h
+++ b/include/spdlog/sinks/sink.h
@@ -9,7 +9,7 @@
 #include "spdlog/details/pattern_formatter.h"
 #include "spdlog/formatter.h"
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace sinks {
 class sink
 {
@@ -20,7 +20,7 @@ public:
     {
     }
 
-    explicit sink(std::unique_ptr<spdlog::pattern_formatter> formatter)
+    explicit sink(std::unique_ptr<chipStar_spdlog::pattern_formatter> formatter)
         : level_(level::trace)
         , formatter_(std::move(formatter))
     {
@@ -30,7 +30,7 @@ public:
     virtual void log(const details::log_msg &msg) = 0;
     virtual void flush() = 0;
     virtual void set_pattern(const std::string &pattern) = 0;
-    virtual void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) = 0;
+    virtual void set_formatter(std::unique_ptr<chipStar_spdlog::formatter> sink_formatter) = 0;
 
     bool should_log(level::level_enum msg_level) const
     {
@@ -44,7 +44,7 @@ public:
 
     level::level_enum level() const
     {
-        return static_cast<spdlog::level::level_enum>(level_.load(std::memory_order_relaxed));
+        return static_cast<chipStar_spdlog::level::level_enum>(level_.load(std::memory_order_relaxed));
     }
 
 protected:
@@ -52,8 +52,8 @@ protected:
     level_t level_;
 
     // sink formatter - default is full format
-    std::unique_ptr<spdlog::formatter> formatter_;
+    std::unique_ptr<chipStar_spdlog::formatter> formatter_;
 };
 
 } // namespace sinks
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/sinks/stdout_color_sinks.h
+++ b/include/spdlog/sinks/stdout_color_sinks.h
@@ -15,7 +15,7 @@
 #include "spdlog/sinks/ansicolor_sink.h"
 #endif
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace sinks {
 #ifdef _WIN32
 using stdout_color_sink_mt = wincolor_stdout_sink_mt;
@@ -53,4 +53,4 @@ inline std::shared_ptr<logger> stderr_color_st(const std::string &logger_name)
 {
     return Factory::template create<sinks::stderr_color_sink_mt>(logger_name);
 }
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/sinks/stdout_sinks.h
+++ b/include/spdlog/sinks/stdout_sinks.h
@@ -16,7 +16,7 @@
 #include <memory>
 #include <mutex>
 
-namespace spdlog {
+namespace chipStar_spdlog {
 
 namespace sinks {
 
@@ -53,10 +53,10 @@ public:
     void set_pattern(const std::string &pattern) override
     {
         std::lock_guard<mutex_t> lock(mutex_);
-        formatter_ = std::unique_ptr<spdlog::formatter>(new pattern_formatter(pattern));
+        formatter_ = std::unique_ptr<chipStar_spdlog::formatter>(new pattern_formatter(pattern));
     }
 
-    void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) override
+    void set_formatter(std::unique_ptr<chipStar_spdlog::formatter> sink_formatter) override
     {
         std::lock_guard<mutex_t> lock(mutex_);
         formatter_ = std::move(sink_formatter);
@@ -99,4 +99,4 @@ inline std::shared_ptr<logger> stderr_logger_st(const std::string &logger_name)
 {
     return Factory::template create<sinks::stderr_sink_st>(logger_name);
 }
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/sinks/syslog_sink.h
+++ b/include/spdlog/sinks/syslog_sink.h
@@ -15,7 +15,7 @@
 #include <string>
 #include <syslog.h>
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace sinks {
 /**
  * Sink that write to syslog using the `syscall()` library call.
@@ -91,4 +91,4 @@ inline std::shared_ptr<logger> syslog_logger_st(
 {
     return Factory::template create<sinks::syslog_sink_st>(logger_name, syslog_ident, syslog_option, syslog_facility);
 }
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/sinks/wincolor_sink.h
+++ b/include/spdlog/sinks/wincolor_sink.h
@@ -20,7 +20,7 @@
 #include <unordered_map>
 #include <wincon.h>
 
-namespace spdlog {
+namespace chipStar_spdlog {
 namespace sinks {
 /*
  * Windows color console sink. Uses WriteConsoleA to write to the console with
@@ -97,10 +97,10 @@ public:
     void set_pattern(const std::string &pattern) override final
     {
         std::lock_guard<mutex_t> lock(mutex_);
-        formatter_ = std::unique_ptr<spdlog::formatter>(new pattern_formatter(pattern));
+        formatter_ = std::unique_ptr<chipStar_spdlog::formatter>(new pattern_formatter(pattern));
     }
 
-    void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) override final
+    void set_formatter(std::unique_ptr<chipStar_spdlog::formatter> sink_formatter) override final
     {
         std::lock_guard<mutex_t> lock(mutex_);
         formatter_ = std::move(sink_formatter);
@@ -140,4 +140,4 @@ using wincolor_stderr_sink_mt = wincolor_sink<details::console_stderr, details::
 using wincolor_stderr_sink_st = wincolor_sink<details::console_stderr, details::console_nullmutex>;
 
 } // namespace sinks
-} // namespace spdlog
+} // namespace chipStar_spdlog

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -19,13 +19,13 @@
 #include <memory>
 #include <string>
 
-namespace spdlog {
+namespace chipStar_spdlog {
 
 // Default logger factory-  creates synchronous loggers
 struct synchronous_factory
 {
     template<typename Sink, typename... SinkArgs>
-    static std::shared_ptr<spdlog::logger> create(std::string logger_name, SinkArgs &&... args)
+    static std::shared_ptr<chipStar_spdlog::logger> create(std::string logger_name, SinkArgs &&... args)
     {
         auto sink = std::make_shared<Sink>(std::forward<SinkArgs>(args)...);
         auto new_logger = std::make_shared<logger>(std::move(logger_name), std::move(sink));
@@ -40,32 +40,32 @@ using default_factory = synchronous_factory;
 // The logger's level, formatter and flush level will be set according the
 // global settings.
 // Example:
-// spdlog::create<daily_file_sink_st>("logger_name", "dailylog_filename", 11, 59);
+// chipStar_spdlog::create<daily_file_sink_st>("logger_name", "dailylog_filename", 11, 59);
 template<typename Sink, typename... SinkArgs>
-inline std::shared_ptr<spdlog::logger> create(std::string logger_name, SinkArgs &&... sink_args)
+inline std::shared_ptr<chipStar_spdlog::logger> create(std::string logger_name, SinkArgs &&... sink_args)
 {
     return default_factory::create<Sink>(std::move(logger_name), std::forward<SinkArgs>(sink_args)...);
 }
 
 // Return an existing logger or nullptr if a logger with such name doesn't
 // exist.
-// example: spdlog::get("my_logger")->info("hello {}", "world");
+// example: chipStar_spdlog::get("my_logger")->info("hello {}", "world");
 inline std::shared_ptr<logger> get(const std::string &name)
 {
     return details::registry::instance().get(name);
 }
 
 // Set global formatter. Each sink in each logger will get a clone of this object
-inline void set_formatter(std::unique_ptr<spdlog::formatter> formatter)
+inline void set_formatter(std::unique_ptr<chipStar_spdlog::formatter> formatter)
 {
     details::registry::instance().set_formatter(std::move(formatter));
 }
 
 // Set global format string.
-// example: spdlog::set_pattern("%Y-%m-%d %H:%M:%S.%e %l : %v");
+// example: chipStar_spdlog::set_pattern("%Y-%m-%d %H:%M:%S.%e %l : %v");
 inline void set_pattern(std::string pattern, pattern_time_type time_type = pattern_time_type::local)
 {
-    set_formatter(std::unique_ptr<spdlog::formatter>(new pattern_formatter(std::move(pattern), time_type)));
+    set_formatter(std::unique_ptr<chipStar_spdlog::formatter>(new pattern_formatter(std::move(pattern), time_type)));
 }
 
 // Set global logging level
@@ -101,7 +101,7 @@ inline void register_logger(std::shared_ptr<logger> logger)
 
 // Apply a user defined function on all registered loggers
 // Example:
-// spdlog::apply_all([&](std::shared_ptr<spdlog::logger> l) {l->flush();});
+// chipStar_spdlog::apply_all([&](std::shared_ptr<chipStar_spdlog::logger> l) {l->flush();});
 inline void apply_all(const std::function<void(std::shared_ptr<logger>)> &fun)
 {
     details::registry::instance().apply_all(fun);
@@ -125,38 +125,38 @@ inline void shutdown()
     details::registry::instance().shutdown();
 }
 
-// Automatic registration of loggers when using spdlog::create() or spdlog::create_async
+// Automatic registration of loggers when using chipStar_spdlog::create() or chipStar_spdlog::create_async
 inline void set_automatic_registration(bool automatic_registation)
 {
     details::registry::instance().set_automatic_registration(automatic_registation);
 }
 
 // API for using default logger (stdout_color_mt),
-// e.g: spdlog::info("Message {}", 1);
+// e.g: chipStar_spdlog::info("Message {}", 1);
 //
-// The default logger object can be accessed using the spdlog::default_logger():
+// The default logger object can be accessed using the chipStar_spdlog::default_logger():
 // For example, to add another sink to it:
-// spdlog::default_logger()->sinks()->push_back(some_sink);
+// chipStar_spdlog::default_logger()->sinks()->push_back(some_sink);
 //
-// The default logger can replaced using spdlog::set_default_logger(new_logger).
+// The default logger can replaced using chipStar_spdlog::set_default_logger(new_logger).
 // For example, to replace it with a file logger.
 //
 // IMPORTANT:
 // The default API is thread safe (for _mt loggers), but:
 // set_default_logger() *should not* be used concurrently with the default API.
-// e.g do not call set_default_logger() from one thread while calling spdlog::info() from another.
+// e.g do not call set_default_logger() from one thread while calling chipStar_spdlog::info() from another.
 
-inline std::shared_ptr<spdlog::logger> default_logger()
+inline std::shared_ptr<chipStar_spdlog::logger> default_logger()
 {
     return details::registry::instance().default_logger();
 }
 
-inline spdlog::logger *default_logger_raw()
+inline chipStar_spdlog::logger *default_logger_raw()
 {
     return details::registry::instance().get_default_raw();
 }
 
-inline void set_default_logger(std::shared_ptr<spdlog::logger> default_logger)
+inline void set_default_logger(std::shared_ptr<chipStar_spdlog::logger> default_logger)
 {
     details::registry::instance().set_default_logger(std::move(default_logger));
 }
@@ -296,7 +296,7 @@ inline void critical(const wchar_t *fmt, const Args &... args)
 
 #endif // SPDLOG_WCHAR_TO_UTF8_SUPPORT
 
-} // namespace spdlog
+} // namespace chipStar_spdlog
 
 
 
@@ -315,49 +315,49 @@ inline void critical(const wchar_t *fmt, const Args &... args)
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
 #define SPDLOG_LOGGER_TRACE(logger, ...)\
-    if(logger->should_log(spdlog::level::trace))\
-        logger->log(spdlog::source_loc{SPDLOG_FILE_BASENAME(__FILE__), __LINE__}, spdlog::level::trace, __VA_ARGS__)
-#define SPDLOG_TRACE(...) SPDLOG_LOGGER_TRACE(spdlog::default_logger_raw(), __VA_ARGS__)
+    if(logger->should_log(chipStar_spdlog::level::trace))\
+        logger->log(chipStar_spdlog::source_loc{SPDLOG_FILE_BASENAME(__FILE__), __LINE__}, chipStar_spdlog::level::trace, __VA_ARGS__)
+#define SPDLOG_TRACE(...) SPDLOG_LOGGER_TRACE(chipStar_spdlog::default_logger_raw(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_TRACE(logger, ...) (void)0
 #define SPDLOG_TRACE(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_DEBUG
-#define SPDLOG_LOGGER_DEBUG(logger, ...) logger->log(spdlog::level::debug, __VA_ARGS__)
-#define SPDLOG_DEBUG(...) SPDLOG_LOGGER_DEBUG(spdlog::default_logger_raw(), __VA_ARGS__)
+#define SPDLOG_LOGGER_DEBUG(logger, ...) logger->log(chipStar_spdlog::level::debug, __VA_ARGS__)
+#define SPDLOG_DEBUG(...) SPDLOG_LOGGER_DEBUG(chipStar_spdlog::default_logger_raw(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_DEBUG(logger, ...) (void)0
 #define SPDLOG_DEBUG(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_INFO
-#define SPDLOG_LOGGER_INFO(logger, ...) logger->log(spdlog::level::info, __VA_ARGS__)
-#define SPDLOG_INFO(...) SPDLOG_LOGGER_INFO(spdlog::default_logger_raw(), __VA_ARGS__)
+#define SPDLOG_LOGGER_INFO(logger, ...) logger->log(chipStar_spdlog::level::info, __VA_ARGS__)
+#define SPDLOG_INFO(...) SPDLOG_LOGGER_INFO(chipStar_spdlog::default_logger_raw(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_INFO(logger, ...) (void)0
 #define SPDLOG_INFO(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_WARN
-#define SPDLOG_LOGGER_WARN(logger, ...) logger->log(spdlog::level::warn, __VA_ARGS__)
-#define SPDLOG_WARN(...) SPDLOG_LOGGER_WARN(spdlog::default_logger_raw(), __VA_ARGS__)
+#define SPDLOG_LOGGER_WARN(logger, ...) logger->log(chipStar_spdlog::level::warn, __VA_ARGS__)
+#define SPDLOG_WARN(...) SPDLOG_LOGGER_WARN(chipStar_spdlog::default_logger_raw(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_WARN(logger, ...) (void)0
 #define SPDLOG_WARN(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_ERROR
-#define SPDLOG_LOGGER_ERROR(logger, ...) logger->log(spdlog::level::err, __VA_ARGS__)
-#define SPDLOG_ERROR(...) SPDLOG_LOGGER_ERROR(spdlog::default_logger_raw(), __VA_ARGS__)
+#define SPDLOG_LOGGER_ERROR(logger, ...) logger->log(chipStar_spdlog::level::err, __VA_ARGS__)
+#define SPDLOG_ERROR(...) SPDLOG_LOGGER_ERROR(chipStar_spdlog::default_logger_raw(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_ERROR(logger, ...) (void)0
 #define SPDLOG_ERROR(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_CRITICAL
-#define SPDLOG_LOGGER_CRITICAL(logger, ...) logger->log(spdlog::level::critical, __VA_ARGS__)
-#define SPDLOG_CRITICAL(...) SPDLOG_LOGGER_CRITICAL(spdlog::default_logger_raw(), __VA_ARGS__)
+#define SPDLOG_LOGGER_CRITICAL(logger, ...) logger->log(chipStar_spdlog::level::critical, __VA_ARGS__)
+#define SPDLOG_CRITICAL(...) SPDLOG_LOGGER_CRITICAL(chipStar_spdlog::default_logger_raw(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_CRITICAL(logger, ...) (void)0
 #define SPDLOG_CRITICAL(...) (void)0

--- a/include/spdlog/tweakme.h
+++ b/include/spdlog/tweakme.h
@@ -28,7 +28,7 @@
 //
 // WARNING: If the log pattern contains any date/time while this flag is on, the
 // result is undefined.
-//          You must set new pattern(spdlog::set_pattern(..") without any
+//          You must set new pattern(chipStar_spdlog::set_pattern(..") without any
 //          date/time in it
 //
 // #define SPDLOG_NO_DATETIME

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1301,7 +1301,7 @@ int chipstar::Backend::getQueuePriorityRange() {
 
 chipstar::Backend::Backend() {
   logDebug("Backend Base Constructor");
-  Logger = spdlog::default_logger();
+  Logger = chipStar_spdlog::default_logger();
 };
 
 chipstar::Backend::~Backend() {
@@ -1922,7 +1922,7 @@ chipstar::Queue::RegisteredVarCopy(chipstar::ExecItem *ExecItem,
 }
 
 void chipstar::Queue::launch(chipstar::ExecItem *ExItem) {
-  if (shouldLog(spdlog::level::info)) {
+  if (shouldLog(chipStar_spdlog::level::info)) {
     std::stringstream InfoStr;
     InfoStr << "\nLaunching kernel " << ExItem->getKernel()->getName() << "\n";
     InfoStr << "GridDim: <" << ExItem->getGrid().x << ", "

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1839,7 +1839,7 @@ protected:
 
   // Keep hold on the default logger instance to make sure that it is
   // not destructed before the backend finishes uninitialization.
-  std::shared_ptr<spdlog::logger> Logger;
+  std::shared_ptr<chipStar_spdlog::logger> Logger;
 
 public:
   void setReinitializeFlag(bool Flag) { ReinitializeFlag_ = Flag; }

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -30,14 +30,14 @@ std::once_flag SpdlogWasSetup;
 void setupSpdlog() { std::call_once(SpdlogWasSetup, &_setupSpdlog); }
 
 void _setupSpdlog() {
-  spdlog::set_default_logger(spdlog::stderr_color_mt("CHIP"));
-  spdlog::set_pattern("%n %^%l%$ [TID %t] [%E.%F] : %v");
+  chipStar_spdlog::set_default_logger(chipStar_spdlog::stderr_color_mt("CHIP"));
+  chipStar_spdlog::set_pattern("%n %^%l%$ [TID %t] [%E.%F] : %v");
 
-  spdlog::level::level_enum SpdLogLevel =
+  chipStar_spdlog::level::level_enum SpdLogLevel =
 #if (SPDLOG_ACTIVE_LEVEL == SPDLOG_LEVEL_TRACE)
-      spdlog::level::debug;
+      chipStar_spdlog::level::debug;
 #else
-      spdlog::level::warn;
+      chipStar_spdlog::level::warn;
 #endif
 
   const char *LogLevel = getenv("CHIP_LOGLEVEL");
@@ -45,20 +45,20 @@ void _setupSpdlog() {
     // std::cout << "CHIP_LOGLEVEL=" << loglevel << "\n";
     std::string Level(LogLevel);
     if (Level == "trace")
-      SpdLogLevel = spdlog::level::trace;
+      SpdLogLevel = chipStar_spdlog::level::trace;
     if (Level == "debug")
-      SpdLogLevel = spdlog::level::debug;
+      SpdLogLevel = chipStar_spdlog::level::debug;
     if (Level == "info")
-      SpdLogLevel = spdlog::level::info;
+      SpdLogLevel = chipStar_spdlog::level::info;
     if (Level == "warn")
-      SpdLogLevel = spdlog::level::warn;
+      SpdLogLevel = chipStar_spdlog::level::warn;
     if (Level == "err")
-      SpdLogLevel = spdlog::level::err;
+      SpdLogLevel = chipStar_spdlog::level::err;
     if (Level == "crit")
-      SpdLogLevel = spdlog::level::critical;
+      SpdLogLevel = chipStar_spdlog::level::critical;
     if (Level == "off")
-      SpdLogLevel = spdlog::level::off;
+      SpdLogLevel = chipStar_spdlog::level::off;
   }
 
-  spdlog::set_level(SpdLogLevel);
+  chipStar_spdlog::set_level(SpdLogLevel);
 }

--- a/src/logging.hh
+++ b/src/logging.hh
@@ -38,7 +38,7 @@ extern void _setupSpdlog();
 template <typename... TypeArgs>
 void logTrace(const char *Fmt, const TypeArgs &...Args) {
   setupSpdlog();
-  spdlog::trace(Fmt, std::forward<const TypeArgs>(Args)...);
+  chipStar_spdlog::trace(Fmt, std::forward<const TypeArgs>(Args)...);
 }
 #else
 #define logTrace(...) void(0)
@@ -48,7 +48,7 @@ void logTrace(const char *Fmt, const TypeArgs &...Args) {
 template <typename... TypeArgs>
 void logDebug(const char *Fmt, const TypeArgs &...Args) {
   setupSpdlog();
-  spdlog::debug(Fmt, std::forward<const TypeArgs>(Args)...);
+  chipStar_spdlog::debug(Fmt, std::forward<const TypeArgs>(Args)...);
 }
 #else
 #define logDebug(...) void(0)
@@ -58,7 +58,7 @@ void logDebug(const char *Fmt, const TypeArgs &...Args) {
 template <typename... TypeArgs>
 void logInfo(const char *Fmt, const TypeArgs &...Args) {
   setupSpdlog();
-  spdlog::info(Fmt, std::forward<const TypeArgs>(Args)...);
+  chipStar_spdlog::info(Fmt, std::forward<const TypeArgs>(Args)...);
 }
 #else
 #define logInfo(...) void(0)
@@ -68,7 +68,7 @@ void logInfo(const char *Fmt, const TypeArgs &...Args) {
 template <typename... TypeArgs>
 void logWarn(const char *Fmt, const TypeArgs &...Args) {
   setupSpdlog();
-  spdlog::warn(Fmt, std::forward<const TypeArgs>(Args)...);
+  chipStar_spdlog::warn(Fmt, std::forward<const TypeArgs>(Args)...);
 }
 #else
 #define logWarn(...) void(0)
@@ -78,7 +78,7 @@ void logWarn(const char *Fmt, const TypeArgs &...Args) {
 template <typename... TypeArgs>
 void logError(const char *Fmt, const TypeArgs &...Args) {
   setupSpdlog();
-  spdlog::error(Fmt, std::forward<const TypeArgs>(Args)...);
+  chipStar_spdlog::error(Fmt, std::forward<const TypeArgs>(Args)...);
 }
 #else
 #define logError(...) void(0)
@@ -88,14 +88,14 @@ void logError(const char *Fmt, const TypeArgs &...Args) {
 template <typename... TypeArgs>
 void logCritical(const char *Fmt, const TypeArgs &...Args) {
   setupSpdlog();
-  spdlog::critical(Fmt, std::forward<const TypeArgs>(Args)...);
+  chipStar_spdlog::critical(Fmt, std::forward<const TypeArgs>(Args)...);
 }
 #else
 #define logCritical(...) void(0)
 #endif
 
-inline bool shouldLog(spdlog::level::level_enum MsgLevel) {
-  return spdlog::default_logger()->should_log(MsgLevel);
+inline bool shouldLog(chipStar_spdlog::level::level_enum MsgLevel) {
+  return chipStar_spdlog::default_logger()->should_log(MsgLevel);
 }
 
 #endif


### PR DESCRIPTION
Rename all spdlog namespace declarations and references from 'spdlog' to 'chipStar_spdlog' in the bundled spdlog headers and chipStar source files. This prevents symbol conflicts when applications linking against libCHIP.so
also use spdlog, avoiding runtime segfaults from ABI mismatches.

Fixes #1096