### PR TITLE
fix: replace clSetEventCallback with event KeepAlives for ArgSpillBuffer (#1090)

### DIFF
--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -324,16 +324,6 @@ annotateIndirectPointers(const CHIPContextOpenCL &Ctx,
   return AllocKeepAlives;
 }
 
-struct KernelEventCallbackData {
-  std::shared_ptr<chipstar::ArgSpillBuffer> ArgSpillBuffer;
-  std::unique_ptr<std::vector<std::shared_ptr<void>>> AllocKeepAlives;
-};
-static void CL_CALLBACK kernelEventCallback(cl_event Event,
-                                            cl_int CommandExecStatus,
-                                            void *UserData) {
-  delete static_cast<KernelEventCallbackData *>(UserData);
-}
-
 // CHIPCallbackDataLevel0
 // ************************************************************************
 
@@ -1695,29 +1685,23 @@ CHIPQueueOpenCL::launchImpl(chipstar::ExecItem *ExecItem) {
   std::shared_ptr<chipstar::ArgSpillBuffer> SpillBuf =
       ExecItem->getArgSpillBuffer();
 
-  if (SpillBuf || AllocationsToKeepAlive) {
-    // Use an event call back to prolong the lifetimes of the
-    // following objects until the kernel terminates.
-    //
-    // * SpillBuffer holds an allocation referenced by the kernel
-    //   shared by exec item, which might get destroyed before the
-    //   kernel is launched/completed
-    //
-    // * Annotated indirect SVM/USM pointers may need to outlive the
-    //   kernel execution. The OpenCL spec does not clearly specify
-    //   how long the pointers, annotated via clSetKernelExecInfo(),
-    //   needs to live.
-    auto *CBData = new KernelEventCallbackData;
-    CBData->ArgSpillBuffer = SpillBuf;
-    CBData->AllocKeepAlives = std::move(AllocationsToKeepAlive);
-    clStatus = clSetEventCallback(
-        std::static_pointer_cast<CHIPEventOpenCL>(LaunchEvent)->getNativeRef(),
-        CL_COMPLETE, kernelEventCallback, CBData);
-    if (clStatus != CL_SUCCESS) {
-      delete CBData;
-      CHIPERR_CHECK_LOG_AND_THROW_TABLE(clSetEventCallback);
-    }
-  }
+  // Extend the lifetimes of SpillBuf and indirect-pointer annotations by
+  // storing them in the launch event's KeepAlives list.  They will be
+  // released when the event is eventually destroyed (after the caller
+  // waits on it or it goes out of scope), by which time the kernel has
+  // completed and the buffers are no longer referenced.
+  //
+  // We deliberately avoid clSetEventCallback here: the callback fires on
+  // an OpenCL-internal thread that may hold driver locks, and calling
+  // clReleaseMemObject() (triggered by ArgSpillBuffer's destructor) from
+  // within that callback can deadlock on Intel OpenCL (issue #1090).
+  auto *LaunchEventOCL =
+      static_cast<CHIPEventOpenCL *>(LaunchEvent.get());
+  if (SpillBuf)
+    LaunchEventOCL->KeepAlives.push_back(SpillBuf);
+  if (AllocationsToKeepAlive)
+    for (auto &Item : *AllocationsToKeepAlive)
+      LaunchEventOCL->KeepAlives.push_back(Item);
 
   LaunchEvent->Msg = "KernelLaunch";
   return LaunchEvent;

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -125,6 +125,10 @@ public:
   friend class CHIPEventOpenCL;
   std::shared_ptr<chipstar::Event> RecordedEvent;
   uint64_t HostTimeStamp;
+  // Objects whose lifetime must be extended until this event completes.
+  // Stored here instead of in a clSetEventCallback to avoid calling
+  // OpenCL APIs from within a callback (which can deadlock, issue #1090).
+  std::vector<std::shared_ptr<void>> KeepAlives;
 
 public:
   CHIPEventOpenCL(CHIPContextOpenCL *ChipContext, cl_event ClEvent,

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -214,3 +214,9 @@ set_tests_properties(TestNativeHandlesBackendName_NoBE PROPERTIES
 
 add_hip_runtime_test(TestHeCBenchF16Max.hip)
 add_hip_runtime_test(TestHeCBenchLebesgue.hip)
+
+# Regression test for https://github.com/CHIP-SPV/chipStar/issues/1090
+# Concurrent ArgSpillBuffer launches must not deadlock via OpenCL callback.
+add_hip_runtime_test(TestArgSpillBufferConcurrent.hip)
+set_tests_properties(TestArgSpillBufferConcurrent PROPERTIES
+  TIMEOUT 60)

--- a/tests/runtime/TestArgSpillBufferConcurrent.hip
+++ b/tests/runtime/TestArgSpillBufferConcurrent.hip
@@ -1,0 +1,58 @@
+// Regression test for OpenCL event-callback deadlock (#1090).
+//
+// The bug: CHIPQueueOpenCL::launchKernel() registered a clSetEventCallback to
+// free the ArgSpillBuffer when the kernel completed.  The callback fires on an
+// OpenCL-internal thread that holds OpenCL driver locks; calling
+// clReleaseMemObject() from within that callback can re-enter the same lock
+// and deadlock.
+//
+// The test launches many kernels with large struct arguments (which trigger
+// ArgSpillBuffer creation) without ever synchronising between launches.  This
+// maximises the chance that callbacks fire while the driver is busy, hitting
+// the deadlock on unpatched code.
+//
+// After the fix the ArgSpillBuffer lifetime is managed through the chipStar
+// event's KeepAlives list, avoiding any OpenCL API call from a callback.
+
+#include <hip/hip_runtime.h>
+#include <iostream>
+
+// Large struct → lowered to PODByRef in SPIR-V → ArgSpillBuffer allocated.
+struct BigArg {
+  float data[64]; // 256 bytes
+};
+
+__global__ void kernelWithBigArg(BigArg a, float *out) {
+  int tid = threadIdx.x;
+  if (tid < 64)
+    out[tid] = a.data[tid];
+}
+
+int main() {
+  constexpr int N = 2000;
+  constexpr size_t Sz = sizeof(float) * 64;
+
+  float *d_out;
+  if (hipMalloc(&d_out, Sz) != hipSuccess) {
+    std::cerr << "hipMalloc failed\n";
+    return 1;
+  }
+
+  // Launch many kernels without syncing between them so that multiple
+  // kernelEventCallback invocations can stack up and contend.
+  for (int i = 0; i < N; i++) {
+    BigArg a;
+    for (int j = 0; j < 64; j++)
+      a.data[j] = (float)(i * 64 + j);
+    hipLaunchKernelGGL(kernelWithBigArg, dim3(1), dim3(64), 0, 0, a, d_out);
+  }
+
+  if (hipDeviceSynchronize() != hipSuccess) {
+    std::cerr << "hipDeviceSynchronize failed\n";
+    return 2;
+  }
+
+  hipFree(d_out);
+  std::cout << "PASSED\n";
+  return 0;
+}


### PR DESCRIPTION
Fixes #1090

Removes the `clSetEventCallback`-based lifetime management for `ArgSpillBuffer` and indirect-pointer annotations. Calling OpenCL APIs (clReleaseMemObject) from within a callback can deadlock on Intel OpenCL since the callback fires on an internal driver thread that may hold locks.

Instead, store keep-alive objects in a new `KeepAlives` list on `CHIPEventOpenCL`. The objects are released when the event is destroyed after the caller synchronises.