### PR TITLE
Swtiching PtrToAllocInfo_ to sorted map to decrease overhead for memcopies

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -250,14 +250,20 @@ void chipstar::AllocationTracker::recordAllocation(
 chipstar::AllocationInfo *
 chipstar::AllocationTracker::getAllocInfoCheckPtrRanges(void *DevPtr) {
   // Note: This function is called from within a locked context
-  for (auto &Info : PtrToAllocInfo_) {
-    chipstar::AllocationInfo *AllocInfo = Info.second;
-    void *Start = AllocInfo->DevPtr;
-    void *End = (char *)Start + AllocInfo->Size;
 
-    if (Start <= DevPtr && DevPtr < End)
-      return AllocInfo;
-  }
+  // upper_bound gives the first entry with key > DevPtr; step back one to get
+  // the candidate whose start address is <= DevPtr, then range-check it.
+  auto It = PtrToAllocInfo_.upper_bound(DevPtr);
+  if (It == PtrToAllocInfo_.begin())
+    return nullptr;
+  --It;
+
+  chipstar::AllocationInfo *AllocInfo = It->second;
+  void *Start = AllocInfo->DevPtr;
+  void *End = (char *)Start + AllocInfo->Size;
+
+  if (Start <= DevPtr && DevPtr < End)
+    return AllocInfo;
 
   return nullptr;
 }

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -253,16 +253,14 @@ chipstar::AllocationTracker::getAllocInfoCheckPtrRanges(void *DevPtr) {
 
   // upper_bound gives the first entry with key > DevPtr; step back one to get
   // the candidate whose start address is <= DevPtr, then range-check it.
-  auto It = PtrToAllocInfo_.upper_bound(DevPtr);
-  if (It == PtrToAllocInfo_.begin())
+  const auto It = PtrToAllocInfo_.upper_bound(DevPtr);
+  if (It == PtrToAllocInfo_.cbegin())
     return nullptr;
-  --It;
 
-  chipstar::AllocationInfo *AllocInfo = It->second;
-  void *Start = AllocInfo->DevPtr;
-  void *End = (char *)Start + AllocInfo->Size;
+  chipstar::AllocationInfo *AllocInfo = std::prev(It)->second;
+  void *End = (char*) AllocInfo->DevPtr + AllocInfo->Size;
 
-  if (Start <= DevPtr && DevPtr < End)
+  if (DevPtr < End)
     return AllocInfo;
 
   return nullptr;

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -508,7 +508,7 @@ private:
   std::string Name_;
 
   std::unordered_set<chipstar::AllocationInfo *> AllocInfos_;
-  std::unordered_map<void *, chipstar::AllocationInfo *> PtrToAllocInfo_;
+  std::map<void *, chipstar::AllocationInfo *> PtrToAllocInfo_;
 
   size_t NumHostAllocations_ = 0;
   size_t NumManagedAllocations_ = 0;

--- a/tests/benchmarks/CMakeLists.txt
+++ b/tests/benchmarks/CMakeLists.txt
@@ -11,3 +11,10 @@ target_compile_definitions(manySmallKernelsOnlyLaunch PRIVATE CHECK_ONLY_LAUNCH)
 target_link_libraries(manySmallKernelsOnlyLaunch CHIP deviceInternal)
 target_include_directories(manySmallKernelsOnlyLaunch
   PRIVATE $<TARGET_PROPERTY:CHIP,INCLUDE_DIRECTORIES>)
+
+set_source_files_properties(manyMallocMemcopies.hip PROPERTIES LANGUAGE CXX)
+add_executable(manyMallocMemcopies manyMallocMemcopies.hip)
+set_target_properties(manyMallocMemcopies PROPERTIES CXX_STANDARD_REQUIRED ON)
+target_link_libraries(manyMallocMemcopies CHIP deviceInternal)
+target_include_directories(manyMallocMemcopies
+  PRIVATE $<TARGET_PROPERTY:CHIP,INCLUDE_DIRECTORIES>)

--- a/tests/benchmarks/manyMallocMemcopies.hip
+++ b/tests/benchmarks/manyMallocMemcopies.hip
@@ -1,0 +1,49 @@
+#include <hip/hip_runtime.h>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#define CHECK(cmd)                                                        \
+    do {                                                                  \
+        hipError_t e = (cmd);                                             \
+        if (e != hipSuccess) {                                            \
+            fprintf(stderr, "HIP error %s:%d: %s\n",                     \
+                    __FILE__, __LINE__, hipGetErrorString(e));            \
+            return 1;                                                     \
+        }                                                                 \
+    } while (0)
+
+int main() {
+    const int    ITERS     = 15000;
+    const size_t BUF_SIZE  = 192;
+    double samples[ITERS];
+    char host_buf[BUF_SIZE];
+    std::vector<void *> dev_ptrs(ITERS, nullptr);
+
+    // time how long the memcopy takes for many allocated pieces
+    for (int i = 0; i < ITERS; ++i) {
+      if(i%1000 == 0) printf( "iteration %d\n", i);
+      CHECK(hipMalloc(&dev_ptrs[i], BUF_SIZE));
+      auto t0 = std::chrono::steady_clock::now();
+      CHECK(hipMemcpy(dev_ptrs[i], host_buf, BUF_SIZE, hipMemcpyHostToDevice));
+      auto t1 = std::chrono::steady_clock::now();
+      samples[i] = std::chrono::duration<double, std::nano>(t1 - t0).count();
+    }
+
+    // free everything
+    for (int i = 0; i < ITERS; ++i) {
+      CHECK(hipFree(dev_ptrs[i]));
+    }
+    
+    // starting at 1 to let the first be a warmup
+    // fail if the last iteration is > double the first 
+    if( samples[ITERS-1] / samples[1] > 2 ) {
+      printf( "Fail, the %d th iteration was %lf and the second was %lf. They should be close\n", ITERS-1, samples[ITERS-1], samples[1]);
+      return 1;
+    }
+    else {
+      printf( "Pass\n");
+      return 0;
+    }
+    return 0;
+}


### PR DESCRIPTION
This changes `PtrToAllocInfo_` from an unsorted map to a sorted map. The reason is that with the unsorted map, to find if a pointer is inside a previously allocated chunk, we must do a linear search through all of `PtrToAllocInfo_`. If there are a lot of allocations, the time to do this will increase with the number of allocations, so hipMemcopy will get slower and slower each iteration for code like:
```
    for (int i = 0; i < 800000; ++i) {
      CHECK(hipMalloc(&dev_ptrs[i], BUF_SIZE));
      CHECK(hipMemcpy(dev_ptrs[i], host_buf, BUF_SIZE, hipMemcpyHostToDevice));
    }
```
If we change it to the sorted map, we can do the search in log(N) time, so this is faster for this type of code.

If there was a specific reason we need unordered_map, let me know and we can try something else.

h/t to @varunhiremath for the report.
