### PR TITLE
fix: run_hipcc.cmake spirv platform branch + regression test

### DIFF
--- a/tests/post-install/FindHIPLegacySpirvTarget/CMakeLists.txt
+++ b/tests/post-install/FindHIPLegacySpirvTarget/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+project(FindHIPLegacySpirvTarget LANGUAGES CXX)
+find_package(HIP REQUIRED)
+# Force compilation through run_hipcc.cmake (same as SeisSol's Device submodule)
+set_source_files_properties(foo.hip PROPERTIES HIP_SOURCE_PROPERTY_FORMAT 1)
+# SHARED triggers --shared -Xcompiler '-fPIC' in HIP_NVCC_FLAGS, which clang
+# cannot understand when run_hipcc.cmake falls through to the nvcc branch
+hip_add_library(foo SHARED foo.hip)
+set_property(TARGET foo PROPERTY HIP_ARCHITECTURES OFF)

--- a/tests/post-install/FindHIPLegacySpirvTarget/foo.hip
+++ b/tests/post-install/FindHIPLegacySpirvTarget/foo.hip
@@ -1,0 +1,3 @@
+#include <hip/hip_runtime.h>
+__global__ void k() {}
+int main() { return 0; }

--- a/tests/post-install/cmake-tests.bash
+++ b/tests/post-install/cmake-tests.bash
@@ -41,6 +41,24 @@ make VERBOSE=1
 echo "Success"
 echo
 
+echo "### Check legacy FindHIP cmake integration on SPIR-V platform (run_hipcc.cmake spirv branch)"
+# Regression test: when HIP_PLATFORM=spirv, run_hipcc.cmake must use the clang
+# branch, not the nvcc branch. The nvcc branch inserts '--compiler-options -fPIC'
+# which clang does not understand, causing compilation to fail.
+setup-test-dir
+cmake @CMAKE_CURRENT_SOURCE_DIR@/FindHIPLegacySpirvTarget \
+      -DCMAKE_PREFIX_PATH=@CMAKE_INSTALL_PREFIX@ \
+      -DCMAKE_MODULE_PATH=@CMAKE_INSTALL_PREFIX@/lib/cmake/hip \
+      -DCMAKE_CXX_COMPILER=${CXX}
+# Build only the compilation step (linking requires hipcc_cmake_linker_helper, tested separately).
+# run_hipcc.cmake names the output file foo_generated_foo.hip.o
+ninja -v "CMakeFiles/foo.dir/foo_generated_foo.hip.o" 2>&1 | tee build.log
+if grep -qF "''-fPIC''" build.log; then
+    echo "FAIL: NVCC-style quoted -fPIC found — run_hipcc.cmake spirv branch missing"
+    exit 1
+fi
+if [ ! -f CMakeFiles/foo.dir/foo_generated_foo.hip.o ]; then
+    echo "FAIL: foo_generated_foo.hip.o was not produced — compilation failed"
 echo "### check CMake-CUDA"
 setup-test-dir
 


### PR DESCRIPTION
## Summary

- Bumps `HIP` submodule to include the fix for `run_hipcc.cmake` (CHIP-SPV/HIP#13)
- Adds a post-install regression test that exercises the `run_hipcc.cmake` clang branch on the SPIR-V platform with a shared library

## Background

When building [SeisSol](https://github.com/SeisSol/SeisSol) with chipStar, the Device submodule uses the legacy `FindHIP` cmake integration (`hip_add_library(SHARED)` + `HIP_SOURCE_PROPERTY_FORMAT`). This routes per-file compilation through `run_hipcc.cmake`, which was missing a `spirv` case and fell into the nvcc branch. For shared libraries that branch appends `--shared -Xcompiler '-fPIC'`; clang rejects the quoted `''-fPIC''` as an unknown file:

```
clang++: error: no such file or directory: ''-fPIC''
```

## Changes

- `HIP` submodule: bumped to CHIP-SPV/HIP#13 (one-line condition fix in `run_hipcc.cmake`)
- `tests/post-install/FindHIPLegacySpirvTarget/`: minimal cmake project using `hip_add_library(SHARED)` + `HIP_SOURCE_PROPERTY_FORMAT` to reproduce the failure
- `tests/post-install/cmake-tests.bash`: new test section that builds the object file and checks for the `''-fPIC''` bad-flag pattern

## Test plan

- [ ] `check-install` target passes with the new `FindHIPLegacySpirvTarget` test section
- [ ] Test fails without the HIP submodule fix (verified locally by temporarily reverting `run_hipcc.cmake`)
- [ ] Existing post-install cmake tests (`HipDeviceTarget`, `HipHostTarget`, `HipDeviceCSource`) unaffected