### PR TITLE
Quick fix to the gitlab CI file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,7 +215,7 @@ performance_hoMusic:
   script:
     - cd ${GENESIS_CI_PROJECT_DIR}
     - |
-      TIME_STR=$(grep "real" output | awk '{print $2}')
+      TIME_STR=$(grep "real" output | tail -n 1 | awk '{print $2}')
       echo "Extracted time: $TIME_STR"
 
       # Convert to total seconds using awk (handles 1m50.315s -> 110.315)


### PR DESCRIPTION
The performance test of an application in gitlab CI was failing since it was getting an incorrect time due to a mistake in the  the grep command. This fixes the grep command to only get the last time.