### PR TITLE
docker: bump base to LLVM 22 native + OneAPI 2025.3.2

### DIFF
--- a/docker/DockerfileBase
+++ b/docker/DockerfileBase
@@ -26,15 +26,18 @@ RUN sudo apt update; sudo apt install -y gcc g++ cmake python3 git software-prop
     sudo apt update; \
     sudo apt install -y python3-dev python3-yaml libpython3-dev build-essential cmake git pkg-config make ninja-build ocl-icd-libopencl1 ocl-icd-dev ocl-icd-opencl-dev libhwloc-dev zlib1g zlib1g-dev clinfo dialog apt-utils libxml2-dev wget lua5.3 lua-bit32:amd64 lua-posix:amd64 lua-posix-dev liblua5.3-0:amd64 liblua5.3-dev:amd64 tcl tcl-dev tcl8.6 tcl8.6-dev:amd64 libtcl8.6:amd64
 
-COPY scripts/configure_llvm.sh /home/chipStarUser/configure_llvm.sh
-RUN sudo chmod +x /home/chipStarUser/configure_llvm.sh
+# configure_llvm.sh resolves patch dirs as $THIS_SCRIPT_DIR/../llvm-patches/{llvm,spirv-translator},
+# so the script and the patch tree must keep their chipStar-tree relative layout.
+COPY scripts /home/chipStarUser/scripts
+COPY llvm-patches /home/chipStarUser/llvm-patches
+RUN sudo chmod +x /home/chipStarUser/scripts/configure_llvm.sh
 
 # Create /apps directory and set ownership to chipStarUser
 RUN sudo mkdir -p /apps && \
     sudo chown chipStarUser:chipStarUser /apps
 
 # Install and setup lmod with StdEnv and non-interactive support
-RUN sudo chown chipStarUser:chipStarUser configure_llvm.sh; \
+RUN sudo chown -R chipStarUser:chipStarUser scripts llvm-patches; \
     wget https://sourceforge.net/projects/lmod/files/Lmod-8.7.tar.bz2; \
     tar -xvf Lmod-8.7.tar.bz2; \
     cd Lmod-8.7; \
@@ -69,38 +72,47 @@ ENV MODULEPATH_ROOT=/apps/modulefiles
 ENV MODULEPATH=/apps/modulefiles/Linux:/apps/modulefiles/Core:/apps/lmod/lmod/modulefiles/Core
 
 # Install default llvm stack and set up defaultly loaded environment (StdEnv)
