### PR TITLE
Add HipCleanupPass to remove chipStar/HIP internal globals

### DIFF
--- a/llvm_passes/CMakeLists.txt
+++ b/llvm_passes/CMakeLists.txt
@@ -99,7 +99,7 @@ add_library(LLVMHipStripUsedIntrinsics MODULE HipStripUsedIntrinsics.cpp)
 add_library(LLVMHipDefrost MODULE HipDefrost.cpp)
 add_library(LLVMHipPasses MODULE HipPasses.cpp
     HipDynMem.cpp HipStripUsedIntrinsics.cpp HipDefrost.cpp
-    HipPrintf.cpp HipGlobalVariables.cpp HipTextureLowering.cpp HipAbort.cpp
+    HipPrintf.cpp HipGlobalVariables.cpp HipCleanup.cpp HipTextureLowering.cpp HipAbort.cpp
     HipEmitLoweredNames.cpp HipWarps.cpp HipKernelArgSpiller.cpp
     HipLowerZeroLengthArrays.cpp HipSanityChecks.cpp HipLowerSwitch.cpp
     HipLowerMemset.cpp HipIGBADetector.cpp HipPromoteInts.cpp 

--- a/llvm_passes/HipCleanup.cpp
+++ b/llvm_passes/HipCleanup.cpp
@@ -1,0 +1,192 @@
+//===- HipCleanup.cpp -----------------------------------------------------===//
+//
+// Part of the chipStar Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Removes chipStar/HIP internal globals that are not needed in the final
+// SPIR-V output:
+//   - __hip_cuid* and __hip_fatbin* (HIP compilation artifacts)
+//
+// Functions that reference removed globals are stubbed (body replaced with
+// ret zeroinitializer). Stubbing is transitive: non-kernel callers of stubbed
+// functions are also stubbed.
+//
+// (c) 2026 chipStar developers
+//===----------------------------------------------------------------------===//
+
+#include "HipCleanup.h"
+
+#include "../src/common.hh"
+
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/CallingConv.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "hip-cleanup"
+
+using namespace llvm;
+
+namespace {
+
+static bool shouldRemoveGlobal(const GlobalVariable &GV) {
+  if (!GV.hasName())
+    return false;
+  StringRef Name = GV.getName();
+
+  // Keep __chip_var_* — those are lowered by HipGlobalVariablesPass
+  if (Name.starts_with(ChipVarPrefix))
+    return false;
+
+  // Keep __chip_module_has_no_IGBAs — consumed by runtime for IGBA detection
+  if (Name == "__chip_module_has_no_IGBAs")
+    return false;
+
+  // Remove HIP compilation artifacts
+  if (Name.starts_with("__hip_cuid") || Name.starts_with("__hip_fatbin"))
+    return true;
+
+  return false;
+}
+
+// Replace the function body with `ret zeroinitializer` (or `ret void`).
+static void stubFunction(Function &F) {
+  // Drop all references first to break use chains between basic blocks.
+  F.dropAllReferences();
+
+  // Delete all basic blocks.
+  while (!F.empty())
+    F.begin()->eraseFromParent();
+
+  BasicBlock *BB = BasicBlock::Create(F.getContext(), "entry", &F);
+  IRBuilder<> B(BB);
+
+  Type *RetTy = F.getReturnType();
+  if (RetTy->isVoidTy()) {
+    B.CreateRetVoid();
+  } else {
+    B.CreateRet(Constant::getNullValue(RetTy));
+  }
+}
+
+// Collect all non-kernel functions that directly use any of the removed
+// globals.  Kernels are skipped — their individual uses are cleaned up in
+// Step 5 so that other stores (e.g. device-variable resets) are preserved.
+static void findDirectUsers(const SmallPtrSetImpl<GlobalVariable *> &Removed,
+                            SmallPtrSetImpl<Function *> &ToStub) {
+  for (auto *GV : Removed) {
+    for (auto *U : GV->users()) {
+      if (auto *I = dyn_cast<Instruction>(U)) {
+        Function *F = I->getFunction();
+        if (F->getCallingConv() != CallingConv::SPIR_KERNEL)
+          ToStub.insert(F);
+      } else if (auto *CE = dyn_cast<ConstantExpr>(U)) {
+        for (auto *CEU : CE->users()) {
+          if (auto *I2 = dyn_cast<Instruction>(CEU)) {
+            Function *F = I2->getFunction();
+            if (F->getCallingConv() != CallingConv::SPIR_KERNEL)
+              ToStub.insert(F);
+          }
+        }
+      }
+    }
+  }
+}
+
+// Transitively stub non-kernel callers of already-stubbed functions.
+static void transitivelyStubCallers(Module &M,
+                                    SmallPtrSetImpl<Function *> &ToStub) {
+  bool Changed = true;
+  while (Changed) {
+    Changed = false;
+    for (auto &F : M) {
+      if (ToStub.count(&F))
+        continue;
+      if (F.getCallingConv() == CallingConv::SPIR_KERNEL)
+        continue;
+      for (auto &BB : F) {
+        for (auto &I : BB) {
+          if (auto *CB = dyn_cast<CallBase>(&I)) {
+            if (auto *Callee = CB->getCalledFunction()) {
+              if (ToStub.count(Callee)) {
+                ToStub.insert(&F);
+                Changed = true;
+                goto next_func;
+              }
+            }
+          }
+        }
+      }
+    next_func:;
+    }
+  }
+}
+
+} // namespace
+
+PreservedAnalyses HipCleanupPass::run(Module &M, ModuleAnalysisManager &AM) {
+  bool ModuleChanged = false;
+
+  // Step 1: Identify globals to remove.
+  SmallPtrSet<GlobalVariable *, 16> ToRemove;
+  for (auto &GV : M.globals()) {
+    if (shouldRemoveGlobal(GV))
+      ToRemove.insert(&GV);
+  }
+
+  // Step 2: Find functions that reference removed globals.
+  SmallPtrSet<Function *, 16> ToStub;
+  findDirectUsers(ToRemove, ToStub);
+
+  // Step 3: Transitively stub non-kernel callers.
+  transitivelyStubCallers(M, ToStub);
+
+  // Step 4: Stub the functions.
+  for (auto *F : ToStub) {
+    LLVM_DEBUG(dbgs() << "HipCleanup: stubbing function " << F->getName()
+                      << "\n");
+    stubFunction(*F);
+    ModuleChanged = true;
+  }
+
+  // Step 5: Remove the globals.
+  // First, delete all instructions that use the globals to avoid leaving
+  // poison values in kernels like __chip_reset_non_symbols.
+  for (auto *GV : ToRemove) {
+    LLVM_DEBUG(dbgs() << "HipCleanup: removing global " << GV->getName()
+                      << "\n");
+    SmallPtrSet<Instruction *, 8> UsersToDelete;
+    for (auto *U : GV->users()) {
+      if (auto *I = dyn_cast<Instruction>(U))
+        UsersToDelete.insert(I);
+      else if (auto *CE = dyn_cast<ConstantExpr>(U)) {
+        for (auto *CEU : CE->users())
+          if (auto *I2 = dyn_cast<Instruction>(CEU))
+            UsersToDelete.insert(I2);
+      }
+    }
+    for (auto *I : UsersToDelete) {
+      if (!I->use_empty())
+        I->replaceAllUsesWith(PoisonValue::get(I->getType()));
+      I->eraseFromParent();
+    }
+    GV->removeDeadConstantUsers();
+    if (GV->use_empty())
+      GV->eraseFromParent();
+    else {
+      GV->replaceAllUsesWith(PoisonValue::get(GV->getType()));
+      GV->eraseFromParent();
+    }
+    ModuleChanged = true;
+  }
+
+  return ModuleChanged ? PreservedAnalyses::none() : PreservedAnalyses::all();
+}

--- a/llvm_passes/HipCleanup.h
+++ b/llvm_passes/HipCleanup.h
@@ -1,0 +1,29 @@
+//===- HipCleanup.h -------------------------------------------------------===//
+//
+// Part of the chipStar Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// LLVM IR pass to clean up chipStar/HIP internal globals and stub functions
+// that reference them. Removes __hip_cuid*, __hip_fatbin*, non-var __chip_*
+// globals and stubs their users.
+//
+// (c) 2026 chipStar developers
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_PASSES_HIP_CLEANUP_H
+#define LLVM_PASSES_HIP_CLEANUP_H
+
+#include "llvm/IR/PassManager.h"
+
+using namespace llvm;
+
+class HipCleanupPass : public PassInfoMixin<HipCleanupPass> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  static bool isRequired() { return true; }
+};
+
+#endif

