### PR TITLE
Validate device pointers in SVM/USM memcpy path

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1778,12 +1778,35 @@ static void mapHostAlloc(const void *Ptr,
 }
 
 ///////// Enqueue Operations //////////
+
+// Validate that a pointer expected to be a device allocation is actually
+// a known allocation in the tracker.  Throws hipErrorInvalidValue if not.
+static void validateDevicePtr(chipstar::AllocationTracker *AT, void *Ptr,
+                               bool IsDevice, const char *Role) {
+  if (!IsDevice)
+    return;
+  if (!AT->getAllocInfoCheckPtrRanges(Ptr))
+    CHIPERR_LOG_AND_THROW(std::string("hipMemcpy: invalid ") + Role +
+                              " device pointer.",
+                          hipErrorInvalidValue);
+}
+
 hipError_t chipstar::Queue::memCopy(void *Dst, const void *Src, size_t Size,
                                     hipMemcpyKind Kind) {
 
   std::shared_ptr<chipstar::Event> ChipEvent;
   unmapHostAlloc(Src);
   unmapHostAlloc(Dst);
+
+  auto *AT = getDevice()->AllocTracker;
+  bool DstDev = (Kind == hipMemcpyHostToDevice || Kind == hipMemcpyDeviceToDevice);
+  bool SrcDev = (Kind == hipMemcpyDeviceToHost || Kind == hipMemcpyDeviceToDevice);
+  if (Kind == hipMemcpyDefault) {
+    DstDev = AT->getAllocInfo(Dst) != nullptr;
+    SrcDev = AT->getAllocInfo(Src) != nullptr;
+  }
+  validateDevicePtr(AT, Dst, DstDev, "destination");
+  validateDevicePtr(AT, const_cast<void *>(Src), SrcDev, "source");
 
   ChipEvent = memCopyAsyncImpl(Dst, Src, Size, Kind);
 
@@ -1800,6 +1823,16 @@ void chipstar::Queue::memCopyAsync(void *Dst, const void *Src, size_t Size,
   std::shared_ptr<chipstar::Event> ChipEvent;
   unmapHostAlloc(Src);
   unmapHostAlloc(Dst);
+
+  auto *AT = getDevice()->AllocTracker;
+  bool DstDev = (Kind == hipMemcpyHostToDevice || Kind == hipMemcpyDeviceToDevice);
+  bool SrcDev = (Kind == hipMemcpyDeviceToHost || Kind == hipMemcpyDeviceToDevice);
+  if (Kind == hipMemcpyDefault) {
+    DstDev = AT->getAllocInfo(Dst) != nullptr;
+    SrcDev = AT->getAllocInfo(Src) != nullptr;
+  }
+  validateDevicePtr(AT, Dst, DstDev, "destination");
+  validateDevicePtr(AT, const_cast<void *>(Src), SrcDev, "source");
 
   ChipEvent = memCopyAsyncImpl(Dst, Src, Size, Kind);
 

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -214,3 +214,4 @@ set_tests_properties(TestNativeHandlesBackendName_NoBE PROPERTIES
 
 add_hip_runtime_test(TestHeCBenchF16Max.hip)
 add_hip_runtime_test(TestHeCBenchLebesgue.hip)
+add_hip_runtime_test(TestHipMemcpyInvalidPtr.hip)

--- a/tests/runtime/TestHipMemcpyInvalidPtr.hip
+++ b/tests/runtime/TestHipMemcpyInvalidPtr.hip
@@ -1,0 +1,57 @@
+/**
+ * @file TestHipMemcpyInvalidPtr.hip
+ * @brief Regression test for https://github.com/CHIP-SPV/chipStar/issues/1223
+ *
+ * When hipMalloc fails (e.g. OOM) and the application ignores the error,
+ * calling hipMemcpy with the uninitialised destination pointer must return
+ * an error — not wedge the process.
+ */
+#include <hip/hip_runtime.h>
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+int main() {
+  // Query device max single allocation size so we can request more.
+  hipDeviceProp_t Props;
+  hipError_t Err = hipGetDeviceProperties(&Props, 0);
+  if (Err != hipSuccess) {
+    fprintf(stderr, "hipGetDeviceProperties failed: %d\n", (int)Err);
+    return 1;
+  }
+
+  // Request twice the reported total memory — guaranteed to fail.
+  size_t ReqBytes = (size_t)Props.totalGlobalMem * 2;
+  fprintf(stderr, "Requesting %zu bytes (device total = %zu)\n",
+          ReqBytes, (size_t)Props.totalGlobalMem);
+
+  char *D = (char *)0xdeadbeef;
+  Err = hipMalloc((void **)&D, ReqBytes);
+  fprintf(stderr, "hipMalloc returned %d (%s)\n", (int)Err,
+          hipGetErrorString(Err));
+  assert(Err != hipSuccess && "hipMalloc should have failed");
+
+  // Small host buffer — we only need it to be a valid source pointer.
+  const size_t HostSize = 64;
+  char H[HostSize];
+  memset(H, 0xab, HostSize);
+
+  // hipMemcpy with the invalid device pointer must return an error,
+  // NOT wedge the process.
+  fprintf(stderr, "hipMemcpy(D=%p, H, %zu, H2D)\n", (void *)D, HostSize);
+  Err = hipMemcpy(D, H, HostSize, hipMemcpyHostToDevice);
+  fprintf(stderr, "hipMemcpy returned %d (%s)\n", (int)Err,
+          hipGetErrorString(Err));
+  assert(Err != hipSuccess && "hipMemcpy with invalid dst must fail");
+
+  // Also test Device-to-Host direction.
+  fprintf(stderr, "hipMemcpy(H, D=%p, %zu, D2H)\n", (void *)D, HostSize);
+  Err = hipMemcpy(H, D, HostSize, hipMemcpyDeviceToHost);
+  fprintf(stderr, "hipMemcpy returned %d (%s)\n", (int)Err,
+          hipGetErrorString(Err));
+  assert(Err != hipSuccess && "hipMemcpy with invalid src must fail");
+
+  fprintf(stderr, "PASSED\n");
+  return 0;
+}


### PR DESCRIPTION
Fixes #1223

Validate device pointers via `AllocationTracker` before calling
`clEnqueueSVMMemcpy` in the `IntelUSM`/`CoarseGrainSVM`/`FineGrainSVM`
branch of `memCopyAsyncImpl`. Throws `hipErrorInvalidValue` if the
pointer is not a known allocation.

Related upstream: https://github.com/intel/compute-runtime/issues/914