-RUN export LLVM_VERSION=15; \
-    ./configure_llvm.sh --version ${LLVM_VERSION} --install-dir /apps/llvm/${LLVM_VERSION} --link-type static --only-necessary-spirv-exts off; \
-    cd llvm-project/llvm/build_${LLVM_VERSION}; \
-    make -j 16; \
-    sudo make install; \
-    mkdir -p /apps/modulefiles/Core/llvm/; \
-    echo "prepend_path(\"CPATH\",\"/apps/llvm/${LLVM_VERSION}/include\")" | tee  /apps/modulefiles/Core/llvm/${LLVM_VERSION}.lua; \
-    echo "prepend_path(\"LD_LIBRARY_PATH\",\"/apps/llvm/${LLVM_VERSION}/lib\")" | tee -a /apps/modulefiles/Core/llvm/${LLVM_VERSION}.lua; \
-    echo "prepend_path(\"LIBRARY_PATH\",\"/apps/llvm/${LLVM_VERSION}/lib\")" | tee -a /apps/modulefiles/Core/llvm/${LLVM_VERSION}.lua; \
-    echo "prepend_path(\"PATH\",\"/apps/llvm/${LLVM_VERSION}/libexec\")" | tee -a /apps/modulefiles/Core/llvm/${LLVM_VERSION}.lua; \
-    echo "prepend_path(\"PATH\",\"/apps/llvm/${LLVM_VERSION}/bin\")" | tee -a /apps/modulefiles/Core/llvm/${LLVM_VERSION}.lua; \
-    echo "prepend_path(\"PKG_CONFIG_PATH\",\"/apps/llvm/${LLVM_VERSION}/lib/pkgconfig/\")" | tee -a /apps/modulefiles/Core/llvm/${LLVM_VERSION}.lua; \
-    ml avail; ml llvm/${LLVM_VERSION}; \
-    rm -rf /home/chipStarUser/llvm-project;
+# Ships LLVM 22 with the native (integrated) SPIR-V backend so chipStar
+# auto-enables CHIP_LLVM_USE_INTERGRATED_SPIRV.
+# Commands are chained with && so any failure aborts the build (a previous
+# `;`-chained version silently produced an image with no clang installed).
+RUN export LLVM_VERSION=22 && export LLVM_TAG=${LLVM_VERSION}.0-native && \
+    ./scripts/configure_llvm.sh --version ${LLVM_VERSION} --install-dir /apps/llvm/${LLVM_TAG} --link-type static --variant native --configure-only && \
+    cd llvm-project/llvm/build_${LLVM_VERSION} && \
+    make -j 16 && \
+    sudo make install && \
+    test -x /apps/llvm/${LLVM_TAG}/bin/clang && \
+    mkdir -p /apps/modulefiles/Core/llvm/ && \
+    echo "prepend_path(\"CPATH\",\"/apps/llvm/${LLVM_TAG}/include\")" | tee  /apps/modulefiles/Core/llvm/${LLVM_TAG}.lua && \
+    echo "prepend_path(\"LD_LIBRARY_PATH\",\"/apps/llvm/${LLVM_TAG}/lib\")" | tee -a /apps/modulefiles/Core/llvm/${LLVM_TAG}.lua && \
+    echo "prepend_path(\"LIBRARY_PATH\",\"/apps/llvm/${LLVM_TAG}/lib\")" | tee -a /apps/modulefiles/Core/llvm/${LLVM_TAG}.lua && \
+    echo "prepend_path(\"PATH\",\"/apps/llvm/${LLVM_TAG}/libexec\")" | tee -a /apps/modulefiles/Core/llvm/${LLVM_TAG}.lua && \
+    echo "prepend_path(\"PATH\",\"/apps/llvm/${LLVM_TAG}/bin\")" | tee -a /apps/modulefiles/Core/llvm/${LLVM_TAG}.lua && \
+    echo "prepend_path(\"PKG_CONFIG_PATH\",\"/apps/llvm/${LLVM_TAG}/lib/pkgconfig/\")" | tee -a /apps/modulefiles/Core/llvm/${LLVM_TAG}.lua && \
+    ml avail && ml llvm/${LLVM_TAG} && \
+    rm -rf /home/chipStarUser/llvm-project
 
 # Install pocl
