### PR TITLE
Implement CHIP_DUMP_PROCESSED_SPIRV

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ CHIP_DEVICE=<N>                                 # If there are multiple devices 
 CHIP_DEVICE_TYPE=<gpu/cpu/accel/fpga/pocl> or empty  # Selects which type of device to use. Cannot be used with CHIP_PLATFORM/CHIP_DEVICE. Defaults to empty.
 CHIP_LOGLEVEL=<trace/debug/info/warn/err/crit>  # Sets the log level. If compiled in RELEASE, only err/crit are available
 CHIP_DUMP_SPIRV=<ON/OFF(default)>               # Dumps the generated SPIR-V code to a file
+CHIP_DUMP_PROCESSED_SPIRV=/path/to/dir          # Dumps processed SPIR-V binaries to the given directory (for debugging)
 CHIP_JIT_FLAGS=<flags>                          # Additional JIT flags
 CHIP_L0_COLLECT_EVENTS_TIMEOUT=<N(30s default)> # Timeout in seconds for collecting Level Zero events
 CHIP_L0_EVENT_TIMEOUT=<N(0 default)             # Timeout in seconds for how long Level Zero should wait on an event before timing out

--- a/src/CHIPDriver.hh
+++ b/src/CHIPDriver.hh
@@ -244,6 +244,7 @@ private:
   bool OCLDisableQueueProfiling_ = false;
   std::optional<std::string> OclUseAllocStrategy_;
   std::optional<std::string> ModuleCacheDir_;
+  std::optional<std::string> DumpProcessedSpirvDir_;
 
   // Track which environment variables were explicitly set
   bool PlatformIdxSet_ = false;
@@ -281,6 +282,9 @@ public:
   }
   const std::optional<std::string> &getModuleCacheDir() const {
     return ModuleCacheDir_;
+  }
+  const std::optional<std::string> &getDumpProcessedSpirvDir() const {
+    return DumpProcessedSpirvDir_;
   }
 
   bool isManualDeviceSelection() const {
@@ -332,6 +336,11 @@ private:
         readEnvVar("CHIP_OCL_USE_ALLOC_STRATEGY", value, true)
             ? value
             : OclUseAllocStrategy_;
+    if (readEnvVar("CHIP_DUMP_PROCESSED_SPIRV", value, false)) {
+      if (value.size())
+        DumpProcessedSpirvDir_ = value;
+    }
+
     if (readEnvVar("CHIP_MODULE_CACHE_DIR", value, true)) {
       if (value.size())
         ModuleCacheDir_ = value;
@@ -408,6 +417,9 @@ private:
                                                   : "off");
     logInfo("CHIP_MODULE_CACHE_DIR={}",
             ModuleCacheDir_.has_value() ? ModuleCacheDir_.value() : "off");
+    logInfo("CHIP_DUMP_PROCESSED_SPIRV={}",
+            DumpProcessedSpirvDir_.has_value() ? DumpProcessedSpirvDir_.value()
+                                               : "off");
   }
 };
 

--- a/src/spirv.cc
+++ b/src/spirv.cc
@@ -35,6 +35,7 @@
 #include "spirv.hh"
 #include "logging.hh"
 #include "Utils.hh"
+#include "CHIPDriver.hh"
 
 const std::string OpenCLStd{"OpenCL.std"};
 
@@ -1035,6 +1036,19 @@ bool postprocessSPIRV(std::vector<uint32_t> &Input) {
   }
 
   Input = std::move(Result);
+
+  // Debug: dump processed SPIR-V for inspection
+  if (auto DumpDir = ChipEnvVars.getDumpProcessedSpirvDir()) {
+    static int DumpCounter = 0;
+    std::string Path = *DumpDir + "/processed_" + std::to_string(DumpCounter++) +
+                       ".spv";
+    std::ofstream F(Path, std::ios::binary);
+    if (F.is_open()) {
+      F.write(reinterpret_cast<const char *>(Input.data()),
+              Input.size() * sizeof(uint32_t));
+      logTrace("Dumped processed SPIR-V to {}", Path);
+    }
+  }
 
   return true;
 }


### PR DESCRIPTION
When set to a directory path, dumps processed SPIR-V binaries (processed_0.spv, processed_1.spv, ...) to that directory for debugging. Parsed in EnvVars like other CHIP flags.