### PR TITLE
Add multi-TU regression test for templated kernels (#808)

### DIFF
--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -117,6 +117,49 @@ if(OpenCL_LIBRARY) # Depends on OpenCL
 endif()
 add_hip_runtime_test(Test887.hip)
 add_hip_runtime_test(TestTemplatedConstantMemcpy.hip)
+# Multi-TU test: same template instantiation in two separate TUs (#808)
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/TemplatedKernelAddOne.o
+  COMMAND ${CMAKE_BINARY_DIR}/bin/hipcc -c
+    ${CMAKE_CURRENT_SOURCE_DIR}/inputs/TemplatedKernelAddOne.hip
+    -o ${CMAKE_CURRENT_BINARY_DIR}/TemplatedKernelAddOne.o
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/inputs/TemplatedKernelAddOne.hip
+    hipcc.bin CHIP devicelib_bc
+)
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/TemplatedKernelAddTwo.o
+  COMMAND ${CMAKE_BINARY_DIR}/bin/hipcc -c
+    ${CMAKE_CURRENT_SOURCE_DIR}/inputs/TemplatedKernelAddTwo.hip
+    -o ${CMAKE_CURRENT_BINARY_DIR}/TemplatedKernelAddTwo.o
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/inputs/TemplatedKernelAddTwo.hip
+    hipcc.bin CHIP devicelib_bc
+)
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/TestTemplateKernelModules.o
+  COMMAND ${CMAKE_BINARY_DIR}/bin/hipcc -c
+    ${CMAKE_CURRENT_SOURCE_DIR}/TestTemplateKernelModules.hip
+    -o ${CMAKE_CURRENT_BINARY_DIR}/TestTemplateKernelModules.o
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/TestTemplateKernelModules.hip
+    hipcc.bin CHIP devicelib_bc
+)
+add_custom_target(TestTemplateKernelModules ALL
+  COMMAND ${CMAKE_BINARY_DIR}/bin/hipcc
+    ${CMAKE_CURRENT_BINARY_DIR}/TestTemplateKernelModules.o
+    ${CMAKE_CURRENT_BINARY_DIR}/TemplatedKernelAddOne.o
+    ${CMAKE_CURRENT_BINARY_DIR}/TemplatedKernelAddTwo.o
+    -o ${CMAKE_CURRENT_BINARY_DIR}/TestTemplateKernelModules
+  DEPENDS
+    ${CMAKE_CURRENT_BINARY_DIR}/TestTemplateKernelModules.o
+    ${CMAKE_CURRENT_BINARY_DIR}/TemplatedKernelAddOne.o
+    ${CMAKE_CURRENT_BINARY_DIR}/TemplatedKernelAddTwo.o
+  COMMENT "Linking TestTemplateKernelModules (multi-TU)"
+)
+add_test(NAME TestTemplateKernelModules
+  COMMAND ${CMAKE_CURRENT_BINARY_DIR}/TestTemplateKernelModules)
+set_tests_properties(TestTemplateKernelModules PROPERTIES
+  PASS_REGULAR_EXPRESSION "PASS"
+  FAIL_REGULAR_EXPRESSION "device function is already registered"
+  TIMEOUT 60)
 
 add_shell_test(../run_testenvvars.sh)
 set_tests_properties(run_testenvvars PROPERTIES

--- a/tests/runtime/TestTemplateKernelModules.hip
+++ b/tests/runtime/TestTemplateKernelModules.hip
@@ -1,0 +1,34 @@
+#include <hip/hip_runtime.h>
+#include <cstdio>
+
+// Both of these functions rely on a templated kernelAddOne<int> defined
+// in separate TUs. Each TU has its own SPIR-V module containing the same
+// template instantiation. The runtime must handle this without warning
+// about "device function is already registered and mapped to a different
+// module" and must dispatch the kernel correctly from both call sites.
+void launchKernelAddOne(int* data);
+void launchKernelAddTwo(int* data);
+
+int main() {
+  int* data;
+  hipHostMalloc((void**)&data, sizeof(int));
+  data[0] = 0;
+
+  launchKernelAddOne(data);
+  hipDeviceSynchronize();
+  if (data[0] != 1) {
+    printf("FAIL: after launchKernelAddOne expected 1, got %d\n", data[0]);
+    return 1;
+  }
+
+  launchKernelAddTwo(data);
+  hipDeviceSynchronize();
+  if (data[0] != 3) {
+    printf("FAIL: after launchKernelAddTwo expected 3, got %d\n", data[0]);
+    return 1;
+  }
+
+  printf("PASS\n");
+  hipFree(data);
+  return 0;
+}

--- a/tests/runtime/inputs/TemplatedKernelAddOne.hip
+++ b/tests/runtime/inputs/TemplatedKernelAddOne.hip
@@ -1,0 +1,10 @@
+#include <hip/hip_runtime.h>
+
+template<typename T>
+__global__ void kernelAddOne(T* data) {
+    data[0] += 1;
+}
+
+void launchKernelAddOne(int* data) {
+  hipLaunchKernelGGL(kernelAddOne<int>, dim3(1), dim3(1), 0, 0, data);
+}

--- a/tests/runtime/inputs/TemplatedKernelAddTwo.hip
+++ b/tests/runtime/inputs/TemplatedKernelAddTwo.hip
@@ -1,0 +1,11 @@
+#include <hip/hip_runtime.h>
+
+template<typename T>
+__global__ void kernelAddOne(T* data) {
+    data[0] += 1;
+}
+
+void launchKernelAddTwo(int* data) {
+  hipLaunchKernelGGL(kernelAddOne<int>, dim3(1), dim3(1), 0, 0, data);
+  hipLaunchKernelGGL(kernelAddOne<int>, dim3(1), dim3(1), 0, 0, data);
+}


### PR DESCRIPTION
## Summary

- Adds regression test for #808: multiple translation units instantiating the same template kernel (e.g. `kernelAddOne<int>`) should not cause "device function is already registered" warnings or incorrect dispatch
- Three separate .hip files compiled individually then linked, verifying both call sites produce correct results
- The underlying issue was already fixed by a prior SPVRegister refactor — this commit adds test coverage to prevent regressions

## Test

`TestTemplateKernelModules` compiles `TemplatedKernelAddOne.hip` and `TemplatedKernelAddTwo.hip` separately, links them with the main test, and verifies correct kernel dispatch. `FAIL_REGULAR_EXPRESSION` is set to catch the warning if it regresses.

## Test results

- Level0 dGPU: 1143/1143 passed
- OpenCL dGPU: 1144/1144 passed

Ref #808