-RUN export LLVM_VERSION=15; ml llvm/${LLVM_VERSION} && cd /home/chipStarUser && git clone --depth 1 --branch release_5_0 https://github.com/pocl/pocl.git pocl; \
-    cd pocl; \
-    mkdir -p build; \
-    cd build; \
-    cmake ..  -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/apps/pocl/5.0-llvm-${LLVM_VERSION} -DENABLE_TESTS=OFF -DENABLE_EXAMPLES=OFF -DSTATIC_LLVM=ON -DKERNELLIB_HOST_CPU_VARIANTS=distro; \
-    cmake --build . --parallel $(nproc); \
-    cmake --install . ; \
-    rm -rf /home/chipStarUser/pocl; \
-    mkdir -p /apps/modulefiles/Core/pocl/; \
-    echo "prepend_path(\"CPATH\",\"/apps/llvm/${LLVM_VERSION}/include\")" | tee  /apps/modulefiles/Core/pocl/5.0-llvm-${LLVM_VERSION}.lua; \
-    echo "prepend_path(\"LD_LIBRARY_PATH\",\"/apps/pocl/5.0-llvm-${LLVM_VERSION}/lib\")" | tee -a /apps/modulefiles/Core/pocl/5.0-llvm-${LLVM_VERSION}.lua; \
-    echo "prepend_path(\"LIBRARY_PATH\",\"/apps/llvm/${LLVM_VERSION}/lib\")" | tee -a /apps/modulefiles/Core/pocl/5.0-llvm-${LLVM_VERSION}.lua; \
-    echo "prepend_path(\"PATH\",\"/apps/pocl/5.0-llvm-${LLVM_VERSION}/bin\")" | tee -a /apps/modulefiles/Core/pocl/5.0-llvm-${LLVM_VERSION}.lua; \
-    echo "prepend_path(\"XDG_DATA_DIRS\",\"/apps/pocl/5.0-llvm-${LLVM_VERSION}/share\")" | tee -a /apps/modulefiles/Core/pocl/5.0-llvm-${LLVM_VERSION}.lua; \
-    echo "setenv(\"OPENCL_VENDOR_PATH\",\"/apps/pocl/5.0-llvm-${LLVM_VERSION}/etc/OpenCL/vendors\")" | tee -a /apps/modulefiles/Core/pocl/5.0-llvm-${LLVM_VERSION}.lua; \
-    echo "load(\"llvm/${LLVM_VERSION}\", \"pocl/5.0-llvm-${LLVM_VERSION}\")" | tee  /apps/modulefiles/Core/StdEnv.lua
+# PoCL 7.1 only supports up to LLVM 21; use pocl main for LLVM 22 support.
+# Commands chained with && so failures abort the build (see LLVM block above).
+RUN export LLVM_VERSION=22 && export LLVM_TAG=${LLVM_VERSION}.0-native && export POCL_TAG=main-llvm-${LLVM_TAG} && \
+    ml llvm/${LLVM_TAG} && cd /home/chipStarUser && git clone --depth 1 --branch main https://github.com/pocl/pocl.git pocl && \
+    cd pocl && \
+    mkdir -p build && \
+    cd build && \
+    cmake ..  -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/apps/pocl/${POCL_TAG} -DENABLE_TESTS=OFF -DENABLE_EXAMPLES=OFF -DSTATIC_LLVM=ON -DKERNELLIB_HOST_CPU_VARIANTS=distro && \
+    cmake --build . --parallel $(nproc) && \
+    cmake --install . && \
+    test -x /apps/pocl/${POCL_TAG}/bin/poclcc && \
+    rm -rf /home/chipStarUser/pocl && \
+    mkdir -p /apps/modulefiles/Core/pocl/ && \
+    echo "prepend_path(\"CPATH\",\"/apps/llvm/${LLVM_TAG}/include\")" | tee  /apps/modulefiles/Core/pocl/${POCL_TAG}.lua && \
+    echo "prepend_path(\"LD_LIBRARY_PATH\",\"/apps/pocl/${POCL_TAG}/lib\")" | tee -a /apps/modulefiles/Core/pocl/${POCL_TAG}.lua && \
+    echo "prepend_path(\"LIBRARY_PATH\",\"/apps/llvm/${LLVM_TAG}/lib\")" | tee -a /apps/modulefiles/Core/pocl/${POCL_TAG}.lua && \
+    echo "prepend_path(\"PATH\",\"/apps/pocl/${POCL_TAG}/bin\")" | tee -a /apps/modulefiles/Core/pocl/${POCL_TAG}.lua && \
+    echo "prepend_path(\"XDG_DATA_DIRS\",\"/apps/pocl/${POCL_TAG}/share\")" | tee -a /apps/modulefiles/Core/pocl/${POCL_TAG}.lua && \
+    echo "setenv(\"OPENCL_VENDOR_PATH\",\"/apps/pocl/${POCL_TAG}/etc/OpenCL/vendors\")" | tee -a /apps/modulefiles/Core/pocl/${POCL_TAG}.lua && \
+    echo "load(\"llvm/${LLVM_TAG}\", \"pocl/${POCL_TAG}\")" | tee  /apps/modulefiles/Core/StdEnv.lua
 
 #////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #//                                                                                                                                        //
