### PR TITLE
Fix #1091: Destroy fences before command queue

### DIFF
--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -870,6 +870,22 @@ CHIPQueueLevel0::~CHIPQueueLevel0() {
                             // updateLastEvent(nullptr)) hasn't been called yet,
                             // and the event monitor ends up waiting forever.
 
+  // Per Level Zero spec, fences must be destroyed before the command queue.
+  // Destroy fences in ActiveCmdLists that were created with this queue.
+  if (zeCmdQOwnership_) {
+    auto BackendLz = static_cast<CHIPBackendLevel0 *>(Backend);
+    {
+      LOCK(BackendLz->ActiveCmdListsMtx);
+      for (auto &CmdList : BackendLz->ActiveCmdLists) {
+        if (CmdList->getAssociatedQueue() == ZeCmdQ_) {
+          CmdList->destroyFence();
+        }
+      }
+    }
+    // Also destroy fences in the context's pool
+    ChipCtxLz_->destroyFencesForQueue(ZeCmdQ_);
+  }
+
   // The application must not call this function from
   // simultaneous threads with the same command queue handle.
   // Done. Destructor should not be called by multiple threads
@@ -1001,6 +1017,25 @@ Borrowed<FencedCmdList> CHIPContextLevel0::getCmdListReg() {
 
     auto CmdList = std::make_unique<FencedCmdList>(ZeDev, ZeCtx, ZeCmdListDesc);
     return Borrowed<FencedCmdList>(CmdList.release(), ReturnToPool);
+  }
+}
+
+void CHIPContextLevel0::destroyFencesForQueue(ze_command_queue_handle_t Queue) {
+  LOCK(FencedCmdListsMtx_);
+  // Iterate through pool and destroy fences that were created with this queue
+  std::stack<std::unique_ptr<FencedCmdList>> TempStack;
+  while (!FencedCmdListsPool_.empty()) {
+    auto CmdList = std::move(FencedCmdListsPool_.top());
+    FencedCmdListsPool_.pop();
+    if (CmdList->getAssociatedQueue() == Queue) {
+      CmdList->destroyFence();
+    }
+    TempStack.push(std::move(CmdList));
+  }
+  // Move everything back to the pool
+  while (!TempStack.empty()) {
+    FencedCmdListsPool_.push(std::move(TempStack.top()));
+    TempStack.pop();
   }
 }
 

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -271,6 +271,7 @@ class FencedCmdList {
   ze_command_list_handle_t ZeCmdList_ = nullptr;
   ze_fence_handle_t ZeFence_ = nullptr;
   ze_fence_desc_t ZeFenceDesc_ = {ZE_STRUCTURE_TYPE_FENCE_DESC, nullptr, 0};
+  ze_command_queue_handle_t AssociatedQueue_ = nullptr;
 
 public:
   FencedCmdList(ze_device_handle_t &DevLz, ze_context_handle_t &CtxLz,
@@ -293,6 +294,7 @@ public:
   }
 
   void execute(ze_command_queue_handle_t &CmdQLz) {
+    AssociatedQueue_ = CmdQLz;
     zeStatus = zeFenceCreate(CmdQLz, &ZeFenceDesc_, &ZeFence_);
     CHIPERR_CHECK_LOG_AND_ABORT("Failed to create fence");
     zeStatus = zeCommandListClose(ZeCmdList_);
@@ -308,16 +310,33 @@ public:
     return zeStatus == ZE_RESULT_SUCCESS;
   }
 
+  /**
+   * @brief Destroy the fence if it exists. Per Level Zero spec, fences must
+   * be destroyed before their associated command queue. This method allows
+   * explicit fence destruction when a queue is being destroyed.
+   */
+  void destroyFence() {
+    if (ZeFence_) {
+      zeStatus = zeFenceDestroy(ZeFence_);
+      CHIPERR_CHECK_LOG_AND_ABORT("Failed to destroy fence");
+      ZeFence_ = nullptr;
+      AssociatedQueue_ = nullptr;
+    }
+  }
+
   ~FencedCmdList() {
     zeStatus = zeCommandListDestroy(ZeCmdList_);
     CHIPERR_CHECK_LOG_AND_ABORT("Failed to destroy command list");
 
-    zeStatus = zeFenceDestroy(ZeFence_);
-    CHIPERR_CHECK_LOG_AND_ABORT("Failed to destroy fence");
+    if (ZeFence_) {
+      zeStatus = zeFenceDestroy(ZeFence_);
+      CHIPERR_CHECK_LOG_AND_ABORT("Failed to destroy fence");
+    }
   }
 
   ze_command_list_handle_t &getCmdList() { return ZeCmdList_; }
   ze_fence_handle_t &getFence() { return ZeFence_; }
+  ze_command_queue_handle_t getAssociatedQueue() const { return AssociatedQueue_; }
 };
 
 class CHIPQueueLevel0 : public chipstar::Queue {
@@ -485,6 +504,14 @@ public:
    * return back to the pool upon destruction
    */
   Borrowed<FencedCmdList> getCmdListReg();
+
+  /**
+   * @brief Destroy all fences in the pool that are assocated with a given queue.
+   * Per Level Zero spec, fences must be destroyed before the command queue.
+   *
+   * @param Queue The queue handle whose fences should be destroyed
+   */
+  void destroyFencesForQueue(ze_command_queue_handle_t Queue);
 
   /**
    * @brief Ger a shared_event from the pool, creating one if none are


### PR DESCRIPTION
Per Level Zero spec, fences must be destroyed before the command queue
they were created with.

- Added AssociatedQueue_ member to FencedCmdList to track which queue
  the fence was created with
- Added destroyFence() method to FencedCmdList for explicit fence
  destruction
- Added destroyFencesForQueue() method to CHIPContextLevel0 to destroy
  fences in the pool
- Updated CHIPQueueLevel0 destructor to destroy fences in ActiveCmdLists
  and in the pool before destroying the queue

Fixes #1091