### PR TITLE
Create OpenCL context with single selected device

### DIFF
--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -2752,9 +2752,10 @@ void CHIPBackendOpenCL::initializeImpl() {
   logDebug("CHIP_DEVICE={} Selected OpenCL device {}",
            ChipEnvVars.getDeviceIdx(), Device.getInfo<CL_DEVICE_NAME>());
 
-  // Create context which has devices
-  // Create queues that have devices each of which has an associated context
-  cl::Context Ctx(SupportedDevices);
+  // Create context with the selected device. Using a single device is required
+  // for OpenCL implementations like clvk that only support single-device
+  // contexts, and chipStar only uses one device anyway (see TODO below).
+  cl::Context Ctx(Device);
   CHIPContextOpenCL *ChipContext =
       new CHIPContextOpenCL(Ctx, Device, SelectedPlatform);
   ::Backend->addContext(ChipContext);


### PR DESCRIPTION
chipStar only uses one device (selected via CHIP_DEVICE), but creates the OpenCL context with the full SupportedDevices vector. Some OpenCL implementations (e.g. clvk) only support single-device contexts and reject multi-device ones.

Use `cl::Context(Device)` instead of `cl::Context(SupportedDevices)`.