--- a/llvm_passes/HipPasses.cpp
+++ b/llvm_passes/HipPasses.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "HipAbort.h"
+#include "HipCleanup.h"
 #include "HipDefrost.h"
 #include "HipDynMem.h"
 #include "HipStripUsedIntrinsics.h"
@@ -189,6 +190,10 @@ static void addFullLinkTimePasses(ModulePassManager &MPM) {
 
   // Fix InvalidBitWidth errors due to non-standard integer types
   addPassWithVerification(MPM, HipPromoteIntsPass(), "HipPromoteIntsPass");
+
+  // Must be last: removes __chip_*/__hip_* globals and stubs their users.
+  // Runs after HipIGBADetectorPass which creates __chip_module_has_no_IGBAs.
+  addPassWithVerification(MPM, HipCleanupPass(), "HipCleanupPass");
 
   // Final verification pass with summary printing
   MPM.addPass(HipVerifyPass("Post-HIP passes", true)); // true = print final summary


### PR DESCRIPTION
## Summary
- New LLVM pass (`HipCleanupPass`) that removes HIP internal globals clspv cannot handle: `__hip_cuid*` and `__hip_fatbin*`
- Functions referencing removed globals are stubbed (body → `ret zeroinitializer`), transitively through non-kernel callers
- Kernel instruction users are individually deleted to preserve other stores (e.g. device-variable resets in `__chip_reset_non_symbols`)
- `__chipspv_device_heap` is NOT removed — it is lowered to i64 by `HipGlobalVariablesPass` in the base branch (#1192)
- Runs last in the pipeline, after `HipIGBADetectorPass` (which creates `__chip_module_has_no_IGBAs`)

## Depends on
- #1192

## Test plan
- [ ] CI passes on all targets
- [x] Verify `__hip_cuid*` and `__hip_fatbin*` globals no longer appear in final SPIR-V