### PR TITLE
fix: hipMemcpyHtoD/HtoDAsync — match HIP-7 const void* signature

### DIFF
--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -4968,7 +4968,7 @@ hipError_t hipMemcpyDtoD(hipDeviceptr_t Dst, hipDeviceptr_t Src,
   CHIP_CATCH
 }
 
-hipError_t hipMemcpyHtoDAsync(hipDeviceptr_t Dst, void *Src, size_t SizeBytes,
+hipError_t hipMemcpyHtoDAsync(hipDeviceptr_t Dst, const void *Src, size_t SizeBytes,
                               hipStream_t Stream) {
   CHIP_TRY
   LOCK(ApiMtx);
@@ -4978,7 +4978,7 @@ hipError_t hipMemcpyHtoDAsync(hipDeviceptr_t Dst, void *Src, size_t SizeBytes,
   CHIP_CATCH
 }
 
-hipError_t hipMemcpyHtoD(hipDeviceptr_t Dst, void *Src, size_t SizeBytes) {
+hipError_t hipMemcpyHtoD(hipDeviceptr_t Dst, const void *Src, size_t SizeBytes) {
   CHIP_TRY
   LOCK(ApiMtx);
   CHIPInitialize();

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_hip_test(test_stream_wait_event_sync.cpp)
+add_hip_test(test_hipMemcpyHtoD_link.cpp)

--- a/tests/regression/test_hipMemcpyHtoD_link.cpp
+++ b/tests/regression/test_hipMemcpyHtoD_link.cpp
@@ -1,0 +1,47 @@
+// Regression test for hipMemcpyHtoD / hipMemcpyHtoDAsync ABI mismatch.
+//
+// The HIP-7 submodule update changed the public signatures in
+// hip_runtime_api.h to take `const void* src` (inside extern "C"), but
+// src/CHIPBindings.cc still defines them with `void* Src`. The compiler
+// treats those as two different functions:
+//   - the header-declared extern "C" symbol has no implementation, so
+//     any caller that includes the header gets an unresolved-reference
+//     link error;
+//   - the .cc-defined function ends up C++-mangled
+//     (e.g. _Z13hipMemcpyHtoDPvS_m) and is unreachable from C and from
+//     any caller that uses the public header.
+//
+// This test simply calls both APIs through the public header. If the
+// signatures match, it links and runs cleanly (the runtime call is
+// expected to fail with a non-success error since we pass null pointers,
+// but that is fine — we only care that the linker resolves the symbol).
+// If the bug is present, the link itself fails with
+// "undefined reference to `hipMemcpyHtoD`" / "...HtoDAsync".
+//
+// See: https://github.com/CHIP-SPV/chipStar issue (OpenMM build break)
+
+#include <hip/hip_runtime.h>
+#include <cstdio>
+
+int main() {
+    hipDeviceptr_t devPtr = nullptr;
+    const void* hostPtr = nullptr;
+    size_t bytes = 0;
+
+    // Synchronous variant.
+    hipError_t err1 = hipMemcpyHtoD(devPtr, hostPtr, bytes);
+    printf("hipMemcpyHtoD returned %d (%s)\n",
+           (int)err1, hipGetErrorString(err1));
+
+    // Async variant.
+    hipStream_t stream = nullptr;
+    hipError_t err2 = hipMemcpyHtoDAsync(devPtr, hostPtr, bytes, stream);
+    printf("hipMemcpyHtoDAsync returned %d (%s)\n",
+           (int)err2, hipGetErrorString(err2));
+
+    // The point of this test is that the link succeeds. Any runtime
+    // result is acceptable — a real implementation would reject the
+    // null inputs. Return 0 unconditionally so the test passes once
+    // the ABI is correct.
+    return 0;
+}


### PR DESCRIPTION
## Summary

The HIP-7 submodule update (`Update HIP submodule to latest chipStar-hip-7`) changed the public signatures of `hipMemcpyHtoD` and `hipMemcpyHtoDAsync` in `HIP/include/hip/hip_runtime_api.h` to take `const void* src` (inside `extern "C"`), but the implementations in `src/CHIPBindings.cc` were not updated and still take `void *Src`.

Because the parameter types differ, the compiler does not view the .cc definitions as redeclarations of the extern "C" header functions — they end up C++-mangled (`_Z13hipMemcpyHtoDPvS_m`, etc.) and the extern "C" symbols the header declared remain unimplemented in `libCHIP.so`.

Result: any caller that includes `<hip/hip_runtime.h>` and uses either function gets an unresolved-reference link error:

```
undefined reference to `hipMemcpyHtoD'
undefined reference to `hipMemcpyHtoDAsync'
```

Found while building OpenMM against chipStar. Reproduces with a one-file test that just calls both APIs through the public header.

## Commits

1. **test:** new regression test under `tests/regression/test_hipMemcpyHtoD_link.cpp` that exposes the bug. With the bug present it fails to link; on a fixed build it links and passes.
2. **fix:** change the two `.cc` parameter types from `void *Src` to `const void *Src`. The bodies already treat `Src` as read-only so no other code changes are required.

## Verified

Built locally against this branch (LLVM 22, Intel Arc A770):

```
$ nm -D --defined-only build/libCHIP.so | grep hipMemcpyHtoD
0000000000168c50 T hipMemcpyHtoD            ← was _Z13hipMemcpyHtoDPvS_m
00000000001689c0 T hipMemcpyHtoDAsync       ← was _Z18hipMemcpyHtoDAsyncPvS_mP12ihipStream_t

$ ctest -R test_hipMemcpyHtoD_link
1/1 Test #142: test_hipMemcpyHtoD_link ..........   Passed    0.15 sec
100% tests passed, 0 tests failed out of 1
```

## Test plan

- [x] Test fails to link before commit 2 is applied (verified by building only commit 1)
- [x] Test links and passes after commit 2 is applied
- [x] No other `hipMemcpy*` API has the same mismatch (spot-checked the rest of the file)

## Impact

Any downstream that uses these two specific HIP API entry points cannot link against `libCHIP.so` from a chipStar build that includes the HIP-7 submodule update. This blocks at least the OpenMM HIP backend; any other `extern "C"` consumer of the HIP API on chipStar would see the same break.