### PR TITLE
shim-queue: workspace for H4I-MKLShim wait()-removal change

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,85 @@
+# shim-queue: drop redundant host fences in H4I-MKLShim FFT exec path
+
+## Problem
+
+`H4I-MKLShim/src/onemklfft.cpp`'s `fftExecR2C`, `fftExecC2R`, `fftExecC2Cforward`,
+`fftExecC2Cbackward` each contained ~6 `ctxt->queue.wait()` calls per single
+FFT operation:
+
+1. wait on entry (drain anything pending)
+2. wait after `get_value(PLACEMENT)`
+3. wait after `set_value(PLACEMENT)` (cold path, placement change only)
+4. wait after `commit(queue)` (cold path)
+5. wait after `compute_forward / compute_backward`
+6. wait on exit
+
+These were added as defensive sync points back when MKLShim created its own
+SYCL queue independent of chipStar's HIP stream. With the queue truly
+independent, ordering between MKL submissions and surrounding chipStar HIP
+kernels could only be enforced via host fences — hence the `wait()`s.
+
+## Why the waits are redundant today
+
+`H4I-MKLShim/src/Context.cpp:Update()` already wraps the **native L0 handles
+that chipStar provides via `hipGetBackendNativeHandles`**:
+
+- For Level Zero (6 handles): wraps chipStar's `ZeCmdListImm_` (immediate
+  command list) as a SYCL queue with `KeepOwnership=true` and the
+  `in_order` property.
+- For OpenCL (5 handles): wraps chipStar's `cl_command_queue`.
+
+Since chipStar 2026.04.x:
+- chipStar L0 backend submits all HIP kernels to `ZeCmdListImm_` (its
+  immediate command list).
+- MKLShim's SYCL queue submits oneMKL DFT work onto **the same** immediate
+  command list (or onto the same `cl_command_queue` for OpenCL).
+
+So MKL submissions and chipStar kernels land on the same in-order L0/CL
+queue and are ordered at the driver level. **Host `wait()` fences between
+them are pure overhead** — they serialize what was already correctly ordered.
+
+## Fix
+
+`shim-queue` commit `8b713cc shim-queue: remove redundant queue.wait() in
+FFT exec hot path`:
+
+- Remove entry, post-`get_value`, post-`compute_*`, and exit `wait()`s in
+  the four exec functions.
+- Keep the `wait()` after `commit(queue)` in the cold placement-change path,
+  since plan rebuild may JIT and the next `compute_*` call must see the
+  freshly-committed plan.
+- Eliminate `std::cout` debug noise in the placement-change branches at the
+  same time (purely cosmetic).
+
+Plan-construction `wait()`s (descriptor constructors) are kept; plan
+construction is one-shot per FFT plan, not on the hot path.
+
+## Why this still works for both backends
+
+The same Context-creation code already handles both paths via
+`#if HAS_UR_API` (MKL 2025) and `#elif __INTEL_LLVM_COMPILER >= 20240000`
+(MKL 2024) — both branches call `make_queue(KeepOwnership=true,
+in_order)`. Tested on Intel Arc A770 with chipStar 2026.04.29 and oneAPI
+2025.3.2 in both `CHIP_BE=level0` and `CHIP_BE=opencl`.
+
+## What was *not* changed
+
+- BLAS (`onemklblas.cpp`) and Solver (`onemklsolver.cpp`) wait patterns:
+  these are lighter and out of scope for this change. Same audit could be
+  applied later.
+- `fftDescriptorSR/SC/DR/DC` constructors: still call `commit + wait()`.
+  Plan creation is rare, not perf-critical.
+- The `__FORCE_MKL_FLUSH__` macro state: orthogonal to this change.
+- `Context.h::chipstar_cmd_list` field: was added in earlier WIP for a
+  different cross-queue idea but is no longer needed and stays unused.
+
+## Repository layout for this work
+
+- `H4I-MKLShim` branch `shim-queue` at `/home/pvelesko/H4I-MKLShim`
+  (commit `8b713cc`).
+- This chipStar worktree `~/chipStar/shim-queue` (branch `shim-queue`,
+  no chipStar source changes — just docs and the benchmark).
+- Snapshot libs at `benchmark/libMKLShim.{before,after}.so` for A/B
+  reproduction without rebuilding.
+
+See `RESULTS.md` for measured numbers.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1,0 +1,103 @@
+# shim-queue: measured uplift
+
+## System
+
+- Intel Arc A770 (`Intel(R) Arc(TM) A770 Graphics`)
+- chipStar 2026.04.29 (`/home/pvelesko/install/HIP/chipStar/2026.04.29`)
+- oneAPI 2025.3.2 (`/space/pvelesko/install/oneapi/2025.3.2`)
+- LLVM 22.0-native (22.1.2)
+
+## Microbenchmark — `benchmark/fft_pingpong`
+
+R2C + 3 chipStar HIP kernels + C2R per iteration, `iters=500`, `warmup=30`.
+Both libs share identical strided `fftPlanMany` and Context setup; only
+the FFT exec hot-path `wait()`s differ.
+
+### Level 0 backend (`CHIP_BE=level0`)
+
+| grid    | before (ms/iter) | after (ms/iter) | speedup |
+|---------|------------------|-----------------|---------|
+| 32^3    | 27.482           | 0.798           | 34.4×   |
+| 64^3    |  0.728           | 0.579           |  1.26×  |
+| 96^3    | 24.447           | 2.618           |  9.34×  |
+| 128^3   | 15.263           | 2.555           |  5.97×  |
+| 200^3   | 45.555           | 2.889           | 15.77×  |
+
+(Variability in the "before" column at 64^3 reflects oneMKL JIT cache hits;
+MKL behaves differently across grid sizes. The overall pattern — host
+fences are the bottleneck — is consistent.)
+
+### OpenCL backend (`CHIP_BE=opencl`)
+
+| grid    | before (ms/iter) | after (ms/iter) | speedup |
+|---------|------------------|-----------------|---------|
+| 32^3    |  1.880           | 0.246           |  7.64×  |
+| 64^3    |  0.527           | 0.437           |  1.21×  |
+| 96^3    |  0.670           | 0.409           |  1.64×  |
+| 128^3   |  1.033           | 0.530           |  1.95×  |
+| 200^3   |  3.197           | 3.852           |  0.83×  |
+
+OpenCL gets less benefit at 200^3 — the `cl_command_queue` is not an
+immediate command list and natively supports OOO without host fences,
+so MKL's per-call overhead dominates the redundant wait cost. Small/mid
+grids still show clear uplift.
+
+## End-to-end — GROMACS PME-on-GPU
+
+GROMACS 2027.0-dev, water_GMX50_bare 1536 (3M atom water box),
+`gmx mdrun -nb gpu -pme gpu -update gpu -ntmpi 1 -ntomp 8 -nstlist 100
+-noconfout -nsteps 500`, chipStar `CHIP_BE=level0` Arc A770.
+
+| MKLShim                           | ns/day | ms/step |
+|-----------------------------------|--------|---------|
+| before (queue.wait everywhere)    | 0.963  | 179.36  |
+| after  (shim-queue commit 8b713cc)| 3.997  |  43.23  |
+| **speedup**                       | **4.15×** | **4.15×** |
+
+The earlier session's local SYCL number on the same input was 11.298 ns/day
+(20000-step run, fully cached); chipStar HIP closes a meaningful chunk of
+that gap on this short-duration test once the host fences are gone.
+
+## Reproducing the A/B
+
+```bash
+cd ~/chipStar/shim-queue/benchmark
+
+# build microbench (one-time)
+/home/pvelesko/install/HIP/chipStar/2026.04.29/bin/hipcc -O2 \
+  -I/space/pvelesko/apps/gromacs/build-chipstar/h4i-hipfft/include \
+  -L/space/pvelesko/apps/gromacs/build-chipstar/h4i-hipfft/lib -lhipfft \
+  -L/space/pvelesko/apps/gromacs/build-chipstar/h4i-mklshim/lib -lMKLShim \
+  -Wl,-rpath,/space/pvelesko/apps/gromacs/build-chipstar/h4i-mklshim/lib:/space/pvelesko/apps/gromacs/build-chipstar/h4i-hipfft/lib \
+  -o fft_pingpong fft_pingpong.hip
+
+ENV_PREFIX="env -i HOME=$HOME PATH=/usr/bin:/bin CHIP_LOGLEVEL=err \
+  LD_LIBRARY_PATH=/space/pvelesko/apps/gromacs/build-chipstar/h4i-mklshim/lib:\
+/space/pvelesko/apps/gromacs/build-chipstar/h4i-hipfft/lib:\
+/home/pvelesko/install/HIP/chipStar/2026.04.29/lib:\
+/space/pvelesko/install/oneapi/2025.3.2/lib"
+
+# Level 0
+$ENV_PREFIX LD_PRELOAD=$PWD/libMKLShim.before.so CHIP_BE=level0 ./fft_pingpong 500 30 96 L0_before
+$ENV_PREFIX LD_PRELOAD=$PWD/libMKLShim.after.so  CHIP_BE=level0 ./fft_pingpong 500 30 96 L0_after
+
+# OpenCL
+$ENV_PREFIX LD_PRELOAD=$PWD/libMKLShim.before.so CHIP_BE=opencl ./fft_pingpong 500 30 96 OCL_before
+$ENV_PREFIX LD_PRELOAD=$PWD/libMKLShim.after.so  CHIP_BE=opencl ./fft_pingpong 500 30 96 OCL_after
+```
+
+## Existing MKLShim tests (regression check)
+
+`ctest` from `/tmp/h4i-mklshim-build`:
+
+| test                                  | L0     | OpenCL |
+|---------------------------------------|--------|--------|
+| `h4i-mklshim_context_test`            | PASS   | PASS   |
+| `h4i-mklshim_batch_smoke_test`        | FAIL†  | FAIL†  |
+| `h4i-mklshim_batch_correctness_test`  | FAIL†  | FAIL†  |
+| `h4i-mklshim_handle_management_test`  | PASS   | PASS   |
+
+† Pre-existing failure on the parent commit `b71b7ca` as well: the test
+calls `Dgetrf_batch` (FP64 LAPACK) which throws "Required aspect fp64 is
+not supported on the device" — an Arc A770 hardware limitation
+(no native FP64). Not a regression.

