### PR TITLE
Install hip-lang-config.cmake for CMake HIP language support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -819,6 +819,10 @@ install(
 )
 install(EXPORT hip-targets FILE hip-targets.cmake NAMESPACE hip:: DESTINATION lib/cmake/hip COMPONENT binary)
 
+# Install hip-lang-config.cmake for CMake's native HIP language support
+install(FILES ${CMAKE_SOURCE_DIR}/cmake/hip-lang/hip-lang-config.cmake
+  DESTINATION ${CONFIG_LANG_PACKAGE_INSTALL_DIR})
+
 # Generate hip_version.h
 set(_pchStatus 0)
 set(_versionInfoHeader


### PR DESCRIPTION
The CONFIG_LANG_PACKAGE_INSTALL_DIR variable was defined but never used,
causing hip-lang-config.cmake to not be installed. CMake's native HIP
language support looks for this file at lib/cmake/hip-lang/.

Fixes #1092