### PR TITLE
Fix hipGraph* null pointer crashes

### DIFF
--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -200,6 +200,10 @@ hipError_t hipGraphAddMemAllocNode(hipGraphNode_t *pGraphNode, hipGraph_t graph,
   CHIP_TRY
   LOCK(ApiMtx);
   CHIPInitialize();
+  if (!pGraphNode)
+    RETURN(hipErrorInvalidValue);
+  if (!graph)
+    RETURN(hipErrorInvalidValue);
   UNIMPLEMENTED(hipErrorNotSupported);
   CHIP_CATCH
 }
@@ -210,6 +214,10 @@ hipError_t hipGraphAddMemFreeNode(hipGraphNode_t *pGraphNode, hipGraph_t graph,
   CHIP_TRY
   LOCK(ApiMtx);
   CHIPInitialize();
+  if (!pGraphNode)
+    RETURN(hipErrorInvalidValue);
+  if (!graph)
+    RETURN(hipErrorInvalidValue);
   UNIMPLEMENTED(hipErrorNotSupported);
   CHIP_CATCH
 }
@@ -1105,6 +1113,8 @@ hipError_t hipGraphCreate(hipGraph_t *pGraph, unsigned int flags) {
   CHIP_TRY
   LOCK(ApiMtx);
   CHIPInitialize();
+  if (!pGraph)
+    RETURN(hipErrorInvalidValue);
   CHIPGraph *Graph = new CHIPGraph();
   *pGraph = Graph;
   RETURN(hipSuccess);
@@ -1225,6 +1235,10 @@ hipError_t hipGraphNodeGetDependencies(hipGraphNode_t node,
   CHIP_TRY
   LOCK(ApiMtx);
   CHIPInitialize();
+  if (!node)
+    RETURN(hipErrorInvalidValue);
+  if (!pNumDependencies)
+    RETURN(hipErrorInvalidValue);
   auto Deps = NODE(node)->getDependencies();
   *pNumDependencies = Deps.size();
   if (!pDependencies)
@@ -1242,6 +1256,10 @@ hipError_t hipGraphNodeGetDependentNodes(hipGraphNode_t node,
   CHIP_TRY
   LOCK(ApiMtx);
   CHIPInitialize();
+  if (!node)
+    RETURN(hipErrorInvalidValue);
+  if (!pNumDependentNodes)
+    RETURN(hipErrorInvalidValue);
   auto Deps = NODE(node)->getDependants();
   *pNumDependentNodes = Deps.size();
   if (!pDependentNodes)
@@ -1343,6 +1361,12 @@ hipError_t hipGraphNodeFindInClone(hipGraphNode_t *pNode,
   CHIP_TRY
   LOCK(ApiMtx);
   CHIPInitialize();
+  if (!pNode)
+    RETURN(hipErrorInvalidValue);
+  if (!originalNode)
+    RETURN(hipErrorInvalidValue);
+  if (!clonedGraph)
+    RETURN(hipErrorInvalidValue);
   auto Node = GRAPH(clonedGraph)->getClonedNodeFromOriginal(NODE(originalNode));
   *pNode = Node;
   RETURN(hipSuccess);
@@ -1406,6 +1430,8 @@ hipError_t hipGraphExecDestroy(hipGraphExec_t graphExec) {
   CHIP_TRY
   LOCK(ApiMtx);
   CHIPInitialize();
+  if (!graphExec)
+    RETURN(hipErrorInvalidValue);
   delete graphExec;
   RETURN(hipSuccess);
   CHIP_CATCH
@@ -1640,7 +1666,7 @@ hipError_t hipGraphAddMemcpyNode(hipGraphNode_t *pGraphNode, hipGraph_t graph,
   // NULLCHECK(graph, pGraphNode, pCopyParams);
   if (!graph || !pGraphNode || !pCopyParams)
     RETURN(hipErrorInvalidValue);
-  if (!pDependencies & numDependencies > 0)
+  if (!pDependencies && numDependencies > 0)
     CHIPERR_LOG_AND_THROW(
         "numDependencies is not 0 while pDependencies is null",
         hipErrorInvalidValue);
@@ -2204,6 +2230,10 @@ hipError_t hipGraphAddEmptyNode(hipGraphNode_t *pGraphNode, hipGraph_t graph,
   CHIP_TRY
   LOCK(ApiMtx);
   CHIPInitialize();
+  if (!pGraphNode)
+    RETURN(hipErrorInvalidValue);
+  if (!graph)
+    RETURN(hipErrorInvalidValue);
   CHIPGraphNodeEmpty *Node = new CHIPGraphNodeEmpty();
   Node->addDependencies(DECONST_NODES(pDependencies), numDependencies);
   *pGraphNode = Node;

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -215,3 +215,5 @@ set_tests_properties(TestNativeHandlesBackendName_NoBE PROPERTIES
 add_hip_runtime_test(TestHeCBenchF16Max.hip)
 add_hip_runtime_test(TestHeCBenchLebesgue.hip)
 add_hip_runtime_test(TestHipMemcpyInvalidPtr.hip)
+
+add_hip_runtime_test(TestGraphNullPtrValidation.hip)

--- a/tests/runtime/TestGraphNullPtrValidation.hip
+++ b/tests/runtime/TestGraphNullPtrValidation.hip
@@ -1,0 +1,59 @@
+// Regression test for #555: hipGraph* API functions must return
+// hipErrorInvalidValue for null pointer arguments instead of crashing.
+#include <hip/hip_runtime_api.h>
+#include <iostream>
+
+int main() {
+  // hipGraphCreate: null pGraph must not crash
+  if (hipGraphCreate(nullptr, 0) != hipErrorInvalidValue)
+    return 1;
+
+  hipGraph_t graph;
+  if (hipGraphCreate(&graph, 0) != hipSuccess)
+    return 2;
+
+  hipGraphNode_t node;
+
+  // hipGraphAddEmptyNode: null pGraphNode or null graph
+  if (hipGraphAddEmptyNode(nullptr, graph, nullptr, 0) != hipErrorInvalidValue)
+    return 3;
+  if (hipGraphAddEmptyNode(&node, nullptr, nullptr, 0) != hipErrorInvalidValue)
+    return 4;
+
+  if (hipGraphAddEmptyNode(&node, graph, nullptr, 0) != hipSuccess)
+    return 5;
+
+  // hipGraphNodeGetDependencies: null node or null pNumDependencies
+  size_t numDeps = 0;
+  if (hipGraphNodeGetDependencies(nullptr, nullptr, &numDeps) !=
+      hipErrorInvalidValue)
+    return 6;
+  if (hipGraphNodeGetDependencies(node, nullptr, nullptr) !=
+      hipErrorInvalidValue)
+    return 7;
+
+  // hipGraphNodeGetDependentNodes: null node or null pNumDependentNodes
+  size_t numDependents = 0;
+  if (hipGraphNodeGetDependentNodes(nullptr, nullptr, &numDependents) !=
+      hipErrorInvalidValue)
+    return 8;
+  if (hipGraphNodeGetDependentNodes(node, nullptr, nullptr) !=
+      hipErrorInvalidValue)
+    return 9;
+
+  // hipGraphExecDestroy: null graphExec must not crash
+  if (hipGraphExecDestroy(nullptr) != hipErrorInvalidValue)
+    return 10;
+
+  // hipGraphAddMemcpyNode: null pDependencies with non-zero numDependencies
+  // (bitwise-AND operator bug fixed to logical-AND)
+  hipMemcpy3DParms copyParams = {};
+  if (hipGraphAddMemcpyNode(&node, graph, nullptr, 1, &copyParams) !=
+      hipErrorInvalidValue)
+    return 11;
+
+  hipGraphDestroy(graph);
+
+  std::cout << "PASSED\n";
+  return 0;
+}


### PR DESCRIPTION
Fixes #555

Adds null-pointer checks to `hipGraphCreate`, `hipGraphAddEmptyNode`, `hipGraphAddMemAllocNode`, `hipGraphAddMemFreeNode`, `hipGraphExecDestroy`, `hipGraphNodeFindInClone`, `hipGraphNodeGetDependencies`, `hipGraphNodeGetDependentNodes`. Fixes bitwise `&` → `&&` in `hipGraphAddMemcpyNode`.