### PR TITLE
fix: HIPRTC cache — persist name-expression map and harden cache file format

### DIFF
--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -848,10 +848,12 @@ class Program {
   /// Include headers.
   std::map<std::string, std::string> Headers_;
 
-  /// Name expressions added before compilation as key to the
-  /// map. After compilation they point to their lowered/mangled
-  /// names. The map value may also be empty meaning the lowered name
-  /// is unknown.
+  /// Name expressions added before compilation are inserted as keys with an
+  /// empty value. After a successful compilation (or a successful HIPRTC
+  /// cache load) the value holds the lowered/mangled name. An empty value
+  /// after compilation indicates a pipeline error: hiprtcGetLoweredName
+  /// treats it as HIPRTC_ERROR_INTERNAL_ERROR rather than returning a
+  /// pointer to an empty string.
   std::map<std::string, std::string> NameExpressions_;
 
   std::string ProgramLog_; ///< Captured compilation log.

--- a/src/spirv_hiprtc.cc
+++ b/src/spirv_hiprtc.cc
@@ -383,13 +383,31 @@ hiprtcResult hiprtcAddNameExpression(hiprtcProgram Prog,
   return HIPRTC_SUCCESS;
 }
 
+/// FNV-1a 64-bit hash — portable, deterministic across runs and platforms.
+/// std::hash<std::string> is implementation-defined and may produce different
+/// values across program runs (some libc++ randomize it) or across different
+/// compiler/stdlib versions, making the cache effectively write-only on those
+/// platforms. The same change was previously proposed in #1231 (closed
+/// unmerged); we re-introduce it here because a stable on-disk cache key is
+/// part of the new versioned cache file format ('CHC1' magic) — without a
+/// stable hash, the version header doesn't help.
+static uint64_t fnv1a64(const std::string &s) {
+  uint64_t hash = UINT64_C(14695981039346656037);
+  for (unsigned char c : s) {
+    hash ^= c;
+    hash *= UINT64_C(1099511628211);
+  }
+  return hash;
+}
+
 /// Compute a cache key for HIPRTC output based on source, headers, options,
 /// and registered name expressions.
-/// The key is a hash of all inputs that affect the SPIRV output AND the set
-/// of name expressions that need a lowered-name mapping. Without including
-/// name expressions, two compilations with the same source/options but a
-/// different set of registered name expressions would alias to the same
-/// cache entry, leaving some lowered-name lookups unmapped on cache hit.
+/// The key is a portable, stable hash of all inputs that affect the SPIRV
+/// output AND the set of name expressions that need a lowered-name mapping.
+/// Without including name expressions, two compilations with the same
+/// source/options but a different set of registered name expressions would
+/// alias to the same cache entry, leaving some lowered-name lookups unmapped
+/// on cache hit.
 static std::string computeHiprtcCacheKey(const chipstar::Program &Program,
                                          int NumOptions,
                                          const char *const *Options) {
@@ -412,8 +430,7 @@ static std::string computeHiprtcCacheKey(const chipstar::Program &Program,
   for (auto &[expr, lowered] : Program.getNameExpressionMap()) {
     combined += expr + "\n";
   }
-  std::hash<std::string> hasher;
-  return std::to_string(hasher(combined));
+  return std::to_string(fnv1a64(combined));
 }
 
 // Cache file format (binary, little-endian):

--- a/src/spirv_hiprtc.cc
+++ b/src/spirv_hiprtc.cc
@@ -27,10 +27,13 @@ THE SOFTWARE.
 #include "Utils.hh"
 #include "logging.hh"
 
+#include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <regex>
 #include <set>
+#include <vector>
 #include <chrono>
 
 struct CompileOptions {
@@ -380,8 +383,13 @@ hiprtcResult hiprtcAddNameExpression(hiprtcProgram Prog,
   return HIPRTC_SUCCESS;
 }
 
-/// Compute a cache key for HIPRTC output based on source, headers, and options.
-/// The key is a hash of all inputs that affect the SPIRV output.
+/// Compute a cache key for HIPRTC output based on source, headers, options,
+/// and registered name expressions.
+/// The key is a hash of all inputs that affect the SPIRV output AND the set
+/// of name expressions that need a lowered-name mapping. Without including
+/// name expressions, two compilations with the same source/options but a
+/// different set of registered name expressions would alias to the same
+/// cache entry, leaving some lowered-name lookups unmapped on cache hit.
 static std::string computeHiprtcCacheKey(const chipstar::Program &Program,
                                          int NumOptions,
                                          const char *const *Options) {
@@ -398,35 +406,118 @@ static std::string computeHiprtcCacheKey(const chipstar::Program &Program,
       combined += Options[i];
     combined += "\n";
   }
+  combined += "\n---name-expressions---\n";
+  // Map values are empty at hash time (filled in only after compilation), so
+  // only keys (the expressions) contribute. std::map iteration is sorted.
+  for (auto &[expr, lowered] : Program.getNameExpressionMap()) {
+    combined += expr + "\n";
+  }
   std::hash<std::string> hasher;
   return std::to_string(hasher(combined));
 }
 
+// Cache file format (binary, little-endian):
+//   magic[4]      = 'C','H','C','1'
+//   spirv_size    = uint32_t
+//   spirv_bytes   = spirv_size bytes
+//   name_count    = uint32_t
+//   for each entry:
+//     expr_len    = uint32_t
+//     expr_bytes  = expr_len bytes (UTF-8)
+//     lowered_len = uint32_t
+//     lowered_bytes = lowered_len bytes (UTF-8)
+//
+// 'CHC1' marks format v1. A future schema change should bump to 'CHC2' etc.
+// loadHiprtcCache rejects any file lacking the magic — old (pre-fix) caches
+// are auto-evicted on first use.
+static constexpr char kCacheMagic[4] = {'C', 'H', 'C', '1'};
+
+static void writeU32LE(std::ostream &out, uint32_t v) {
+  char b[4];
+  b[0] = (char)(v & 0xff);
+  b[1] = (char)((v >> 8) & 0xff);
+  b[2] = (char)((v >> 16) & 0xff);
+  b[3] = (char)((v >> 24) & 0xff);
+  out.write(b, 4);
+}
+
+static bool readU32LE(std::istream &in, uint32_t &v) {
+  unsigned char b[4];
+  if (!in.read((char *)b, 4)) return false;
+  v = (uint32_t)b[0]
+    | ((uint32_t)b[1] << 8)
+    | ((uint32_t)b[2] << 16)
+    | ((uint32_t)b[3] << 24);
+  return true;
+}
+
 /// Try to load a cached HIPRTC compilation result.
-/// Returns true and populates Program.Code_ if a cache hit is found.
+/// Returns true and populates Program.Code_ and the name-expression map if a
+/// cache hit is found. Returns false on miss, missing magic (old format), or
+/// any read/parse error (treated as cache miss).
 static bool loadHiprtcCache(chipstar::Program &Program,
                              const std::string &cacheKey) {
   if (!ChipEnvVars.getModuleCacheDir().has_value())
     return false;
   auto cacheFile = fs::path(ChipEnvVars.getModuleCacheDir().value())
                    / "hiprtc" / cacheKey;
-  std::ifstream in(cacheFile, std::ios::binary | std::ios::ate);
+  std::ifstream in(cacheFile, std::ios::binary);
   if (!in)
     return false;
-  auto size = in.tellg();
-  if (size <= 0)
+
+  char magic[4];
+  if (!in.read(magic, 4) ||
+      std::memcmp(magic, kCacheMagic, 4) != 0) {
+    logDebug("hiprtc: cache file '{}' has missing/old magic; ignoring",
+             cacheFile.string());
     return false;
-  in.seekg(0);
-  std::string content(size, '\0');
-  in.read(content.data(), size);
-  if (!in)
+  }
+
+  uint32_t spirvSize = 0;
+  if (!readU32LE(in, spirvSize))
     return false;
-  Program.addCode(content);
-  logInfo("hiprtc: Loaded SPIRV from cache (key={})", cacheKey);
+  std::string spirv(spirvSize, '\0');
+  if (spirvSize && !in.read(spirv.data(), spirvSize))
+    return false;
+
+  uint32_t nameCount = 0;
+  if (!readU32LE(in, nameCount))
+    return false;
+  // Stage parsed names locally; only commit to Program after a fully
+  // successful read so a partial/corrupt cache file doesn't leave half-set
+  // state on the program object.
+  std::vector<std::pair<std::string, std::string>> names;
+  names.reserve(nameCount);
+  for (uint32_t i = 0; i < nameCount; i++) {
+    uint32_t exprLen = 0;
+    if (!readU32LE(in, exprLen)) return false;
+    std::string expr(exprLen, '\0');
+    if (exprLen && !in.read(expr.data(), exprLen)) return false;
+    uint32_t loweredLen = 0;
+    if (!readU32LE(in, loweredLen)) return false;
+    std::string lowered(loweredLen, '\0');
+    if (loweredLen && !in.read(lowered.data(), loweredLen)) return false;
+    names.emplace_back(std::move(expr), std::move(lowered));
+  }
+
+  Program.addCode(spirv);
+  // Populate the name-expression map. The user-registered expressions are
+  // already present (with empty values) from prior hiprtcAddNameExpression()
+  // calls; we fill in the lowered names from the cache.
+  auto &NameExprMap = Program.getNameExpressionMap();
+  for (auto &[expr, lowered] : names) {
+    auto It = NameExprMap.find(expr);
+    if (It != NameExprMap.end())
+      It->second = lowered;
+  }
+  logInfo("hiprtc: Loaded SPIRV from cache (key={}, names={})",
+          cacheKey, nameCount);
   return true;
 }
 
 /// Save HIPRTC compilation result to cache.
+/// Writes both the SPIR-V binary and the name-expression -> lowered-name
+/// table so subsequent cache hits can satisfy hiprtcGetLoweredName().
 static void saveHiprtcCache(const chipstar::Program &Program,
                              const std::string &cacheKey) {
   if (!ChipEnvVars.getModuleCacheDir().has_value())
@@ -439,14 +530,51 @@ static void saveHiprtcCache(const chipstar::Program &Program,
     return;
   }
   auto cacheFile = cacheDir / cacheKey;
-  std::ofstream out(cacheFile, std::ios::binary);
-  if (!out) {
-    logDebug("hiprtc: Could not open cache file for writing: {}", cacheFile.string());
+  // Write to a temp file then rename, so a crash mid-write does not leave a
+  // partial cache file that would later be loaded as if valid.
+  auto tmpFile = cacheFile;
+  tmpFile += ".tmp";
+  {
+    std::ofstream out(tmpFile, std::ios::binary | std::ios::trunc);
+    if (!out) {
+      logDebug("hiprtc: Could not open cache temp file for writing: {}",
+               tmpFile.string());
+      return;
+    }
+    out.write(kCacheMagic, 4);
+    const auto &code = Program.getCode();
+    if (code.size() > UINT32_MAX) {
+      logDebug("hiprtc: SPIR-V too large for cache file format ({} bytes)",
+               code.size());
+      out.close();
+      fs::remove(tmpFile, ec);
+      return;
+    }
+    writeU32LE(out, (uint32_t)code.size());
+    out.write(code.data(), code.size());
+    const auto &NameExprMap = Program.getNameExpressionMap();
+    writeU32LE(out, (uint32_t)NameExprMap.size());
+    for (auto &[expr, lowered] : NameExprMap) {
+      writeU32LE(out, (uint32_t)expr.size());
+      out.write(expr.data(), expr.size());
+      writeU32LE(out, (uint32_t)lowered.size());
+      out.write(lowered.data(), lowered.size());
+    }
+    if (!out) {
+      logDebug("hiprtc: Error while writing cache temp file: {}",
+               tmpFile.string());
+      fs::remove(tmpFile, ec);
+      return;
+    }
+  }
+  fs::rename(tmpFile, cacheFile, ec);
+  if (ec) {
+    logDebug("hiprtc: Could not rename cache temp file: {}", ec.message());
+    fs::remove(tmpFile, ec);
     return;
   }
-  const auto &code = Program.getCode();
-  out.write(code.data(), code.size());
-  logInfo("hiprtc: Saved SPIRV to cache (key={})", cacheKey);
+  logInfo("hiprtc: Saved SPIRV to cache (key={}, names={})",
+          cacheKey, Program.getNameExpressionMap().size());
 }
 
 hiprtcResult hiprtcCompileProgram(hiprtcProgram Prog, int NumOptions,
@@ -584,6 +712,17 @@ hiprtcResult hiprtcGetLoweredName(hiprtcProgram WrappedProg,
   const auto &NameExprMap = Prog.getNameExpressionMap();
   auto It = NameExprMap.find(NameExpression);
   if (It != NameExprMap.end()) {
+    if (It->second.empty()) {
+      // Defensive: a populated map entry should never have an empty lowered
+      // name. If it does, the compilation pipeline (or cache load) failed
+      // to record the mapping. Returning success with an empty string makes
+      // the caller pass "" to hipModuleGetFunction, which fails downstream
+      // with the misleading error "Failed to find kernel via kernel name: ".
+      logError("hiprtc: lowered name for '{}' is empty; refusing to return "
+               "empty string as success",
+               NameExpression);
+      return HIPRTC_ERROR_INTERNAL_ERROR;
+    }
     *LoweredName = It->second.data();
     return HIPRTC_SUCCESS;
   }

--- a/src/spirv_hiprtc.cc
+++ b/src/spirv_hiprtc.cc
@@ -35,6 +35,7 @@ THE SOFTWARE.
 #include <set>
 #include <vector>
 #include <chrono>
+#include <unistd.h>
 
 struct CompileOptions {
   std::vector<std::string> Options; /// All accepted user options.
@@ -387,10 +388,8 @@ hiprtcResult hiprtcAddNameExpression(hiprtcProgram Prog,
 /// std::hash<std::string> is implementation-defined and may produce different
 /// values across program runs (some libc++ randomize it) or across different
 /// compiler/stdlib versions, making the cache effectively write-only on those
-/// platforms. The same change was previously proposed in #1231 (closed
-/// unmerged); we re-introduce it here because a stable on-disk cache key is
-/// part of the new versioned cache file format ('CHC1' magic) — without a
-/// stable hash, the version header doesn't help.
+/// platforms. A stable on-disk hash is required for the versioned cache file
+/// format ('CHC1' magic) to be useful.
 static uint64_t fnv1a64(const std::string &s) {
   uint64_t hash = UINT64_C(14695981039346656037);
   for (unsigned char c : s) {
@@ -460,11 +459,10 @@ static void writeU32LE(std::ostream &out, uint32_t v) {
 
 static bool readU32LE(std::istream &in, uint32_t &v) {
   unsigned char b[4];
-  if (!in.read((char *)b, 4)) return false;
-  v = (uint32_t)b[0]
-    | ((uint32_t)b[1] << 8)
-    | ((uint32_t)b[2] << 16)
-    | ((uint32_t)b[3] << 24);
+  if (!in.read((char *)b, 4))
+    return false;
+  v = (uint32_t)b[0] | ((uint32_t)b[1] << 8) | ((uint32_t)b[2] << 16) |
+      ((uint32_t)b[3] << 24);
   return true;
 }
 
@@ -473,18 +471,18 @@ static bool readU32LE(std::istream &in, uint32_t &v) {
 /// cache hit is found. Returns false on miss, missing magic (old format), or
 /// any read/parse error (treated as cache miss).
 static bool loadHiprtcCache(chipstar::Program &Program,
-                             const std::string &cacheKey) {
+                            const std::string &cacheKey) {
   if (!ChipEnvVars.getModuleCacheDir().has_value())
     return false;
-  auto cacheFile = fs::path(ChipEnvVars.getModuleCacheDir().value())
-                   / "hiprtc" / cacheKey;
+  auto cacheFile =
+      fs::path(ChipEnvVars.getModuleCacheDir().value()) / "hiprtc" / cacheKey;
   std::ifstream in(cacheFile, std::ios::binary);
   if (!in)
     return false;
 
-  char magic[4];
-  if (!in.read(magic, 4) ||
-      std::memcmp(magic, kCacheMagic, 4) != 0) {
+  char magic[sizeof(kCacheMagic)];
+  if (!in.read(magic, sizeof(magic)) ||
+      std::memcmp(magic, kCacheMagic, sizeof(kCacheMagic)) != 0) {
     logDebug("hiprtc: cache file '{}' has missing/old magic; ignoring",
              cacheFile.string());
     return false;
@@ -507,13 +505,17 @@ static bool loadHiprtcCache(chipstar::Program &Program,
   names.reserve(nameCount);
   for (uint32_t i = 0; i < nameCount; i++) {
     uint32_t exprLen = 0;
-    if (!readU32LE(in, exprLen)) return false;
+    if (!readU32LE(in, exprLen))
+      return false;
     std::string expr(exprLen, '\0');
-    if (exprLen && !in.read(expr.data(), exprLen)) return false;
+    if (exprLen && !in.read(expr.data(), exprLen))
+      return false;
     uint32_t loweredLen = 0;
-    if (!readU32LE(in, loweredLen)) return false;
+    if (!readU32LE(in, loweredLen))
+      return false;
     std::string lowered(loweredLen, '\0');
-    if (loweredLen && !in.read(lowered.data(), loweredLen)) return false;
+    if (loweredLen && !in.read(lowered.data(), loweredLen))
+      return false;
     names.emplace_back(std::move(expr), std::move(lowered));
   }
 
@@ -527,8 +529,8 @@ static bool loadHiprtcCache(chipstar::Program &Program,
     if (It != NameExprMap.end())
       It->second = lowered;
   }
-  logInfo("hiprtc: Loaded SPIRV from cache (key={}, names={})",
-          cacheKey, nameCount);
+  logInfo("hiprtc: Loaded SPIRV from cache (key={}, names={})", cacheKey,
+          nameCount);
   return true;
 }
 
@@ -536,7 +538,7 @@ static bool loadHiprtcCache(chipstar::Program &Program,
 /// Writes both the SPIR-V binary and the name-expression -> lowered-name
 /// table so subsequent cache hits can satisfy hiprtcGetLoweredName().
 static void saveHiprtcCache(const chipstar::Program &Program,
-                             const std::string &cacheKey) {
+                            const std::string &cacheKey) {
   if (!ChipEnvVars.getModuleCacheDir().has_value())
     return;
   auto cacheDir = fs::path(ChipEnvVars.getModuleCacheDir().value()) / "hiprtc";
@@ -547,10 +549,12 @@ static void saveHiprtcCache(const chipstar::Program &Program,
     return;
   }
   auto cacheFile = cacheDir / cacheKey;
-  // Write to a temp file then rename, so a crash mid-write does not leave a
-  // partial cache file that would later be loaded as if valid.
+  // Write to a per-process temp file then atomically rename. The PID suffix
+  // prevents two concurrent writers from interleaving into the same temp
+  // file; the rename step then races safely (both produce the same content
+  // since the cache key is content-derived).
   auto tmpFile = cacheFile;
-  tmpFile += ".tmp";
+  tmpFile += "." + std::to_string(getpid()) + ".tmp";
   {
     std::ofstream out(tmpFile, std::ios::binary | std::ios::trunc);
     if (!out) {
@@ -558,12 +562,11 @@ static void saveHiprtcCache(const chipstar::Program &Program,
                tmpFile.string());
       return;
     }
-    out.write(kCacheMagic, 4);
+    out.write(kCacheMagic, sizeof(kCacheMagic));
     const auto &code = Program.getCode();
     if (code.size() > UINT32_MAX) {
       logDebug("hiprtc: SPIR-V too large for cache file format ({} bytes)",
                code.size());
-      out.close();
       fs::remove(tmpFile, ec);
       return;
     }
@@ -590,8 +593,8 @@ static void saveHiprtcCache(const chipstar::Program &Program,
     fs::remove(tmpFile, ec);
     return;
   }
-  logInfo("hiprtc: Saved SPIRV to cache (key={}, names={})",
-          cacheKey, Program.getNameExpressionMap().size());
+  logInfo("hiprtc: Saved SPIRV to cache (key={}, names={})", cacheKey,
+          Program.getNameExpressionMap().size());
 }
 
 hiprtcResult hiprtcCompileProgram(hiprtcProgram Prog, int NumOptions,

--- a/tests/hiprtc/CMakeLists.txt
+++ b/tests/hiprtc/CMakeLists.txt
@@ -28,3 +28,11 @@ add_hip_test(TestHiprtcOptions.cc)
 add_hip_test(TestShellMetacharacters.cc)
 add_hip_test(TestConstantMemory.cc)
 add_hip_test(TestProjectionBasisKernel.cc)
+add_hip_test(TestHiprtcCacheNameExpressions.cc)
+# This test exercises the HIPRTC SPIR-V cache, so it needs CHIP_MODULE_CACHE_DIR
+# set in the environment at libCHIP static-init time. Use a private directory
+# under the build tree so the test does not collide with the default cache
+# location. The test itself clears any stale `hiprtc/` subdir at startup so
+# repeat ctest invocations always start from a known-empty cache.
+set_tests_properties(TestHiprtcCacheNameExpressions PROPERTIES
+  ENVIRONMENT "CHIP_MODULE_CACHE_DIR=${CMAKE_CURRENT_BINARY_DIR}/test_cache_TestHiprtcCacheNameExpressions")

--- a/tests/hiprtc/TestHiprtcCacheNameExpressions.cc
+++ b/tests/hiprtc/TestHiprtcCacheNameExpressions.cc
@@ -50,8 +50,8 @@ __global__ void demo_kernel(int *data, int n) {
 // Compile once and return the (mangled) lowered name for "demo_kernel".
 static std::string compileAndGetLoweredName() {
   hiprtcProgram Prog;
-  HIPRTC_CHECK(hiprtcCreateProgram(&Prog, Source, "demo.hip", 0, nullptr,
-                                   nullptr));
+  HIPRTC_CHECK(
+      hiprtcCreateProgram(&Prog, Source, "demo.hip", 0, nullptr, nullptr));
   HIPRTC_CHECK(hiprtcAddNameExpression(Prog, "demo_kernel"));
 
   hiprtcResult R = hiprtcCompileProgram(Prog, 0, nullptr);

--- a/tests/hiprtc/TestHiprtcCacheNameExpressions.cc
+++ b/tests/hiprtc/TestHiprtcCacheNameExpressions.cc
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 chipStar developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+// Regression test for the HIPRTC cache + name-expression interaction.
+//
+// Before the fix that landed alongside this test, hiprtcCompileProgram() on a
+// cache hit returned HIPRTC_SUCCESS without populating the name-expression ->
+// lowered-name map. hiprtcGetLoweredName() then returned a pointer to an
+// empty string, and the caller's downstream hipModuleGetFunction("") failed
+// with "Failed to find kernel via kernel name: ".
+//
+// CHIP_MODULE_CACHE_DIR must be set and non-empty in the environment when
+// this test runs (it is read by libCHIP at static-init time, before main()).
+// Test running infrastructure (CMakeLists.txt) sets the env var; if you run
+// the binary by hand, export CHIP_MODULE_CACHE_DIR=<some dir> first.
+
+#include "TestCommon.hh"
+
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <string>
+
+static constexpr auto Source = R"---(
+__global__ void demo_kernel(int *data, int n) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n) data[i] = data[i] + 1;
+}
+)---";
+
+// Compile once and return the (mangled) lowered name for "demo_kernel".
+static std::string compileAndGetLoweredName() {
+  hiprtcProgram Prog;
+  HIPRTC_CHECK(hiprtcCreateProgram(&Prog, Source, "demo.hip", 0, nullptr,
+                                   nullptr));
+  HIPRTC_CHECK(hiprtcAddNameExpression(Prog, "demo_kernel"));
+
+  hiprtcResult R = hiprtcCompileProgram(Prog, 0, nullptr);
+  if (R != HIPRTC_SUCCESS) {
+    size_t LogSize;
+    HIPRTC_CHECK(hiprtcGetProgramLogSize(Prog, &LogSize));
+    if (LogSize) {
+      std::string Log(LogSize, '\0');
+      hiprtcGetProgramLog(Prog, Log.data());
+      std::cerr << Log << "\n";
+    }
+    HIPRTC_CHECK(R);
+  }
+
+  // The bug surfaces here on cache hit: pre-fix, *Mangled is the empty string.
+  const char *Mangled = nullptr;
+  HIPRTC_CHECK(hiprtcGetLoweredName(Prog, "demo_kernel", &Mangled));
+  TEST_ASSERT(Mangled != nullptr);
+  std::string Result(Mangled);
+  HIPRTC_CHECK(hiprtcDestroyProgram(&Prog));
+  return Result;
+}
+
+int main() {
+  // The cache-hit path can only be exercised when CHIP_MODULE_CACHE_DIR is
+  // set. libCHIP reads this env var at static-init time, so we validate it
+  // here rather than try to set it ourselves (too late from main).
+  const char *CacheDir = std::getenv("CHIP_MODULE_CACHE_DIR");
+  if (!CacheDir || !*CacheDir) {
+    std::cerr << "CHIP_MODULE_CACHE_DIR is not set in the environment; this "
+                 "test is meaningless without it. The CMake build sets it "
+                 "for ctest invocations.\n";
+    return 1;
+  }
+
+  // Wipe any stale 'hiprtc/' subdir from a prior ctest run so Run 1 below is
+  // guaranteed to be a cache miss and Run 2 a cache hit.
+  std::error_code Ec;
+  std::filesystem::remove_all(std::string(CacheDir) + "/hiprtc", Ec);
+
+  // First compile: cache miss (cache dir was just cleared).
+  std::string Mangled1 = compileAndGetLoweredName();
+  TEST_ASSERT(!Mangled1.empty());
+  std::cerr << "Run 1 lowered name: '" << Mangled1 << "'\n";
+
+  // Second compile: cache hit guaranteed (Run 1 just populated it).
+  std::string Mangled2 = compileAndGetLoweredName();
+  std::cerr << "Run 2 lowered name: '" << Mangled2 << "'\n";
+
+  // The regression assertion: pre-fix, this would be "".
+  TEST_ASSERT(!Mangled2.empty());
+  TEST_ASSERT(Mangled1 == Mangled2);
+
+  return 0;
+}


### PR DESCRIPTION
## What this PR does

Fixes a HIPRTC cache bug where `hiprtcGetLoweredName()` returns an empty string after a cache hit, causing the caller to pass `""` to `hipModuleGetFunction()` and downstream failures of the form `Failed to find kernel via kernel name: `. See accompanying issue **#1246** for the symptom-side report and reproducer details.

The PR also folds in three closely-related correctness improvements that come naturally with the fix and are best landed together because they share the cache file format / cache-key code path. See per-commit messages for details.

## Bug summary (one paragraph)

`chipstar::Program::NameExpressions_` is populated in two phases. `hiprtcAddNameExpression()` inserts `(name, "")` (empty value); `compile()` later runs the `HipEmitLoweredNames` LLVM pass and `getLoweredNameExpressions()` fills in the `.second` mangled-symbol values. On a cache hit, `hiprtcCompileProgram()` returns `HIPRTC_SUCCESS` immediately after `loadHiprtcCache()` succeeds — `compile()` never runs, the map stays empty-valued, and `hiprtcGetLoweredName()` returns a pointer to the empty `.second`. This is why a cache-warmed second run of any program using `AddNameExpression` + `GetLoweredName` (e.g. any non-`extern "C"` C++ kernel that needs its mangled name) silently breaks.

## Commits

1. **`fix: persist name-expression -> lowered-name map in HIPRTC cache`** — the primary fix.
   - Cache file format extended to a small framed binary layout with magic `CHC1`, length-prefixed SPIR-V, then a `(name_expression, lowered_name)` count + entries table.
   - `loadHiprtcCache()` rejects any file lacking the magic — pre-fix cache entries are auto-evicted on first use, so users don't need to manually clear `~/.cache/chipStar/`.
   - `saveHiprtcCache()` now writes to `<key>.tmp` and `fs::rename()`s on success — a process killed mid-write no longer leaves a partially-written cache file behind that subsequent runs treat as valid.
   - `computeHiprtcCacheKey()` now also hashes the registered name-expression keys, closing a separate aliasing gap (two programs with identical source/options but different `AddNameExpression` sets would have aliased to the same cache entry).
   - `hiprtcGetLoweredName()` returns `HIPRTC_ERROR_INTERNAL_ERROR` (with a clear log line) if a found map entry has an empty lowered name, instead of silently returning `HIPRTC_SUCCESS` with a pointer to `""`. Defensive — catches any future regression of this class at the API boundary.

2. **`fix: replace std::hash with FNV-1a for HIPRTC cache key`** — re-introduces the FNV-1a 64-bit helper from PR #1231 (closed unmerged). A stable, portable on-disk hash is a prerequisite of the new versioned cache file format — without it the version header doesn't help on platforms where `std::hash<std::string>` is randomized per process. The `fnv1a64()` helper is byte-identical to the one in #1231 to honor the prior author's intent.

3. **`test: regression for HIPRTC cache + name-expression interaction`** — adds `tests/hiprtc/TestHiprtcCacheNameExpressions.cc`. Compiles the same RTC source twice in one process, asserts that the second compilation's `hiprtcGetLoweredName` returns the same non-empty mangled name as the first. Pre-fix this assertion fails; post-fix it passes.

## Relationship to prior PRs and issues

- **#1142** (issue, "HIPRTC cache appears write-only") — referenced by this PR but **not directly fixed** by it. That issue describes the symptom of cache files being written but never loaded, which is a separate failure mode (most likely caused by `std::hash<std::string>` being non-deterministic across runs on some libstdc++/libc++ implementations). This PR includes the FNV-1a change from #1231 which would address #1142 on those platforms, but the primary bug fixed here (empty mangled-name on cache hit) is a different issue that surfaces on platforms where `std::hash<std::string>` *is* deterministic (e.g. Aurora's libstdc++).
- **#1231** (PR, "fix: use FNV-1a instead of std::hash for HIPRTC cache key", closed unmerged on Apr 14, 2026) — this PR re-introduces that change as commit 2/3 (`fnv1a64()` helper) because it is logically prerequisite to the new versioned cache format. If there is a reason the original FNV-1a PR was rejected that I missed, happy to drop that commit and address separately — but I think the cache-versioning context makes the case for landing it together.

## Validation

- Built the patched library against the same toolchain used for ChipStar's `chipStar/llvm22/20260402-22/release` deployment (chipStar LLVM 22 fork, commit equivalent to deployed commit `b508f598`, rebased onto current `main`).
- Standalone reproducer (run twice as separate processes with a shared `CHIP_MODULE_CACHE_DIR`) — pre-fix Run 2 fails with empty mangled name; post-fix all runs succeed. Cache file size grows by exactly the planned trailer overhead (49 bytes for one `(expr, lowered)` entry where `expr="demo_kernel"` and `lowered="_Z11demo_kernelPii"`).
- New regression test (`TestHiprtcCacheNameExpressions.cc`) added in this PR — passes on the patched build, would fail on `b508f598`.
- The `cache files written` log line `hiprtc: Saved/Loaded SPIRV from cache (key=…, names=N)` now reports the persisted entry count for visibility.

## Affected file summary

```
src/spirv_hiprtc.cc                                | +181 -25
tests/hiprtc/CMakeLists.txt                        |   +1
tests/hiprtc/TestHiprtcCacheNameExpressions.cc     | +112 (new)
```

No public API changes; cache file format is private.

---

## Appendix: cache-key aliasing in detail

The PR's commit 1 also makes `computeHiprtcCacheKey()` hash the registered name expressions. The reasoning, in case a reviewer wants the chain of inference:

1. **`hiprtcAddNameExpression()` is observable on output.** When the user calls `hiprtcAddNameExpression(prog, "foo")`, ChipStar synthesizes a magic variable like `_chip_name_expr_<n>` and injects it into the augmented source it hands to clang. The `HipEmitLoweredNames` LLVM pass then uses those magic variables to extract the C++-mangled symbol that `"foo"` lowered to. Concretely: a program that registered just `"foo"` produces a different augmented source — and thus different SPIR-V symbol-table contents — than the same-original-source program that also registered `"bar"`.

2. **The cache key is computed from the original (pre-augmentation) source**, plus the API-supplied virtual headers (`hiprtcCreateProgram`'s `Headers`/`IncludeNames` parameters), plus options. (Note: "headers" here is *only* the in-memory virtual headers the caller passes at program-create time — `computeHiprtcCacheKey` is blind to filesystem-resolved `#include` files reached through `-I` paths or system header dirs. That is a separate soundness gap, out of scope for this PR.) So two programs A and B with identical original source / virtual-headers / options but different `AddNameExpression` sets compute the **same** cache key.

3. **Same key → same cache file → "aliasing".** If A runs first and writes the cache, then B starts and computes the same key, B sees a cache hit and loads A's SPIR-V — even though A's compilation didn't include B's name expressions in the augmented source.

### What goes wrong without this fix

Pre-fix (cache stores only SPIR-V):
- A registers `foo`, compiles, saves SPIR-V containing `foo`'s mangled symbol.
- B registers `foo` AND `bar`, hits cache, loads A's SPIR-V — which has no info about `bar`.
- B's `NameExpressions_` map already had `foo→""` and `bar→""` from the pre-compile registration; the cache-hit path skips `getLoweredNameExpressions()`, so both stay empty. Both lookups fail (the primary bug fixed by this PR's commit 1). The aliasing here is masked by the larger bug.

Post-fix without also putting names in the cache key:
- A registers `foo`, compiles, saves `(SPIR-V, [foo→_Z3fooPi])`.
- B registers `foo, bar`, hits cache, loads `(SPIR-V, [foo→_Z3fooPi])`. The new `loadHiprtcCache` fills in `foo` in B's map. **`bar` stays unmapped.**
- B's `hiprtcGetLoweredName(prog, "bar", ...)` returns the new `HIPRTC_ERROR_INTERNAL_ERROR` from the defensive check (instead of silently returning a pointer to `""`) — so the failure is loud and clearly diagnosable, but it is *still* a failure, and B's compile succeeded so the user has no obvious reason to expect it.
- The right behaviour: B should have gotten a cache *miss* (because its registered name set differs from A's), recompiled fresh, and produced a SPIR-V that maps both `foo` and `bar`.

### Significance

- **Real-world likelihood**: low. Most code (WARPM included, where this PR's diagnosis originated) registers a fixed, code-determined set of kernel names per RTC program. Two programs with identical source+options but *different* registered name sets would have to be intentionally constructed.
- **Severity if it happens, post-fix**: loud (`HIPRTC_ERROR_INTERNAL_ERROR` from `GetLoweredName`) — not silent. So even without putting names in the cache key, this PR's defensive check at the API boundary already converts the worst-case symptom from "silent kernel name mystery" to "explicit error."
- **Why fix it anyway**: cache keys should reflect every input that affects the meaningful output. Registered name expressions affect the lowered names extracted from the SPIR-V, so they belong in the key. It's a small change and prevents a class of "weird intermittent error" reports that would otherwise be hard to diagnose.

The cost is one additional small loop in `computeHiprtcCacheKey()` (iterating the already-sorted `std::map<std::string, std::string>` of name expressions and hashing the keys). Map values are empty at hash time (filled only after compilation), so only the keys contribute to the hash, making the key computation deterministic.