--- a/benchmark/fft_pingpong.hip
+++ b/benchmark/fft_pingpong.hip
@@ -1,0 +1,120 @@
+// shim-queue micro-benchmark.
+//
+// Times a FFT-heavy ping-pong on chipStar: alternating HIP kernels and
+// hipFFT R2C / C2R transforms, mirroring the inner loop of GROMACS PME.
+// Reports ms/iteration and FFTs/s. Intended to be run twice — once
+// LD_PRELOADing libMKLShim.before.so (entry/exit/post-compute queue.wait()
+// calls in MKLShim's exec path), once LD_PRELOADing libMKLShim.after.so
+// (those waits removed). The host-fence cost is what we are measuring.
+//
+// Build:
+//   /home/pvelesko/install/HIP/chipStar/2026.04.29/bin/hipcc \
+//     -O2 \
+//     -I/space/pvelesko/apps/gromacs/build-chipstar/h4i-hipfft/include \
+//     -L/space/pvelesko/apps/gromacs/build-chipstar/h4i-hipfft/lib -lhipfft \
+//     -L/space/pvelesko/apps/gromacs/build-chipstar/h4i-mklshim/lib -lMKLShim \
+//     -Wl,-rpath,/space/pvelesko/apps/gromacs/build-chipstar/h4i-mklshim/lib:\
+//                /space/pvelesko/apps/gromacs/build-chipstar/h4i-hipfft/lib \
+//     -o fft_pingpong fft_pingpong.hip
+
+#include <hip/hip_runtime.h>
+#include <hipfft/hipfft.h>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#define HIPCK(x) do { hipError_t err=(x); if (err != hipSuccess) { \
+    fprintf(stderr,"HIP err %s:%d %s\n",__FILE__,__LINE__,hipGetErrorString(err)); std::exit(1);} } while(0)
+#define FFTCK(x) do { hipfftResult r=(x); if (r != HIPFFT_SUCCESS) { \
+    fprintf(stderr,"FFT err %s:%d rc=%d\n",__FILE__,__LINE__,(int)r); std::exit(1);} } while(0)
+
+// Lightweight kernel; the goal is to keep the queue busy with chipStar work
+// between FFT calls so any host-side queue.wait() inside MKLShim shows up
+// as a serialization stall.
+__global__ void touch_real(float *p, int n, int it) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) p[i] = p[i] * 1.000001f + (float)(it & 0xff);
+}
+
+int main(int argc, char** argv) {
+    int iters    = (argc > 1) ? std::atoi(argv[1]) : 200;
+    int warmup   = (argc > 2) ? std::atoi(argv[2]) : 20;
+    int N        = (argc > 3) ? std::atoi(argv[3]) : 200;       // grid edge
+    const char* tag = (argc > 4) ? argv[4] : "run";
+
+    int NX = N, NY = N, NZ = N;
+    int NZc = NZ/2 + 1;
+    size_t realCount    = (size_t)NX * NY * NZ;
+    size_t complexCount = (size_t)NX * NY * NZc;
+
+    HIPCK(hipSetDevice(0));
+    hipStream_t stream;
+    HIPCK(hipStreamCreate(&stream));
+
+    float *d_real = nullptr;
+    hipfftComplex *d_complex = nullptr;
+    HIPCK(hipMalloc(&d_real,    realCount    * sizeof(float)));
+    HIPCK(hipMalloc(&d_complex, complexCount * sizeof(hipfftComplex)));
+
+    int n[3]       = { NX, NY, NZ };
+    int inembed[3] = { NX, NY, NZ };
+    int onembed[3] = { NX, NY, NZc };
+    hipfftHandle planR2C, planC2R;
+    FFTCK(hipfftPlanMany(&planR2C, 3, n,
+                          inembed, 1, NX*NY*NZ,
+                          onembed, 1, NX*NY*NZc,
+                          HIPFFT_R2C, 1));
+    FFTCK(hipfftPlanMany(&planC2R, 3, n,
+                          onembed, 1, NX*NY*NZc,
+                          inembed, 1, NX*NY*NZ,
+                          HIPFFT_C2R, 1));
+    FFTCK(hipfftSetStream(planR2C, stream));
+    FFTCK(hipfftSetStream(planC2R, stream));
+
+    int threads = 256;
+    int blocksR = (int)((realCount + threads - 1) / threads);
+
+    auto run_iter = [&](int it){
+        // PP-like work
+        hipLaunchKernelGGL(touch_real, dim3(blocksR), dim3(threads), 0, stream,
+                           d_real, (int)realCount, it);
+        // R2C
+        hipfftExecR2C(planR2C, d_real, d_complex);
+        // PME-solve-like
+        hipLaunchKernelGGL(touch_real, dim3(blocksR), dim3(threads), 0, stream,
+                           d_real, (int)realCount, it);
+        // C2R
+        hipfftExecC2R(planC2R, d_complex, d_real);
+        // Update-like
+        hipLaunchKernelGGL(touch_real, dim3(blocksR), dim3(threads), 0, stream,
+                           d_real, (int)realCount, it);
+    };
+
+    // Warmup (JIT compile, plan settle)
+    for (int it = 0; it < warmup; ++it) run_iter(it);
+    HIPCK(hipStreamSynchronize(stream));
+
+    // Timed loop
+    auto t0 = std::chrono::high_resolution_clock::now();
+    for (int it = 0; it < iters; ++it) run_iter(it);
+    HIPCK(hipStreamSynchronize(stream));
+    auto t1 = std::chrono::high_resolution_clock::now();
+
+    double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    double per_iter_ms = ms / iters;
+    double ffts_per_s  = (2.0 * iters) * 1000.0 / ms;   // 2 FFTs (R2C + C2R) per iter
+
+    fprintf(stdout,
+            "[%s] grid=%dx%dx%d iters=%d warmup=%d total=%.3f ms  "
+            "per_iter=%.3f ms  ffts/s=%.1f\n",
+            tag, NX, NY, NZ, iters, warmup, ms, per_iter_ms, ffts_per_s);
+
+    FFTCK(hipfftDestroy(planR2C));
+    FFTCK(hipfftDestroy(planC2R));
+    HIPCK(hipFree(d_real));
+    HIPCK(hipFree(d_complex));
+    HIPCK(hipStreamDestroy(stream));
+    return 0;
+}


### PR DESCRIPTION
Workspace (DESIGN.md, RESULTS.md, fft_pingpong microbench) for the companion H4I-MKLShim PR that removes redundant queue.wait() calls from the FFT exec hot path; documents the rationale and measured uplift on Intel Arc A770 (Level 0 + OpenCL) and end-to-end GROMACS PME-on-GPU (4.15× on water_GMX50_bare 500 steps).