### PR TITLE
fix: promote __half/__half2 operators to __host__ __device__ (issue #1248)

### DIFF
--- a/include/hip/spirv_hip_fp16.h
+++ b/include/hip/spirv_hip_fp16.h
@@ -184,42 +184,42 @@ THE SOFTWARE.
             #endif
 
             #if !defined(__HIP_NO_HALF_OPERATORS__)
-                __device__
+                __HOST_DEVICE__
                 __half& operator+=(const __half& x)
                 {
                     data += x.data;
                     return *this;
                 }
-                __device__
+                __HOST_DEVICE__
                 __half& operator-=(const __half& x)
                 {
                     data -= x.data;
                     return *this;
                 }
-                __device__
+                __HOST_DEVICE__
                 __half& operator*=(const __half& x)
                 {
                     data *= x.data;
                     return *this;
                 }
-                __device__
+                __HOST_DEVICE__
                 __half& operator/=(const __half& x)
                 {
                     data /= x.data;
                     return *this;
                 }
-                __device__
+                __HOST_DEVICE__
                 __half& operator++() { ++data; return *this; }
-                __device__
+                __HOST_DEVICE__
                 __half operator++(int)
                 {
                     __half tmp{*this};
                     ++*this;
                     return tmp;
                 }
-                __device__
+                __HOST_DEVICE__
                 __half& operator--() { --data; return *this; }
-                __device__
+                __HOST_DEVICE__
                 __half operator--(int)
                 {
                     __half tmp{*this};
@@ -252,9 +252,9 @@ THE SOFTWARE.
             #endif
 
             #if !defined(__HIP_NO_HALF_OPERATORS__)
-                __device__
+                __HOST_DEVICE__
                 __half operator+() const { return *this; }
-                __device__
+                __HOST_DEVICE__
                 __half operator-() const
                 {
                     __half tmp{*this};
@@ -267,70 +267,70 @@ THE SOFTWARE.
             #if !defined(__HIP_NO_HALF_OPERATORS__)
                 friend
                 inline
-                __device__
+                __HOST_DEVICE__
                 __half operator+(const __half& x, const __half& y)
                 {
                     return __half{x} += y;
                 }
                 friend
                 inline
-                __device__
+                __HOST_DEVICE__
                 __half operator-(const __half& x, const __half& y)
                 {
                     return __half{x} -= y;
                 }
                 friend
                 inline
-                __device__
+                __HOST_DEVICE__
                 __half operator*(const __half& x, const __half& y)
                 {
                     return __half{x} *= y;
                 }
                 friend
                 inline
-                __device__
+                __HOST_DEVICE__
                 __half operator/(const __half& x, const __half& y)
                 {
                     return __half{x} /= y;
                 }
                 friend
                 inline
-                __device__
+                __HOST_DEVICE__
                 bool operator==(const __half& x, const __half& y)
                 {
                     return x.data == y.data;
                 }
                 friend
                 inline
-                __device__
+                __HOST_DEVICE__
                 bool operator!=(const __half& x, const __half& y)
                 {
                     return !(x == y);
                 }
                 friend
                 inline
-                __device__
+                __HOST_DEVICE__
                 bool operator<(const __half& x, const __half& y)
                 {
                     return x.data < y.data;
                 }
                 friend
                 inline
-                __device__
+                __HOST_DEVICE__
                 bool operator>(const __half& x, const __half& y)
                 {
                     return y.data < x.data;
                 }
                 friend
                 inline
-                __device__
+                __HOST_DEVICE__
                 bool operator<=(const __half& x, const __half& y)
                 {
                     return !(y < x);
                 }
                 friend
                 inline
-                __device__
+                __HOST_DEVICE__
                 bool operator>=(const __half& x, const __half& y)
                 {
                     return !(x < y);
@@ -387,42 +387,42 @@ THE SOFTWARE.
 
             // MANIPULATORS - DEVICE ONLY
             #if !defined(__HIP_NO_HALF_OPERATORS__)
-                __device__
+                __HOST_DEVICE__
                 __half2& operator+=(const __half2& xx)
                 {
                     data += xx.data;
                     return *this;
                 }
-                __device__
+                __HOST_DEVICE__
                 __half2& operator-=(const __half2& xx)
                 {
                     data -= xx.data;
                     return *this;
                 }
-                __device__
+                __HOST_DEVICE__
                 __half2& operator*=(const __half2& xx)
                 {
                     data *= xx.data;
                     return *this;
                 }
-                __device__
+                __HOST_DEVICE__
                 __half2& operator/=(const __half2& xx)
                 {
                     data /= xx.data;
                     return *this;
                 }
-                __device__
+                __HOST_DEVICE__
                 __half2& operator++() { return *this += _Float16_2{1, 1}; }
-                __device__
+                __HOST_DEVICE__
                 __half2 operator++(int)
                 {
                     __half2 tmp{*this};
                     ++*this;
                     return tmp;
                 }
-                __device__
+                __HOST_DEVICE__
                 __half2& operator--() { return *this -= _Float16_2{1, 1}; }
-                __device__
+                __HOST_DEVICE__
                 __half2 operator--(int)
                 {
                     __half2 tmp{*this};
@@ -443,9 +443,9 @@ THE SOFTWARE.
 
             // ACCESSORS - DEVICE ONLY
             #if !defined(__HIP_NO_HALF_OPERATORS__)
-                __device__
+                __HOST_DEVICE__
                 __half2 operator+() const { return *this; }
-                __device__
+                __HOST_DEVICE__
                 __half2 operator-() const
                 {
                     __half2 tmp{*this};
@@ -458,35 +458,35 @@ THE SOFTWARE.
             #if !defined(__HIP_NO_HALF_OPERATORS__)
                 friend
                 inline
-                __device__
+                __HOST_DEVICE__
                 __half2 operator+(const __half2& xx, const __half2& yy)
                 {
                     return __half2{xx} += yy;
                 }
                 friend
                 inline
-                __device__
+                __HOST_DEVICE__
                 __half2 operator-(const __half2& xx, const __half2& yy)
                 {
                     return __half2{xx} -= yy;
                 }
                 friend
                 inline
-                __device__
+                __HOST_DEVICE__
                 __half2 operator*(const __half2& xx, const __half2& yy)
                 {
                     return __half2{xx} *= yy;
                 }
                 friend
                 inline
-                __device__
+                __HOST_DEVICE__
                 __half2 operator/(const __half2& xx, const __half2& yy)
                 {
                     return __half2{xx} /= yy;
                 }
                 friend
                 inline
-                __device__
+                __HOST_DEVICE__
                 bool operator==(const __half2& xx, const __half2& yy)
                 {
                     auto r = xx.data == yy.data;
@@ -494,14 +494,14 @@ THE SOFTWARE.
                 }
                 friend
                 inline
-                __device__
+                __HOST_DEVICE__
                 bool operator!=(const __half2& xx, const __half2& yy)
                 {
                     return !(xx == yy);
                 }
                 friend
                 inline
-                __device__
+                __HOST_DEVICE__
                 bool operator<(const __half2& xx, const __half2& yy)
                 {
                     auto r = xx.data < yy.data;
@@ -509,21 +509,21 @@ THE SOFTWARE.
                 }
                 friend
                 inline
-                __device__
+                __HOST_DEVICE__
                 bool operator>(const __half2& xx, const __half2& yy)
                 {
                     return yy < xx;
                 }
                 friend
                 inline
-                __device__
+                __HOST_DEVICE__
                 bool operator<=(const __half2& xx, const __half2& yy)
                 {
                     return !(yy < xx);
                 }
                 friend
                 inline
-                __device__
+                __HOST_DEVICE__
                 bool operator>=(const __half2& xx, const __half2& yy)
                 {
                     return !(xx < yy);

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -118,6 +118,8 @@ add_test(NAME "TestHipccHalfOperators"
   COMMAND ${CMAKE_BINARY_DIR}/bin/hipcc -D__HIP_NO_HALF_OPERATORS__=1
   ${CMAKE_CURRENT_SOURCE_DIR}/TestHipccHalfConversions.cc)
 
+add_hipcc_test(TestFix1248HalfHostOps.hip HIPCC_OPTIONS -fsyntax-only)
+
 add_hipcc_test(TestZeroLenArrayTypes.hip TEST_NAME TestZeroLenArrayTypes-O0
   HIPCC_OPTIONS -O0 -c)
 add_hipcc_test(TestZeroLenArrayTypes.hip TEST_NAME TestZeroLenArrayTypes-O1

--- a/tests/compiler/TestFix1248HalfHostOps.hip
+++ b/tests/compiler/TestFix1248HalfHostOps.hip
@@ -1,0 +1,35 @@
+// Reproduces issue #1248: __half arithmetic/comparison operators must be
+// __host__ __device__ (as in ROCm 6.4+), not __device__-only.
+#include <hip/hip_fp16.h>
+
+bool host_half_ops() {
+    __half a = __float2half(1.5f);
+    __half b = __float2half(2.5f);
+
+    __half c = a + b;
+    __half d = a - b;
+    __half e = a * b;
+    __half f = a / b;
+    bool lt = a < b;
+    bool gt = a > b;
+    bool eq = a == b;
+    bool ne = a != b;
+    bool le = a <= b;
+    bool ge = a >= b;
+    a += b;
+    a -= b;
+    a *= b;
+    a /= b;
+    ++a;
+    --a;
+    __half g = +a;
+    __half h = -a;
+
+    (void)c; (void)d; (void)e; (void)f;
+    (void)g; (void)h;
+    return lt && !gt && !eq && ne && le && !ge;
+}
+
+int main() {
+    return 0;
+}


### PR DESCRIPTION
## Summary

- chipStar reports HIP 7.2.0 (≥6.4), but `__half` and `__half2` arithmetic/comparison operators in `spirv_hip_fp16.h` were still `__device__`-only — a mismatch with ROCm 6.4+ where these were promoted to `__host__ __device__`
- Host-side frameworks that use `__half` arithmetic (e.g. Kokkos::HIP) hit a hard compile error: _"call to `__device__` function from `__host__` function"_
- Fix: change all 40 affected operators inside `#if !defined(__HIP_NO_HALF_OPERATORS__)` from `__device__` to `__HOST_DEVICE__` for both `__half` and `__half2`; the underlying `_Float16` arithmetic is valid on both host and device with Clang

## Test plan

- [ ] New compilation test `TestFix1248HalfHostOps.hip` (run with `-fsyntax-only`) exercises all affected operators in a plain host function — **fails before this fix, passes after**
- [ ] `check.py dgpu level0` passes (87%, 3 pre-existing failures unrelated to `__half`)

Closes #1248