### PR TITLE
Update HIP submodule to latest chipStar-hip-7 and capture error output for Aurora gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -206,7 +206,7 @@ hoMusic_run:
   extends: .aurora-batch-runner
   script:
     - rm -f ${GENESIS_CI_PROJECT_DIR}/output
-    - ${GENESIS_CI_PROJECT_DIR}/hoMusic_ci.sh run chipStar/llvm19 | tee -a ${GENESIS_CI_PROJECT_DIR}/output
+    - ${GENESIS_CI_PROJECT_DIR}/hoMusic_ci.sh run chipStar/llvm19 |& tee -a ${GENESIS_CI_PROJECT_DIR}/output
   allow_failure: true
 
 performance_hoMusic:
@@ -271,7 +271,7 @@ zeroRK_run:
   - module use ${WRK_DIR}/modulefiles
   - module load chipStar/llvm19
   - rm -f output
-  - ./submit_job.sh | tee -a output
+  - ./submit_job.sh |& tee -a output
   allow_failure: true
 
 zeroRK_performance:


### PR DESCRIPTION
This updates the HIP submodule to the latest latest chipStar-hip-7 (which has the pthreads fix in it). This should let the tests run on Aurora.

It also makes a small change to the Aurora gitlab CI yaml file so we save error output as well.