@@ -115,35 +127,39 @@ RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -
 
 # Set up conda environment
 ENV PATH="/apps/conda/bin:${PATH}"
-RUN conda init bash && \
+# Accept Anaconda Terms of Service for the default channels; without these,
+# `conda create` fails non-interactively (CondaToSNonInteractiveError).
+RUN conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main && \
+    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r && \
+    conda init bash && \
     conda config --add channels https://software.repos.intel.com/python/conda/ && \
     conda config --add channels conda-forge && \
-    conda create -n oneapi-2024.1.0 -y
+    conda create -n oneapi-2025.3.2 -y
 
-# Install OneAPI packages
-RUN conda run -n oneapi-2024.1.0 conda install -y \
-    dpcpp-cpp-rt=2024.1.0=intel_963 \
-    dpcpp_impl_linux-64=2024.1.0=intel_963 \
-    icc_rt=2024.1.0=intel_963 \
-    intel-cmplr-lib-rt=2024.1.0=intel_963 \
-    intel-cmplr-lic-rt=2024.1.0=intel_963 \
-    intel-opencl-rt=2024.1.0=intel_963 \
-    intel-openmp=2024.1.0=intel_963 \
-    mkl=2024.1.0=intel_691 \
-    mkl-devel=2024.1.0=intel_691 \
-    mkl-devel-dpcpp=2024.1.0=intel_691 \
-    mkl-dpcpp=2024.1.0=intel_691 \
-    mkl-include=2024.1.0=intel_691 \
-    onedpl-devel=2022.5.0=intel_215 \
-    onemkl-sycl-blas=2024.1.0=intel_691 \
-    onemkl-sycl-datafitting=2024.1.0=intel_691 \
-    onemkl-sycl-dft=2024.1.0=intel_691 \
-    onemkl-sycl-lapack=2024.1.0=intel_691 \
-    onemkl-sycl-rng=2024.1.0=intel_691 \
-    onemkl-sycl-sparse=2024.1.0=intel_691 \
-    onemkl-sycl-stats=2024.1.0=intel_691 \
-    onemkl-sycl-vm=2024.1.0=intel_691 \
-    tbb=2021.12.0=intel_495
+# Install OneAPI 2025.3 packages (build strings mirror /apps/conda env at 2025.3.2)
+RUN conda run -n oneapi-2025.3.2 conda install -y \
+    dpcpp-cpp-rt=2025.3.2=intel_832 \
+    dpcpp_impl_linux-64=2025.3.2=intel_832 \
+    intel-cmplr-lib-rt=2025.3.2=intel_832 \
+    intel-cmplr-lib-ur=2025.3.2=intel_832 \
+    intel-cmplr-lic-rt=2025.3.2=intel_832 \
+    intel-opencl-rt=2025.3.2=intel_832 \
+    intel-openmp=2025.3.2=intel_832 \
+    intel-sycl-rt=2025.3.2=intel_832 \
+    mkl=2025.3.1=intel_8 \
+    mkl-devel=2025.3.1=intel_8 \
+    mkl-devel-dpcpp=2025.3.1=intel_8 \
+    mkl-dpcpp=2025.3.1=intel_8 \
+    mkl-include=2025.3.1=intel_8 \
+    onemkl-sycl-blas=2025.3.1=intel_8 \
+    onemkl-sycl-datafitting=2025.3.1=intel_8 \
+    onemkl-sycl-dft=2025.3.1=intel_8 \
+    onemkl-sycl-lapack=2025.3.1=intel_8 \
+    onemkl-sycl-rng=2025.3.1=intel_8 \
+    onemkl-sycl-sparse=2025.3.1=intel_8 \
+    onemkl-sycl-stats=2025.3.1=intel_8 \
+    onemkl-sycl-vm=2025.3.1=intel_8 \
+    tbb=2022.3.0
 
 USER root
 # Install level-zero and other dependencies
