### PR TITLE
fix: install libhiprtc.so stub for HIP-7 consumers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -904,7 +904,8 @@ endif()
 
 add_library(hip::host ALIAS host)
 add_library(hip::device ALIAS device)
-add_library(hiprtc-lib INTERFACE)
+add_library(hiprtc-lib SHARED src/stubs/hiprtc_stub.c)
+set_target_properties(hiprtc-lib PROPERTIES OUTPUT_NAME hiprtc)
 add_library(hiprtc::hiprtc ALIAS hiprtc-lib)
 
 INSTALL(TARGETS CHIP host device deviceRDC hiprtc-lib

--- a/src/stubs/hiprtc_stub.c
+++ b/src/stubs/hiprtc_stub.c
@@ -1,0 +1,3 @@
+/* Empty translation unit. libhiprtc is a stub: chipStar's hipRTC symbols
+ * live in libCHIP.so, but HIP-7 consumers (e.g. libCEED) pass `-lhiprtc`
+ * on the link line. This stub provides a linker-resolvable libhiprtc.so. */

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -89,6 +89,7 @@ add_hip_runtime_test(TestThreadDetachCleanup.cpp)
 add_shell_test(TestAssert.bash)
 add_shell_test(TestAssertFail.bash)
 add_shell_test(TestForgottenModuleUnload.bash)
+add_shell_test(TestLinkHiprtc.bash)
 
 add_hip_runtime_test(TestIndirectCall.hip)
 add_hip_runtime_test(TestStructWithFnPtr.hip)

--- a/tests/runtime/TestLinkHiprtc.bash
+++ b/tests/runtime/TestLinkHiprtc.bash
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Reproduces: chipStar does not produce a libhiprtc.so file. libCEED (and
+# other HIP-7 consumers) link with `-lhiprtc` because hipconfig --version
+# reports 7.x; the linker then fails with "cannot find -lhiprtc".
+set -eu
+
+BUILD_DIR=@CMAKE_BINARY_DIR@
+OUT_DIR=@CMAKE_CURRENT_BINARY_DIR@/@TEST_NAME@.d
+HIPCC=${BUILD_DIR}/bin/hipcc
+
+mkdir -p ${OUT_DIR}
+cd ${OUT_DIR}
+
+cat > consumer.c <<'EOF'
+int main(void) { return 0; }
+EOF
+
+${HIPCC} consumer.c -L${BUILD_DIR} -lhiprtc -o consumer 2> link.err || {
+    echo "FAIL: linker could not find -lhiprtc"
+    cat link.err
+    exit 1
+}
+
+echo "PASS"


### PR DESCRIPTION
Adds a real libhiprtc.so so HIP-7 consumers like libCEED that link with -lhiprtc resolve cleanly; chipStar's hipRTC symbols continue to live in libCHIP.so.