### PR TITLE
Fix cross-queue sync marker event premature recycling

### DIFF
--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -2160,6 +2160,12 @@ protected:
     EventLocks.push_back(
         std::make_unique<std::unique_lock<std::mutex>>(ChipDevice_->QueueAddRemoveMtx));
 
+    // Collect marker events to keep alive on this queue. These are
+    // cross-queue sync markers whose underlying ze_events are referenced
+    // as GPU-level wait dependencies. They must not be recycled by
+    // checkEvents() until this queue finishes.
+    std::vector<std::shared_ptr<chipstar::Event>> MarkerEvents;
+
     // If this is a default stream (legacy or per-thread), create markers for all blocking queues
     if (this->isDefaultLegacyQueue() || this->isDefaultPerThreadQueue()) {
       // Create markers for all blocking queues
@@ -2175,6 +2181,7 @@ protected:
 
           // Track the marker event so it gets properly managed by the event monitor
           BackendPtr->trackEvent(ChipMarkerEvent);
+          MarkerEvents.push_back(ChipMarkerEvent);
 
 	}
       }
@@ -2192,7 +2199,7 @@ protected:
         
         EventHandles.push_back(handle);
         BackendPtr->trackEvent(ChipMarkerEvent);
-	
+        MarkerEvents.push_back(ChipMarkerEvent);
       }
 
       // Create marker for per-thread default stream if used
@@ -2204,8 +2211,18 @@ protected:
           
           EventHandles.push_back(handle);
           BackendPtr->trackEvent(ChipMarkerEvent);
+          MarkerEvents.push_back(ChipMarkerEvent);
         }
       }
+    }
+
+    // Store marker events on this queue to prevent premature recycling.
+    // checkEvents() may see that marker ze_events have been signaled and
+    // recycle them, but GPU operations on THIS queue still reference those
+    // ze_events as wait dependencies. Holding shared_ptrs here prevents
+    // the event pool from resetting the ze_events until this queue finishes.
+    if (!MarkerEvents.empty()) {
+      storeCrossQueueDeps(std::move(MarkerEvents));
     }
 
     return {EventHandles, std::move(EventLocks)};
@@ -2395,6 +2412,11 @@ public:
    */
 
   virtual void finish() = 0;
+
+  /// Store cross-queue dependency marker events to prevent premature recycling.
+  /// Default implementation is a no-op; Level0 backend overrides this.
+  virtual void storeCrossQueueDeps(
+      std::vector<std::shared_ptr<chipstar::Event>> Markers) {}
 
   /**
    * @brief Wait for this queue to finish, assuming EventsMtx is already held

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1877,7 +1877,10 @@ void CHIPQueueLevel0::finish() {
   // host wait for command lists to complete
   zeStatus = zeCommandListHostSynchronize(ZeCmdListImm_, UINT64_MAX);
   CHIPERR_CHECK_LOG_AND_THROW_TABLE(zeCommandListHostSynchronize);
-  IsEmptyQueue_.store(true);  
+  // All GPU work on this queue has completed. Release cross-queue dependency
+  // marker events so their ze_events can be recycled by the event pool.
+  PendingCrossQueueDeps_.clear();
+  IsEmptyQueue_.store(true);
   return;
 }
 

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -382,6 +382,10 @@ public:
   void recordEvent(chipstar::Event *ChipEvent) override;
   std::mutex CommandListMtx; /// prevent simultaneous access to ZeCmdListImm_
   std::atomic<bool> IsEmptyQueue_{true};
+  /// Cross-queue sync marker events that must be kept alive until this queue
+  /// is finished. Without this, checkEvents() may recycle their underlying
+  /// ze_events while GPU operations on this queue still reference them.
+  std::vector<std::shared_ptr<chipstar::Event>> PendingCrossQueueDeps_;
   // we would like to use just return IsEmptyQueue_.load() here
   // but there is a bug (https://github.com/argonne-lcf/AuroraBugTracking/issues/124)
   bool isEmptyQueue() override {
@@ -430,6 +434,12 @@ public:
   void finishNoLock(); // Helper that assumes EventsMtx is already held
 
   virtual void finishWithoutEventsMtx() override;
+
+  void storeCrossQueueDeps(
+      std::vector<std::shared_ptr<chipstar::Event>> Markers) override {
+    for (auto& M : Markers)
+      PendingCrossQueueDeps_.push_back(std::move(M));
+  }
 
   virtual std::shared_ptr<chipstar::Event>
   memCopyAsyncImpl(void *Dst, const void *Src, size_t Size,


### PR DESCRIPTION
      PR #1162 removed addDependency() calls (since kernel launches no longer
      create target events), but this also removed the shared_ptr references
      that kept cross-queue sync marker events alive. checkEvents() could then
      see a signaled marker, recycle its ze_event via zeEventHostReset(), while
      the dependent queue was still waiting on it — causing a hang.

      Fix: store marker event shared_ptrs on the dependent queue
      (PendingCrossQueueDeps_) and release them in finish() after
      zeCommandListHostSynchronize completes.