@@ -177,21 +193,21 @@ ENV CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # Create a module file for OneAPI
 RUN mkdir -p /apps/modulefiles/Core/oneapi && \
-    echo 'local version = "2024.1.0"' > /apps/modulefiles/Core/oneapi/2024.1.0.lua && \
-    echo 'local base = "/apps/conda/envs/oneapi-" .. version' >> /apps/modulefiles/Core/oneapi/2024.1.0.lua && \
-    echo '' >> /apps/modulefiles/Core/oneapi/2024.1.0.lua && \
-    echo 'prepend_path("PATH", pathJoin(base, "bin"))' >> /apps/modulefiles/Core/oneapi/2024.1.0.lua && \
-    echo 'prepend_path("LD_LIBRARY_PATH", pathJoin(base, "lib"))' >> /apps/modulefiles/Core/oneapi/2024.1.0.lua && \
-    echo 'prepend_path("LD_LIBRARY_PATH", pathJoin(base, "lib64"))' >> /apps/modulefiles/Core/oneapi/2024.1.0.lua && \
-    echo 'prepend_path("LIBRARY_PATH", pathJoin(base, "lib"))' >> /apps/modulefiles/Core/oneapi/2024.1.0.lua && \
-    echo 'prepend_path("LIBRARY_PATH", pathJoin(base, "lib64"))' >> /apps/modulefiles/Core/oneapi/2024.1.0.lua && \
-    echo 'prepend_path("PKG_CONFIG_PATH", pathJoin(base, "lib/pkgconfig"))' >> /apps/modulefiles/Core/oneapi/2024.1.0.lua && \
-    echo 'prepend_path("CMAKE_PREFIX_PATH", pathJoin(base, "lib/cmake"))' >> /apps/modulefiles/Core/oneapi/2024.1.0.lua && \
-    echo 'prepend_path("XDG_DATA_DIRS", pathJoin(base, "share"))' >> /apps/modulefiles/Core/oneapi/2024.1.0.lua && \
-    echo 'setenv("OPENCL_VENDOR_PATH", "/apps/conda/envs/oneapi-2024.1.0/etc/OpenCL/vendors")' >> /apps/modulefiles/Core/oneapi/2024.1.0.lua && \
-    echo '' >> /apps/modulefiles/Core/oneapi/2024.1.0.lua && \
-    echo 'setenv("ONEAPI_ROOT", base)' >> /apps/modulefiles/Core/oneapi/2024.1.0.lua && \
-    echo 'setenv("ONEAPI_VERSION", version)' >> /apps/modulefiles/Core/oneapi/2024.1.0.lua
+    echo 'local version = "2025.3.2"' > /apps/modulefiles/Core/oneapi/2025.3.2.lua && \
+    echo 'local base = "/apps/conda/envs/oneapi-" .. version' >> /apps/modulefiles/Core/oneapi/2025.3.2.lua && \
+    echo '' >> /apps/modulefiles/Core/oneapi/2025.3.2.lua && \
+    echo 'prepend_path("PATH", pathJoin(base, "bin"))' >> /apps/modulefiles/Core/oneapi/2025.3.2.lua && \
+    echo 'prepend_path("LD_LIBRARY_PATH", pathJoin(base, "lib"))' >> /apps/modulefiles/Core/oneapi/2025.3.2.lua && \
+    echo 'prepend_path("LD_LIBRARY_PATH", pathJoin(base, "lib64"))' >> /apps/modulefiles/Core/oneapi/2025.3.2.lua && \
+    echo 'prepend_path("LIBRARY_PATH", pathJoin(base, "lib"))' >> /apps/modulefiles/Core/oneapi/2025.3.2.lua && \
+    echo 'prepend_path("LIBRARY_PATH", pathJoin(base, "lib64"))' >> /apps/modulefiles/Core/oneapi/2025.3.2.lua && \
+    echo 'prepend_path("PKG_CONFIG_PATH", pathJoin(base, "lib/pkgconfig"))' >> /apps/modulefiles/Core/oneapi/2025.3.2.lua && \
+    echo 'prepend_path("CMAKE_PREFIX_PATH", pathJoin(base, "lib/cmake"))' >> /apps/modulefiles/Core/oneapi/2025.3.2.lua && \
+    echo 'prepend_path("XDG_DATA_DIRS", pathJoin(base, "share"))' >> /apps/modulefiles/Core/oneapi/2025.3.2.lua && \
+    echo 'setenv("OPENCL_VENDOR_PATH", "/apps/conda/envs/oneapi-2025.3.2/etc/OpenCL/vendors")' >> /apps/modulefiles/Core/oneapi/2025.3.2.lua && \
+    echo '' >> /apps/modulefiles/Core/oneapi/2025.3.2.lua && \
+    echo 'setenv("ONEAPI_ROOT", base)' >> /apps/modulefiles/Core/oneapi/2025.3.2.lua && \
+    echo 'setenv("ONEAPI_VERSION", version)' >> /apps/modulefiles/Core/oneapi/2025.3.2.lua
 
 RUN pip install pyyaml
 
