### PR TITLE
Fix make install failure on macOS due to hardcoded .so extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,11 +357,9 @@ endif()
 if(CHIP_BUILD_SHARED_LIBS)
   message(STATUS "Buiding chipStar as a shared library")
   add_library(CHIP SHARED ${CHIP_SRC})
-  set(CHIP_LIB_NAME "libCHIP.so")
 else()
   message(STATUS "Buiding chipStar as a static library")
   add_library(CHIP STATIC ${CHIP_SRC})
-  set(CHIP_LIB_NAME "libCHIP.a")
 endif()
 
 # Check if the compiler supports F16C
@@ -885,7 +883,6 @@ install(TARGETS CHIP
 )
 
 install(FILES ${CMAKE_BINARY_DIR}/include/chipStarConfig.hh DESTINATION ${INCLUDE_INSTALL_DIR})
-install(FILES ${PROJECT_BINARY_DIR}/${CHIP_LIB_NAME} DESTINATION lib)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/HIP/include DESTINATION . USE_SOURCE_PERMISSIONS)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include DESTINATION . USE_SOURCE_PERMISSIONS
         PATTERN "spdlog" EXCLUDE)


### PR DESCRIPTION
## Summary

Fix `make install` failure on macOS caused by hardcoded `.so` library extension.

## Problem

On macOS, `make install` fails with:
```
CMake Error at cmake_install.cmake:285 (file):
  file INSTALL cannot find ".../build/libCHIP.so": No such file or directory.
```

This happens because:
- Line 360 sets `CHIP_LIB_NAME="libCHIP.so"` (hardcoded)
- Line 888 tries to install `${PROJECT_BINARY_DIR}/${CHIP_LIB_NAME}`
- On macOS, the actual file is `libCHIP.dylib`, not `libCHIP.so`

The failure blocks subsequent install commands, preventing headers and `libocml_host_math_funcs.a` from being installed.

## Solution

Remove `CHIP_LIB_NAME` variable (lines 360, 364) and the redundant install command (line 888). The library is already correctly installed by `install(TARGETS CHIP ...)` on lines 881-885, which handles platform-specific naming automatically.

## Testing

- Tested on macOS 16 (Darwin 25.2.0), Apple Silicon M1 Max
- LLVM 21, POCL main branch
- `make install` now completes successfully
- Compiled and ran HIP test programs using the installed chipStar
- `make install` is part of existing Linux CI as well, which will verify this change doesn't break Linux builds