### PR TITLE
fix: use FNV-1a instead of std::hash for HIPRTC cache key (#1142)

### DIFF
--- a/src/spirv_hiprtc.cc
+++ b/src/spirv_hiprtc.cc
@@ -380,8 +380,20 @@ hiprtcResult hiprtcAddNameExpression(hiprtcProgram Prog,
   return HIPRTC_SUCCESS;
 }
 
+/// FNV-1a 64-bit hash — portable, deterministic across runs and platforms,
+/// unlike std::hash<std::string> which is implementation-defined and may
+/// produce different values in different program runs or on different systems.
+static uint64_t fnv1a64(const std::string &s) {
+  uint64_t hash = UINT64_C(14695981039346656037);
+  for (unsigned char c : s) {
+    hash ^= c;
+    hash *= UINT64_C(1099511628211);
+  }
+  return hash;
+}
+
 /// Compute a cache key for HIPRTC output based on source, headers, and options.
-/// The key is a hash of all inputs that affect the SPIRV output.
+/// The key is a portable, stable hash of all inputs that affect the SPIRV output.
 static std::string computeHiprtcCacheKey(const chipstar::Program &Program,
                                          int NumOptions,
                                          const char *const *Options) {
@@ -398,8 +410,7 @@ static std::string computeHiprtcCacheKey(const chipstar::Program &Program,
       combined += Options[i];
     combined += "\n";
   }
-  std::hash<std::string> hasher;
-  return std::to_string(hasher(combined));
+  return std::to_string(fnv1a64(combined));
 }
 
 /// Try to load a cached HIPRTC compilation result.

--- a/tests/hiprtc/CMakeLists.txt
+++ b/tests/hiprtc/CMakeLists.txt
@@ -28,3 +28,7 @@ add_hip_test(TestHiprtcOptions.cc)
 add_hip_test(TestShellMetacharacters.cc)
 add_hip_test(TestConstantMemory.cc)
 add_hip_test(TestProjectionBasisKernel.cc)
+
+# Regression test for https://github.com/CHIP-SPV/chipStar/issues/1142
+# Verify the HIPRTC cache is read back on repeated compilations.
+add_hip_test(TestHiprtcCache.cc)

--- a/tests/hiprtc/TestHiprtcCache.cc
+++ b/tests/hiprtc/TestHiprtcCache.cc
@@ -1,0 +1,85 @@
+// Test that the HIPRTC output cache is populated on the first compilation
+// and reused (not recompiled) on subsequent calls with identical inputs (#1142).
+//
+// The cache key is computed from source + headers + options.  With a
+// non-deterministic hash (std::hash<std::string>) the key would differ between
+// runs, making the cache write-only.  After switching to FNV-1a, the key is
+// stable and a second compilation with the same inputs returns the cached SPIR-V.
+
+#include "TestCommon.hh"
+#include <filesystem>
+#include <fstream>
+#include <cstdlib>
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+
+static constexpr auto KernelSrc = R"---(
+__global__ void add_one(int *out, const int *in) {
+  *out = *in + 1;
+}
+)---";
+
+static void runKernel(hipModule_t Mod) {
+  hipFunction_t Fn;
+  HIP_CHECK(hipModuleGetFunction(&Fn, Mod, "add_one"));
+
+  int h_in = 41, h_out = 0;
+  int *d_in, *d_out;
+  HIP_CHECK(hipMalloc(&d_in, sizeof(int)));
+  HIP_CHECK(hipMalloc(&d_out, sizeof(int)));
+  HIP_CHECK(hipMemcpy(d_in, &h_in, sizeof(int), hipMemcpyHostToDevice));
+
+  void *args[] = {&d_out, &d_in};
+  HIP_CHECK(hipModuleLaunchKernel(Fn, 1, 1, 1, 1, 1, 1, 0, nullptr, args, nullptr));
+  HIP_CHECK(hipDeviceSynchronize());
+  HIP_CHECK(hipMemcpy(&h_out, d_out, sizeof(int), hipMemcpyDeviceToHost));
+
+  HIP_CHECK(hipFree(d_in));
+  HIP_CHECK(hipFree(d_out));
+  TEST_ASSERT(h_out == 42);
+}
+
+static hipModule_t compileAndLoad(const char *cacheDirEnv) {
+  hiprtcProgram Prog;
+  HIPRTC_CHECK(hiprtcCreateProgram(&Prog, KernelSrc, "test.hip", 0, nullptr, nullptr));
+  HIPRTC_CHECK(hiprtcCompileProgram(Prog, 0, nullptr));
+
+  size_t CodeSz;
+  HIPRTC_CHECK(hiprtcGetCodeSize(Prog, &CodeSz));
+  std::vector<char> Code(CodeSz);
+  HIPRTC_CHECK(hiprtcGetCode(Prog, Code.data()));
+  HIPRTC_CHECK(hiprtcDestroyProgram(&Prog));
+
+  hipModule_t Mod;
+  HIP_CHECK(hipModuleLoadData(&Mod, Code.data()));
+  return Mod;
+}
+
+int main() {
+  // Use a per-process temporary directory so the test is hermetic.
+  std::string cacheDir = "/tmp/chipstar_hiprtc_cache_" + std::to_string(getpid());
+  fs::create_directories(cacheDir);
+
+  setenv("CHIP_MODULE_CACHE_DIR", cacheDir.c_str(), 1);
+
+  HIP_CHECK(hipInit(0));
+  HIP_CHECK(hipSetDevice(0));
+
+  // --- First compilation: cache miss, SPIR-V written to cache. ---
+  auto cacheEntriesBefore = 0;
+  for (auto &e : fs::directory_iterator(cacheDir / "hiprtc"))
+    cacheEntriesBefore++;
+  (void)cacheEntriesBefore; // may not exist yet
+
+  hipModule_t Mod1 = compileAndLoad(cacheDir.c_str());
+  runKernel(Mod1);
+  HIP_CHECK(hipModuleUnload(Mod1));
+
+  // Count cache entries after first compilation.
+  int filesAfterFirst = 0;
+  if (fs::exists(cacheDir + "/hiprtc"))
+    for (auto &e : fs::directory_iterator(cacheDir + "/hiprtc"))
+      filesAfterFirst++;
+  TEST_ASSERT(filesAfterFirst >= 1 && "Cache should have been written after first compilation");
+

--- a/tests/hiprtc/TestHiprtcCache.cc
+++ b/tests/hiprtc/TestHiprtcCache.cc
@@ -83,3 +83,21 @@ int main() {
       filesAfterFirst++;
   TEST_ASSERT(filesAfterFirst >= 1 && "Cache should have been written after first compilation");
 
+  // --- Second compilation: cache hit, no recompilation needed. ---
+  hipModule_t Mod2 = compileAndLoad(cacheDir.c_str());
+  runKernel(Mod2);
+  HIP_CHECK(hipModuleUnload(Mod2));
+
+  // The number of cache files should not have increased (same key → same file).
+  int filesAfterSecond = 0;
+  for (auto &e : fs::directory_iterator(cacheDir + "/hiprtc"))
+    filesAfterSecond++;
+  TEST_ASSERT(filesAfterSecond == filesAfterFirst &&
+              "Second compilation should reuse the cached entry, not create a new one");
+
+  fs::remove_all(cacheDir);
+  unsetenv("CHIP_MODULE_CACHE_DIR");
+
+  std::cerr << "PASSED\n";
+  return 0;
+}


### PR DESCRIPTION
Fixes #1142

`std::hash<std::string>` is implementation-defined and may produce different values across program runs on some platforms (libc++ may randomize it) or across stdlib versions. This makes the HIPRTC cache write-only: the key written on run N differs from the key checked on run N+1.

Replace with FNV-1a 64-bit which is portable and deterministic.