### PR TITLE
fp16: fix UB in bit extraction and error message typo

### DIFF
--- a/samples/fp16/fp16_conversion.hpp
+++ b/samples/fp16/fp16_conversion.hpp
@@ -1,4 +1,5 @@
 // Copyright (c) 1993-2016, NVIDIA CORPORATION. All rights reserved.
+#include <cstring>
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -94,7 +95,7 @@ static const half approx_float_to_half(float fl) {
 static float half_to_float(half hf) {
   __half temp = static_cast<__half>(hf);
   FP16 h;
-  h.u = temp;
+  memcpy(&h.u, &temp, sizeof(h.u));
 
   static const FP32 magic = {113 << 23};
   static const uint shifted_exp = 0x7c00 << 13; // exponent mask after shift
@@ -124,9 +125,9 @@ static float half_to_float(half hf) {
 static int compare_calculated(half h1, half h2) {
   FP16 h_1, h_2;
   __half temp = static_cast<__half>(h1);
-  h_1.u = temp;
+  memcpy(&h_1.u, &temp, sizeof(h_1.u));
   temp = static_cast<__half>(h2);
-  h_2.u = temp;
+  memcpy(&h_2.u, &temp, sizeof(h_2.u));
 
   // also deliberately compares equal infs and equal-value nans
   if (h_1.u == h_2.u)

--- a/samples/fp16/half_math.cpp
+++ b/samples/fp16/half_math.cpp
@@ -96,7 +96,7 @@ void check(std::string fn, const half *x, const half *y, const half *z, const in
         (!eq_oper && compare_calculated(zz_computed, verify) > 8)) {
       if (current_errors < 8) {
         std::cerr << std::hexfloat <<"Test " << fn << " failed at : " << i << " x[i]: "
-		  << xx_computed << " y[i]: " << xx_computed
+		  << xx_computed << " y[i]: " << yy_computed
 		  << " GPU: " << zz_computed
 		  << " CPU: " << verify << "\n";
       }


### PR DESCRIPTION
`compare_calculated()` and `half_to_float()` in `fp16_conversion.hpp`
assigned a `__half` value to `unsigned short` via implicit conversion.
On non-NVIDIA platforms where `__half` lacks `operator unsigned short()`
and only provides `operator float()`, this goes through
`__half → float → unsigned short`, which is undefined behavior for
negative values and produces wrong bit patterns.

Fix by using `memcpy` to extract the raw 16-bit representation directly,
matching the intent of the surrounding union-based code.

Also fix a typo in `half_math.cpp` where the error message printed `x[i]`
twice instead of `x[i]` and `y[i]`.