### PR TITLE
fix: erase AllocationTracker record before freeing memory (#1133)

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1419,14 +1419,28 @@ hipError_t chipstar::Context::free(void *Ptr) {
     // test suite excepts hipErrorInvalidValue. Go with the latter.
     return hipErrorInvalidValue;
 
-  if (AllocInfo->DevPtr)
-    ChipDev->AllocTracker->releaseMemReservation(AllocInfo->Size);
-  if (AllocInfo->MemoryType == hipMemoryTypeHost && AllocInfo->HostPtr &&
-      AllocInfo->HostPtr != AllocInfo->DevPtr)
-    std::free(AllocInfo->HostPtr);
+  // Save the fields we need before eraseRecord() deletes AllocInfo.
+  bool HasDevPtr = AllocInfo->DevPtr != nullptr;
+  size_t AllocSize = AllocInfo->Size;
+  bool IsHostNonMapped = (AllocInfo->MemoryType == hipMemoryTypeHost &&
+                          AllocInfo->HostPtr &&
+                          AllocInfo->HostPtr != AllocInfo->DevPtr);
+  void *HostPtrToFree = AllocInfo->HostPtr;
+
+  if (HasDevPtr)
+    ChipDev->AllocTracker->releaseMemReservation(AllocSize);
+
+  // Erase the record BEFORE freeing the underlying memory.  Freeing first
+  // returns the address to the allocator pool, so a concurrent allocation
+  // could obtain the same address and call recordAllocation() while the old
+  // entry is still in the tracker, causing a "Device pointer already
+  // recorded" abort (issue #1133).
+  ChipDev->AllocTracker->eraseRecord(AllocInfo); // AllocInfo deleted here.
+
+  if (IsHostNonMapped)
+    std::free(HostPtrToFree);
   else
     freeImpl(Ptr);
-  ChipDev->AllocTracker->eraseRecord(AllocInfo);
 
   return hipSuccess;
 }


### PR DESCRIPTION
## Summary

Fix the "Device pointer already recorded" abort in #1133 by reordering
two calls in `Context::free()`.

## The race

```
Main thread (holds ApiMtx)              OCL driver thread (no ApiMtx)
──────────────────────────              ─────────────────────────────
hipLaunchKernel                         kernel completes
 └─ setupAllArgs                         └─ kernelEventCallback fires
    └─ ArgSpillBuffer::                     └─ delete KernelEventCallbackData
       computeAndReserveSpace                  └─ ~ArgSpillBuffer
       └─ Context::allocate                      └─ Context::free  (pre-fix)
          └─ recordAllocation  ◄─── ABORT           ├─ freeImpl(ptr)     ← addr back to pool
             if OCL recycled ptr                    │   ══ race window ══
                                                    └─ eraseRecord(ptr)  ← closes window
```

`ApiMtx` serializes HIP API calls on the main thread, but the OCL callback
runs on the driver's internal thread and isn't covered. If the OCL
allocator recycles the freed address while the window is open, the next
`recordAllocation` aborts with exactly the message in the issue
(`Device pointer already recorded` at `ArgSpillBuffer::computeAndReserveSpace`).

## The fix

Swap the two calls: `eraseRecord(ptr)` then `freeImpl(ptr)`. Window closed.

## How we validated

The bug is rare in the wild — it surfaces only in CI where many workloads
run in parallel, and GPU load varies the timing of kernel-complete
callbacks enough to open the narrow race window. We cannot reproduce it
reliably on-demand in isolation.

To model that timing variance we instrumented the pre-fix `Context::free`
with a short sleep between `freeImpl` and `eraseRecord` (simulating the
additional CPU-side latency real workload contention introduces). With the
sleep inserted, the abort reproduces reliably with the same assertion
message and the same stack as the issue.

Ran on: Intel Arc A770, NEO 26.09.37435.1.

- natural window  (<10 µs): 0 aborts in a 50k-launch stress run
- sleep 50 µs:              reliable abort with #1133's exact message
- sleep 1 ms:               instant abort every run

## Why no automated regression test

The only way to make a test fail deterministically on current hardware is
to add a debug-only sleep hook in `Context::free`. We don't want that in
the release binary for a bug we understand, so the fix ships without an
automated regression test. The validation above (instrumented repro,
matching stack, mechanism analysis) is what backs the change.

## Test plan

- [x] Rebased on `origin/main` at `3c8d52d4e358`
- [x] `ninja` + `ninja build_tests` clean
- [x] `check.py dgpu level0`: 1158/1158 passed
- [x] `check.py dgpu opencl`: 1159/1159 passed