### PR TITLE
fix: poll zeCommandListHostSynchronize to detect GPU hangcheck reset (#1191)

### DIFF
--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1872,14 +1872,26 @@ void CHIPQueueLevel0::finish() {
   }
   LOCK(CommandListMtx);
 
-  // host wait for command list to complete
-  if( ZeCmdListImmCopy_ != ZeCmdListImm_) {
-    zeStatus = zeCommandListHostSynchronize(ZeCmdListImmCopy_, UINT64_MAX);
+  // Poll with a finite timeout per iteration so that a GPU reset (e.g. from
+  // the i915 hangcheck / heartbeat mechanism) can be detected and reported
+  // instead of blocking forever (issue #1191).
+  //
+  // With UINT64_MAX, zeCommandListHostSynchronize() never returns after the
+  // driver kills in-flight batches during a GPU reset.  Using a 1-second
+  // poll interval allows Level Zero to surface ZE_RESULT_ERROR_DEVICE_LOST
+  // on the next iteration.
+  constexpr uint64_t PollIntervalNs = 1000000000ULL; // 1 second
+
+  if (ZeCmdListImmCopy_ != ZeCmdListImm_) {
+    do {
+      zeStatus = zeCommandListHostSynchronize(ZeCmdListImmCopy_, PollIntervalNs);
+    } while (zeStatus == ZE_RESULT_NOT_READY);
     CHIPERR_CHECK_LOG_AND_THROW_TABLE(zeCommandListHostSynchronize);
   }
-  
-  // host wait for command list to complete
-  zeStatus = zeCommandListHostSynchronize(ZeCmdListImm_, UINT64_MAX);
+
+  do {
+    zeStatus = zeCommandListHostSynchronize(ZeCmdListImm_, PollIntervalNs);
+  } while (zeStatus == ZE_RESULT_NOT_READY);
   CHIPERR_CHECK_LOG_AND_THROW_TABLE(zeCommandListHostSynchronize);
 
   // All GPU work on this queue has completed. Release cross-queue dependency

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -214,3 +214,10 @@ set_tests_properties(TestNativeHandlesBackendName_NoBE PROPERTIES
 
 add_hip_runtime_test(TestHeCBenchF16Max.hip)
 add_hip_runtime_test(TestHeCBenchLebesgue.hip)
+
+# Regression test for https://github.com/CHIP-SPV/chipStar/issues/1191
+# GPU hangcheck recovery: hipDeviceSynchronize must return an error (not hang)
+# when the i915 driver resets the GPU after the hangcheck threshold.
+add_hip_runtime_test(TestGpuHangcheckRecovery.hip)
+set_tests_properties(TestGpuHangcheckRecovery PROPERTIES
+  TIMEOUT 120)

--- a/tests/runtime/TestGpuHangcheckRecovery.hip
+++ b/tests/runtime/TestGpuHangcheckRecovery.hip
@@ -1,0 +1,67 @@
+/// \file
+/// Regression test for chipStar issue #1191: hipDeviceSynchronize hangs
+/// indefinitely when GPU hang detection (i915 hangcheck) kills long-running
+/// batches and chipStar doesn't recover.
+///
+/// On Intel dGPUs with numQueues=1, all HIP streams serialize on a single
+/// hardware queue. When the total GPU wall time exceeds the i915 hangcheck
+/// threshold (~18-20s with default heartbeat_interval_ms=2500), the GPU
+/// resets all in-flight work. chipStar's finish() calls
+/// zeCommandListHostSynchronize with UINT64_MAX timeout, which never
+/// returns after a GPU reset.
+///
+/// This test launches enough long-running kernels to exceed the hangcheck.
+/// EXPECTED: chipStar should detect the GPU reset and return an error
+/// (not hang forever).
+
+#include <hip/hip_runtime.h>
+#include <cstdio>
+#include <cstdlib>
+
+__global__ void spin_kernel(long *d_out, long iterations) {
+  long val = 0;
+  for (long i = 0; i < iterations; i++)
+    val += i % 3;
+  d_out[0] = val;
+}
+
+int main() {
+  hipDeviceProp_t prop;
+  hipGetDeviceProperties(&prop, 0);
+
+  // Each kernel runs ~4s at clockRate=2.4GHz.
+  // 5 kernels × 4s = 20s, exceeding the ~18s hangcheck threshold.
+  const int nkernels = 5;
+  const long clock_count = (long)(20.0f * prop.clockRate);
+
+  long *d_buf;
+  hipError_t err = hipMalloc(&d_buf, nkernels * sizeof(long));
+  if (err != hipSuccess) {
+    printf("HIP_SKIP_THIS_TEST\n");
+    return 77;
+  }
+
+  hipStream_t streams[nkernels];
+  for (int i = 0; i < nkernels; i++)
+    hipStreamCreate(&streams[i]);
+
+  for (int i = 0; i < nkernels; i++)
+    spin_kernel<<<1, 1, 0, streams[i]>>>(&d_buf[i], clock_count);
+
+  err = hipDeviceSynchronize();
+
+  // If we get here (not hung), the test passes.
+  // Currently chipStar hangs here, so this test is expected to FAIL
+  // (timeout) until the fix is implemented.
+  if (err == hipSuccess) {
+    printf("PASS (all kernels completed)\n");
+  } else {
+    // GPU reset detected — chipStar correctly reported an error
+    printf("PASS (GPU reset detected: %s)\n", hipGetErrorString(err));
+  }
+
+  for (int i = 0; i < nkernels; i++)
+    hipStreamDestroy(streams[i]);
+  hipFree(d_buf);
+  return 0;
+}


### PR DESCRIPTION
Fixes #1191

Replaces `zeCommandListHostSynchronize(UINT64_MAX)` with a polling loop using a 1-second interval. When i915 hangcheck kills in-flight GPU batches, Level Zero returns `ZE_RESULT_ERROR_DEVICE_LOST` on the next poll instead of blocking forever. `hipDeviceSynchronize` then returns an error rather than hanging indefinitely.