### PR TITLE
Fix hipGetLastError not catching error (#1158)

### DIFF
--- a/src/macros.hh
+++ b/src/macros.hh
@@ -46,7 +46,8 @@
 #define RETURN(x)                                                              \
   do {                                                                         \
     hipError_t err = (x);                                                      \
-    CHIPTlsLastError = err;                                                    \
+    if (err != hipSuccess && err != hipErrorNotReady)                           \
+      CHIPTlsLastError = err;                                                  \
     return err;                                                                \
   } while (0)
 


### PR DESCRIPTION
Only update CHIPTlsLastError when err != hipSuccess. Fixes #1158