@@ -210,8 +226,9 @@ RUN mkdir neo && cd neo && \
     wget https://github.com/intel/compute-runtime/releases/download/25.05.32567.17/libigdgmm12_22.6.0_amd64.deb && \
     sudo dpkg -i *.deb
 
-# Copy the intel.icd file to the current OpenCL vendor path
-RUN cp  /etc/OpenCL/vendors/intel.icd $OPENCL_VENDOR_PATH
+# Copy the intel.icd file to the current OpenCL vendor path.
+# PoCL main does not always create etc/OpenCL/vendors on install — mkdir -p first.
+RUN mkdir -p "$OPENCL_VENDOR_PATH" && cp /etc/OpenCL/vendors/intel.icd "$OPENCL_VENDOR_PATH"
 
 # Set as default user
 USER chipStarUser

--- a/docker/DockerfileLatest
+++ b/docker/DockerfileLatest
@@ -10,6 +10,11 @@ SHELL ["/bin/bash", "-ci"]
 #//                                                                                                                                        //
 #////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+# Fail fast if the base image isn't what we expect (LLVM 22 native + OneAPI 2025.3.2).
+# A prior `;`-chained DockerfileBase silently shipped without /apps/llvm/22.0-native populated.
+RUN test -x /apps/llvm/22.0-native/bin/clang || { echo "ERROR: /apps/llvm/22.0-native/bin/clang missing — base image is stale, rebuild pveleskopglc/chipstar:base"; exit 1; }
+RUN test -d /apps/conda/envs/oneapi-2025.3.2 || { echo "ERROR: oneapi-2025.3.2 conda env missing — base image is stale, rebuild pveleskopglc/chipstar:base"; exit 1; }
+
 RUN clinfo -l
 
 ENV CHIP_BE=opencl
@@ -18,17 +23,24 @@ ENV CHIP_LOGLEVEL=info
 ENV NEOReadDebugKeys=1
 ENV OverrideGpuAddressSpace=48
 
-RUN module unload pocl && module load oneapi/2024.1.0 &&  module load pocl && clinfo -l
+RUN module unload pocl && module load oneapi/2025.3.2 && module load llvm/22.0-native && module load pocl && clinfo -l
 
