### PR TITLE
CI: Add install step testing to macOS ARM64 workflow

### DIFF
--- a/.github/workflows/macos-arm64-ci.yml
+++ b/.github/workflows/macos-arm64-ci.yml
@@ -63,7 +63,7 @@ jobs:
           module load ocl-icd-loader
           module load pocl
           
-          rm -rf build
+          rm -rf build install
           mkdir -p build
           cd build
           cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCHIP_BUILD_SAMPLES=ON -DCHIP_BUILD_TESTS=ON -DOpenCL_LIBRARY=/Users/paulius/install/ocl-icd-loader/lib/libOpenCL.dylib -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install


### PR DESCRIPTION
## Summary

Add install step testing to the macOS ARM64 CI workflow to catch install-related bugs.

## Motivation

A bug was discovered where `make install` failed on macOS due to a hardcoded `.so` extension (see PR #1138). This wasn't caught because the CI only tested from the build directory, never running the install step.

The Linux CI (`compile-and-cache-main.yml`) runs `make install`, but neither platform actually tests using the installed binaries.

## Changes

1. Add `-DCMAKE_INSTALL_PREFIX` to cmake configure
2. Add "Install" step that runs `ninja install`
3. Add "Test Install" step that:
   - Verifies `hipcc` is installed and in PATH
   - Compiles and runs a simple HIP program using the **installed** binaries
   - Sets `SDKROOT` (required for POCL JIT on macOS with custom LLVM)

## Dependencies

This PR is based on #1138 which must be merged first, otherwise the install step will fail.

## Testing

- Test program verified locally on macOS ARM64
- Workflow steps tested manually