### PR TITLE
Fix .c files being treated as -x hip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -710,12 +710,12 @@ message(STATUS "Generated HIP_OFFLOAD_LINK_OPTIONS: ${HIP_OFFLOAD_LINK_OPTIONS_I
 # TODO: Is there a better way to do this?
 add_library(deviceInternal INTERFACE)
 target_compile_options(deviceInternal INTERFACE
-  -x hip ${HIP_OFFLOAD_COMPILE_OPTIONS_BUILD_})
+  $<$<COMPILE_LANGUAGE:CXX>:-xhip> ${HIP_OFFLOAD_COMPILE_OPTIONS_BUILD_})
 target_link_libraries(deviceInternal INTERFACE CHIP)
 
 add_library(device INTERFACE)
 target_compile_options(device INTERFACE
-  -x hip ${HIP_OFFLOAD_COMPILE_OPTIONS_INSTALL_})
+  $<$<COMPILE_LANGUAGE:CXX>:-xhip> ${HIP_OFFLOAD_COMPILE_OPTIONS_INSTALL_})
 target_link_libraries(device INTERFACE CHIP)
 
 # same as device on chipStar but provides compatibility with AMD

--- a/tests/post-install/HipDeviceCSource/CMakeLists.txt
+++ b/tests/post-install/HipDeviceCSource/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Regression test for #1001: C source files in a CMake target that links
+# against hip::device must not receive -x hip / -xhip compilation flags.
+# With the bug, helper.c (which uses 'class' as a C identifier) fails to
+# compile because it is treated as C++ / HIP source.
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
+project(HipDeviceCSourceTrial
+  DESCRIPTION "Checking C sources are not compiled as HIP when using hip::device."
+  LANGUAGES C CXX)
+find_package(HIP CONFIG REQUIRED)
+
+# A mixed C+HIP executable that links against hip::device.
+add_executable(hip_c_source main.cpp helper.c)
+target_link_libraries(hip_c_source PRIVATE hip::device)

--- a/tests/post-install/HipDeviceCSource/helper.c
+++ b/tests/post-install/HipDeviceCSource/helper.c
@@ -1,0 +1,7 @@
+/* Pure C helper used by the regression test for issue #1001.
+   'class' is a reserved keyword in C++ / HIP but a valid identifier in C.
+   If this file is compiled with -x hip the compiler will reject it. */
+int get_value(void) {
+  int class = 42;
+  return class;
+}

--- a/tests/post-install/HipDeviceCSource/main.cpp
+++ b/tests/post-install/HipDeviceCSource/main.cpp
@@ -1,0 +1,18 @@
+#include <hip/hip_runtime.h>
+#include <iostream>
+
+// Declared in helper.c (pure C, uses 'class' as a C identifier).
+// If -xhip/-x hip is applied to helper.c the compiler rejects it.
+extern "C" int get_value(void);
+
+int main() {
+  // Verify chipStar runtime is reachable.
+  int deviceCount = 0;
+  if (hipGetDeviceCount(&deviceCount) != hipSuccess)
+    return 1;
+
+  // Call the pure-C helper to confirm it compiled correctly.
+  int v = get_value();
+  std::cout << "get_value() = " << v << "\n";
+  return v != 42;
+}

--- a/tests/post-install/cmake-tests.bash
+++ b/tests/post-install/cmake-tests.bash
@@ -32,6 +32,15 @@ else
     echo "Skip: clang++ or g++ is required"
 fi
 echo
+echo "### Check hip::device with mixed C/C++ sources (#1001)"
+setup-test-dir
+cmake @CMAKE_CURRENT_SOURCE_DIR@/HipDeviceCSource \
+      -DCMAKE_PREFIX_PATH=@CMAKE_INSTALL_PREFIX@ \
+      -DCMAKE_CXX_COMPILER=${CXX}
+make VERBOSE=1
+echo "Success"
+echo
+
 echo "### check CMake-CUDA"
 setup-test-dir
 


### PR DESCRIPTION
Fixes #1001

Use a CMake generator expression so `-xhip` is applied only to CXX sources in the `device`/`deviceInternal` targets. Also bumps HIPCC to reorder flag application so per-source language tags win.