-RUN module unload pocl; module load oneapi/2024.1.0 && which icpx && git clone https://github.com/CHIP-SPV/chipStar.git && \
+# Re-load llvm/22.0-native AFTER oneapi so /apps/llvm/22.0-native/bin/clang wins in PATH
+# (oneapi ships its own icx/clang). With LLVM >=22 + the native target,
+# chipStar auto-enables CHIP_LLVM_USE_INTERGRATED_SPIRV.
+RUN module unload pocl; module load oneapi/2025.3.2 && module load llvm/22.0-native && which clang && which icpx && \
+    git clone https://github.com/CHIP-SPV/chipStar.git && \
     cd chipStar && \
     git submodule update --init --recursive && \
     mkdir build && \
     cd build && \
     cmake .. -DCMAKE_BUILD_TYPE=Release -DCHIP_BUILD_SAMPLES=ON && \
     make -j$(nproc) && \
-    /home/chipStarUser/chipStar/build/samples/0_MatrixMultiply/MatrixMultiply && \
-    sudo make install 
+    sudo make install
+# Note: the MatrixMultiply smoke-test that used to run here was removed —
+# `docker build` has no /dev/dri/* passthrough on the CI runner (or anywhere
+# else by default), so CHIP_DEVICE_TYPE=gpu finds no devices and aborts.
+# End-users run samples after `docker run --device /dev/dri/...` per docker.md.
 
 #////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #//                                                                                                                                        //

--- a/docker/docker.md
+++ b/docker/docker.md
@@ -49,7 +49,7 @@ To run the Docker image with GPU support, follow these steps:
 
 2. Unload PoCL module to expose Intel GPUs (if available):
    ```
-   module unload pocl/5.0-llvm-15
+   module unload pocl/main-llvm-22.0-native
    ```
 
 3. Run a GPU-accelerated sample:
@@ -64,9 +64,9 @@ This process allows you to run the chipStar Docker image with GPU support, enabl
 - Base: Ubuntu latest
 - User: 'chipStarUser' with sudo, video, render group access
 - Core tools: gcc, g++, cmake, python3, git, OpenCL dev environment
-- LLVM/Clang: Customizable version (default 15)
+- LLVM/Clang: 22.0 with the native (integrated) SPIR-V backend (`llvm/22.0-native`)
 - Lmod: For environment module management
-- POCL: Portable OpenCL implementation
+- POCL: Portable OpenCL implementation (built from `main` for LLVM 22 support)
 - Intel OneAPI: Via Miniconda, includes MKL, TBB, DPC++
 - Level Zero API: For low-level device control
 
@@ -126,7 +126,7 @@ This layer builds upon the base image and adds:
 
 Key components:
 - PyYAML: Python package for YAML parsing
-- LLVM/Clang 15: Loaded as a module
+- LLVM/Clang 22 (native SPIR-V backend): Loaded via `llvm/22.0-native` module
 - Vim common: Includes 'xxd' utility
 - chipStar: 
   - Cloned from GitHub


### PR DESCRIPTION
## Summary
- LLVM 22 with the integrated SPIR-V backend (`--variant native`); chipStar auto-enables `CHIP_LLVM_USE_INTERGRATED_SPIRV`.
- PoCL `main` (7.1 caps at LLVM 21).
- OneAPI conda env bumped to 2025.3.2 + accept Anaconda ToS.
- Drop in-build `MatrixMultiply` smoke test (no `/dev/dri` in `docker build` sandbox).
- Fail-loud: `&&`-chained build steps, `test -x clang/poclcc` guards, base-staleness checks in `DockerfileLatest`.

Fixes the `HipCleanup.cpp` `starts_with` compile error in the publish-docker workflow.

## Test plan
- [x] Base image rebuilt + verified locally (clang 22.1.6, `spirv*` targets registered, OneAPI 2025.3.2 env present).
- [x] Latest image rebuilt against new base; chipStar compiles 100% clean and installs.
- [x] Both images pushed to Docker Hub (`pveleskopglc/chipstar:{base,latest}`).