### PR TITLE
Fix mv path in test-llvm-patches install steps

### DIFF
--- a/.github/workflows/test-llvm-patches.yml
+++ b/.github/workflows/test-llvm-patches.yml
@@ -5,10 +5,12 @@ on:
     paths:
       - 'llvm-patches/**'
       - 'scripts/configure_llvm.sh'
+      - '.github/workflows/test-llvm-patches.yml'
   pull_request:
     paths:
       - 'llvm-patches/**'
       - 'scripts/configure_llvm.sh'
+      - '.github/workflows/test-llvm-patches.yml'
   workflow_dispatch:
 
 concurrency:
@@ -244,8 +246,10 @@ jobs:
     steps:
       - name: Install LLVM ${{ matrix.build-id }}
         run: |
-          rm -rf $HOME/install/llvm/${{ matrix.llvm-version }}.0${{ matrix.install-suffix }}
-          mv $HOME/llvm-stage/${{ matrix.build-id }}/$HOME/install/llvm/${{ matrix.llvm-version }}.0${{ matrix.install-suffix }} $HOME/install/llvm/${{ matrix.llvm-version }}.0${{ matrix.install-suffix }}
+          STAGED="$HOME/llvm-stage/${{ matrix.build-id }}"
+          INSTALL_DIR="$HOME/install/llvm/${{ matrix.llvm-version }}.0${{ matrix.install-suffix }}"
+          rm -rf "$INSTALL_DIR"
+          mv "${STAGED}${INSTALL_DIR}" "$INSTALL_DIR"
         timeout-minutes: 5
       - name: Verify LLVM ${{ matrix.build-id }} installation
         run: |
@@ -399,8 +403,10 @@ jobs:
     steps:
       - name: Install LLVM 22 (${{ matrix.variant }})
         run: |
-          rm -rf $HOME/install/llvm/22.0-${{ matrix.variant }}
-          mv $HOME/llvm-stage/22-${{ matrix.variant }}/$HOME/install/llvm/22.0-${{ matrix.variant }} $HOME/install/llvm/22.0-${{ matrix.variant }}
+          STAGED="$HOME/llvm-stage/22-${{ matrix.variant }}"
+          INSTALL_DIR="$HOME/install/llvm/22.0-${{ matrix.variant }}"
+          rm -rf "$INSTALL_DIR"
+          mv "${STAGED}${INSTALL_DIR}" "$INSTALL_DIR"
         timeout-minutes: 5
       - name: Verify LLVM 22 (${{ matrix.variant }}) installation
         run: |


### PR DESCRIPTION
## Summary
- Fix DESTDIR `mv` path in both Linux and macOS install jobs — the source path was double-absolute (`$STAGE/$HOME/...` instead of `$STAGE$HOME/...`), causing `No such file or directory`
- Add `.github/workflows/test-llvm-patches.yml` to the workflow's own trigger paths so CI runs on workflow changes

## Test plan
- [ ] CI triggers on this PR (workflow file is now in trigger paths)
- [ ] Verify the `install-llvm-on-main` step1-configure + step2-build-test pass