### PR TITLE
fix(bitcode/devicelib): use memory_order_relaxed for default atomic ops

### DIFF
--- a/bitcode/devicelib.cl
+++ b/bitcode/devicelib.cl
@@ -615,8 +615,16 @@ EXPORT long __chip_ctz_li(long var) { return ctz(var); }
                                    memory_scope_##SCOPE);                     \
   }
 
+// CUDA's atomicAdd / atomicSub / atomicMin / ... provide atomicity only,
+// not ordering — see CUDA C Programming Guide "Atomic Functions". ROCm/HIP
+// matches that on AMD. Default chipStar atomics here used memory_order_seq_cst,
+// which forces full device-scope acquire+release fences per atomic op on
+// Intel GPU (level0/opencl), serializing every contended atomic. Switch to
+// memory_order_relaxed to match CUDA/ROCm semantics (atomicity, no fences) —
+// drastically faster on hot, contended atomics. The _system and _block
+// variants keep seq_cst for now.
 #define DEF_CHIP_ATOMIC2(NAME, OP)                                            \
-  DEF_CHIP_ATOMIC2_ORDER_SCOPE (NAME, OP, seq_cst, device)                    \
+  DEF_CHIP_ATOMIC2_ORDER_SCOPE (NAME, OP, relaxed, device)                    \
   DEF_CHIP_ATOMIC2_ORDER_SCOPE (NAME##_system, OP, seq_cst, all_svm_devices)  \
   DEF_CHIP_ATOMIC2_ORDER_SCOPE (NAME##_block, OP, seq_cst, work_group)
 


### PR DESCRIPTION
## Summary

CUDA's `atomicAdd` / `atomicSub` / `atomicMin` / ... provide **atomicity only, not ordering** (see CUDA C Programming Guide, "Atomic Functions"). ROCm/HIP matches that on AMD. chipStar's `DEF_CHIP_ATOMIC2` macro in `bitcode/devicelib.cl` was using `memory_order_seq_cst`, which on Intel GPU (level0/opencl) forces full device-scope acquire+release fences for every atomic op — serializing every contended atomic.

This PR switches the default (device-scope) variant to `memory_order_relaxed`. `_system` and `_block` keep `seq_cst` because they are the explicit "give me strong ordering" overloads.

## Impact — HeCBench `all-pairs-distance` on Intel Arc A770 (opencl backend, 5000 iters)

| | µs | vs SYCL |
|---|---:|---:|
| BASELINE (chipStar `seq_cst`) | 6127 | 23.1x slower |
| **THIS PR (chipStar `relaxed`)** | **354** | **1.34x slower** |
| SYCL `atomic_ref<int, memory_order::relaxed>::fetch_add` | 264 | — |
| (HIP `GPUshared` reference, no contended atomic) | 280 | tied |

**17.3x speedup** on a kernel that does an `atomicAdd` in an inner loop. The shared-memory variant is unaffected (still 280µs). Closes ~96% of the gap to the SYCL reference.

## Test results

Full chipStar test suite passes on cupcake (Intel Arc A770) with this change:

```
dgpu opencl:  100% tests passed, 0 tests failed out of 1165
dgpu level0:  100% tests passed, 0 tests failed out of 1164
```

## Why this is correct

- CUDA `atomicAdd` (and friends): documented as providing atomicity only.
- HIP on AMD: identical CUDA-compatible semantics.
- This change brings chipStar into alignment with CUDA/HIP semantics, not stronger.

If a user explicitly needs ordering, they have:
- `atomicAdd_system` (kept `seq_cst`, scope `all_svm_devices`)
- `atomicAdd_block` (kept `seq_cst`, scope `work_group`)
- explicit `__threadfence*` between operations.

## Discovery

Found while investigating a 23x perf gap on `all-pairs-distance-hip` between chipStar HIP and SYCL on Arc A770 — the only HeCBench benchmark in the suite where chipStar regressed by >5x against SYCL. The shared-memory variant of the same kernel was tied with SYCL, narrowing the suspect to the per-iteration `atomicAdd`. SYCL emits the equivalent loop with `atomic_ref<int, memory_order::relaxed, memory_scope::device>::fetch_add`, which is what this PR makes chipStar emit too.