### PR TITLE
Changing hipHostRegister to use a lazy-allocation strategy

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -2015,7 +2015,10 @@ chipstar::Queue::RegisteredVarCopy(chipstar::ExecItem *ExecItem,
         MemUnmap(&AllocInfo);
       else
         MemMap(&AllocInfo, chipstar::Queue::MEM_MAP_TYPE::HOST_READ_WRITE);
-    } else if (AllocInfo.HostPtr &&
+    } else if (AllocInfo.HostPtr && AllocInfo.DevPtr &&
+               // DevPtr will be null if hipHostRegister was called but
+               // hipHostGetDevicePointer was never called, meaning no device
+               // backing exists yet and there is nothing to sync.
                AllocInfo.MemoryType == hipMemoryTypeManaged) {
       // If the module has no indirect global buffer accesses, only sync
       // allocations whose DevPtr is explicitly passed as a kernel argument.

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -540,6 +540,30 @@ public:
     NumManagedAllocations_ += 1;
   }
 
+  /**
+   * @brief Record a hipHostRegister'd pointer without yet allocating device
+   * memory. DevPtr is left null and filled in lazily by hipHostGetDevicePointer.
+   *
+   * @param HostPtr  User-provided host pointer (malloc'd by the caller)
+   * @param Device   Device ID the registration is associated with
+   * @param Size     Byte size of the host allocation
+   * @param Flags    Host allocation flags from the hipHostRegister call
+   */
+  void registerHostPointerDeferred(void *HostPtr, hipDevice_t Device,
+                                   size_t Size, chipstar::HostAllocFlags Flags) {
+    CHIPASSERT(HostPtr && "HostPtr is null");
+    LOCK(AllocationTrackerMtx);
+    if (PtrToAllocInfo_.count(HostPtr))
+      CHIPERR_LOG_AND_THROW("Host memory is already registered!",
+                            hipErrorHostMemoryAlreadyRegistered);
+    chipstar::AllocationInfo *AllocInfo = new chipstar::AllocationInfo{
+        nullptr, HostPtr, Size, Flags, Device, false, hipMemoryTypeManaged};
+    AllocInfo->IsHostRegistered = true;
+    AllocInfos_.insert(AllocInfo);
+    PtrToAllocInfo_[HostPtr] = AllocInfo;
+    NumManagedAllocations_ += 1;
+  }
+
   size_t GlobalMemSize, TotalMemSize, MaxMemUsed;
   /**
    * @brief Construct a new chipstar::AllocationTracker object

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -547,7 +547,7 @@ public:
    * @param HostPtr  User-provided host pointer (malloc'd by the caller)
    * @param Device   Device ID the registration is associated with
    * @param Size     Byte size of the host allocation
-   * @param Flags    Host allocation flags from the hipHostRegister call
+   * @param Flags    Host allocation flags
    */
   void registerHostPointerDeferred(void *HostPtr, hipDevice_t Device,
                                    size_t Size, chipstar::HostAllocFlags Flags) {

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -4477,6 +4477,7 @@ hipError_t hipHostRegister(void *HostPtr, size_t SizeBytes,
   if (SizeBytes >= FreeMem)
     RETURN(hipErrorInvalidValue);
 
+  // TODO fixOpenCLTests - make this a class
   // First 4 bits are valid flag bits. This includes flags from CUDA which are
   // not supported or documented in HIP.
   constexpr unsigned FlagMask = (1u << 4u) - 1u;
@@ -4487,6 +4488,7 @@ hipError_t hipHostRegister(void *HostPtr, size_t SizeBytes,
     CHIPERR_LOG_AND_THROW("Unsupported hipHostRegisterIoMemory flag",
                           hipErrorInvalidValue);
 
+  // TODO fixOpenCLTests - use recordAllocation()
   // Record the registration without allocating device memory. Device memory
   // is allocated lazily the first time hipHostGetDevicePointer is called.
   Dev->AllocTracker->registerHostPointerDeferred(

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -4425,10 +4425,11 @@ hipError_t hipHostGetDevicePointer(void **DevPtr, void *HostPtr,
     CHIP_CATCH_RETURN_CODE(hipErrorInvalidValue)
 
     Device->AllocTracker->registerHostPointer(HostPtr, DevPtr_internal);
-    AllocInfo = Device->AllocTracker->getAllocInfo(HostPtr);
+    *DevPtr = DevPtr_internal;
   }
-
-  *DevPtr = AllocInfo->DevPtr;
+  else {
+    *DevPtr = AllocInfo->DevPtr;
+  }
   RETURN(hipSuccess);
   CHIP_CATCH
 }

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -4405,15 +4405,30 @@ hipError_t hipHostGetDevicePointer(void **DevPtr, void *HostPtr,
   if (!HostPtr)
     RETURN(hipErrorInvalidValue);
 
-  auto Device = Backend->getActiveDevice();
-  auto AllocInfo = Device->AllocTracker->getAllocInfo(HostPtr);
+  auto *Device = Backend->getActiveDevice();
+  auto *AllocInfo = Device->AllocTracker->getAllocInfo(HostPtr);
   if (!AllocInfo)
     CHIPERR_LOG_AND_THROW("Host pointer is not allocated by hipHostMalloc or "
                           "registered with hipHostRegister!",
                           hipErrorInvalidValue);
 
-  *DevPtr = AllocInfo->DevPtr;
+  if (AllocInfo->DevPtr == nullptr) {
+    // First call: erase the deferred placeholder and allocate backing device
+    // memory now.
+    size_t Size = AllocInfo->Size;
+    Device->AllocTracker->eraseRecord(AllocInfo);
 
+    void *DevPtr_internal;
+    CHIP_TRY
+    if (hipMallocInternal(&DevPtr_internal, Size) != hipSuccess)
+      RETURN(hipErrorInvalidValue);
+    CHIP_CATCH_RETURN_CODE(hipErrorInvalidValue)
+
+    Device->AllocTracker->registerHostPointer(HostPtr, DevPtr_internal);
+    AllocInfo = Device->AllocTracker->getAllocInfo(HostPtr);
+  }
+
+  *DevPtr = AllocInfo->DevPtr;
   RETURN(hipSuccess);
   CHIP_CATCH
 }
@@ -4462,35 +4477,20 @@ hipError_t hipHostRegister(void *HostPtr, size_t SizeBytes,
   if (SizeBytes >= FreeMem)
     RETURN(hipErrorInvalidValue);
 
-  // TODO fixOpenCLTests - make this a class
-  if (Flags) {
-    // Currently, the flags are ignored. This only exists to satisfy hip-tests.
+  // First 4 bits are valid flag bits. This includes flags from CUDA which are
+  // not supported or documented in HIP.
+  constexpr unsigned FlagMask = (1u << 4u) - 1u;
+  if (Flags & ~FlagMask)
+    CHIPERR_LOG_AND_THROW("Invalid hipHostRegister flags passed",
+                          hipErrorInvalidValue);
+  if (Flags & hipHostRegisterIoMemory)
+    CHIPERR_LOG_AND_THROW("Unsupported hipHostRegisterIoMemory flag",
+                          hipErrorInvalidValue);
 
-    // First 4 bits are valid flag bits. This includes flags from CUDA which are
-    // not supported or documented in HIP.
-    constexpr unsigned FlagMask = (1u << 4u) - 1u;
-
-    if (Flags & ~FlagMask) // Has invalid flags
-      CHIPERR_LOG_AND_THROW("Invalid hipHostRegister flags passed",
-                            hipErrorInvalidValue);
-
-    if (Flags & hipHostRegisterIoMemory)
-      CHIPERR_LOG_AND_THROW("Unsupported hipHostRegisterIoMemory flag",
-                            hipErrorInvalidValue);
-  }
-
-  void *DevPtr;
-  CHIP_TRY
-  if (hipMallocInternal(&DevPtr, SizeBytes) != hipSuccess)
-    // Translate hipOutOfMemory to hipErrorInvalidValue. The latter is
-    // the one hip-tests suite expects in case of OoM.
-    RETURN(hipErrorInvalidValue);
-  CHIP_CATCH_RETURN_CODE(hipErrorInvalidValue)
-
-  // Associate the pointer
-  auto Device = Backend->getActiveDevice();
-  // TODO fixOpenCLTests - use recordAllocation()
-  Device->AllocTracker->registerHostPointer(HostPtr, DevPtr);
+  // Record the registration without allocating device memory. Device memory
+  // is allocated lazily the first time hipHostGetDevicePointer is called.
+  Dev->AllocTracker->registerHostPointerDeferred(
+      HostPtr, Dev->getDeviceId(), SizeBytes, chipstar::HostAllocFlags());
 
   RETURN(hipSuccess);
 
@@ -4509,6 +4509,13 @@ hipError_t hipHostUnregister(void *HostPtr) {
   if (!AllocInfo)
     CHIPERR_LOG_AND_THROW("Host pointer is not registered!",
                           hipErrorHostMemoryNotRegistered);
+
+  if (AllocInfo->DevPtr == nullptr) {
+    // hipHostGetDevicePointer was never called; no device memory to free.
+    Device->AllocTracker->eraseRecord(AllocInfo);
+    RETURN(hipSuccess);
+  }
+
   auto Err = hipFreeInternal(AllocInfo->DevPtr);
   RETURN(Err);
 
@@ -5241,10 +5248,12 @@ static inline hipError_t hipMemsetInternal(void *Dst, int Value,
           AllocInfo, chipstar::Queue::MEM_MAP_TYPE::HOST_WRITE);
       memset(AllocInfo->HostPtr, Value, SizeBytes);
       Backend->getActiveDevice()->getDefaultQueue()->MemUnmap(AllocInfo);
-    } else if (AllocInfo->MemoryType == hipMemoryTypeManaged) {
+    } else if (AllocInfo->MemoryType == hipMemoryTypeManaged && AllocInfo->DevPtr) {
       // For managed memory (from hipHostRegister), we need to memset both
       // device and host sides. Device memset is already done above.
       // Host memset ensures the host-accessible memory is also updated.
+      // DevPtr will be null if hipHostGetDevicePointer was never called, in
+      // which case there is no device backing and only the host side exists.
       logDebug("AllocInfo->MemoryType == hipMemoryTypeManaged - executing "
                "memset on host");
       Backend->getActiveDevice()->getDefaultQueue()->MemMap(

--- a/tests/benchmarks/CMakeLists.txt
+++ b/tests/benchmarks/CMakeLists.txt
@@ -25,3 +25,10 @@ set_target_properties(hostRegisterOverhead PROPERTIES CXX_STANDARD_REQUIRED ON)
 target_link_libraries(hostRegisterOverhead CHIP deviceInternal)
 target_include_directories(hostRegisterOverhead
   PRIVATE $<TARGET_PROPERTY:CHIP,INCLUDE_DIRECTORIES>)
+
+set_source_files_properties(hostRegisterMemcpyOverhead.hip PROPERTIES LANGUAGE CXX)
+add_executable(hostRegisterMemcpyOverhead hostRegisterMemcpyOverhead.hip)
+set_target_properties(hostRegisterMemcpyOverhead PROPERTIES CXX_STANDARD_REQUIRED ON)
+target_link_libraries(hostRegisterMemcpyOverhead CHIP deviceInternal)
+target_include_directories(hostRegisterMemcpyOverhead
+  PRIVATE $<TARGET_PROPERTY:CHIP,INCLUDE_DIRECTORIES>)

--- a/tests/benchmarks/hostRegisterMemcpyOverhead.hip
+++ b/tests/benchmarks/hostRegisterMemcpyOverhead.hip
@@ -1,0 +1,70 @@
+#include <chrono>
+#include <cstring>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+#include <numeric>
+#include <algorithm>
+#include "hip/hip_runtime.h"
+
+#define CHECK(cmd)                                                             \
+  do {                                                                         \
+    hipError_t e = (cmd);                                                      \
+    if (e != hipSuccess) {                                                     \
+      std::cerr << "HIP error " << hipGetErrorString(e) << " at " << __FILE__ \
+                << ":" << __LINE__ << "\n";                                    \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (0)
+
+static constexpr int N_ITERS = 1000;
+static constexpr size_t BUF_SIZE = 1024 * 1024 * 4; // 4 MB
+
+int main() {
+  CHECK(hipSetDevice(0));
+
+  double *HostBuf = (double *)malloc(BUF_SIZE);
+  memset(HostBuf, 0, BUF_SIZE);
+
+  double *DevBuf;
+  CHECK(hipMalloc(&DevBuf, BUF_SIZE));
+
+  auto bench = [&](const char *label) {
+    std::vector<double> timings(N_ITERS);
+    CHECK(hipDeviceSynchronize());
+    for (int i = 0; i < N_ITERS; ++i) {
+      auto t0 = std::chrono::high_resolution_clock::now();
+      CHECK(hipMemcpy(DevBuf, HostBuf, BUF_SIZE, hipMemcpyHostToDevice));
+      CHECK(hipDeviceSynchronize());
+      auto t1 = std::chrono::high_resolution_clock::now();
+      timings[i] = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    }
+    double total = std::accumulate(timings.begin(), timings.end(), 0.0);
+    double avg   = total / N_ITERS;
+    double mn    = *std::min_element(timings.begin(), timings.end());
+    double mx    = *std::max_element(timings.begin(), timings.end());
+    std::cout << N_ITERS << " hipMemcpy H2D (" << BUF_SIZE / (1024 * 1024)
+              << " MB) " << label << ": "
+              << "avg=" << avg << " ms  min=" << mn << " ms  max=" << mx
+              << " ms\n";
+    return avg;
+  };
+
+  CHECK(hipHostRegister(HostBuf, BUF_SIZE, 0));
+  double avg_with = bench("WITH    hipHostRegister");
+  CHECK(hipHostUnregister(HostBuf));
+
+  double avg_without = bench("WITHOUT hipHostRegister");
+
+  std::cout << "overhead factor (avg): " << avg_with / avg_without << "x\n";
+
+  free(HostBuf);
+  CHECK(hipFree(DevBuf));
+
+  if (avg_with / avg_without > 5) {
+    printf("Fail\n");
+    return 1;
+  }
+  printf("Pass\n");
+  return 0;
+}

--- a/tests/benchmarks/hostRegisterOverhead.hip
+++ b/tests/benchmarks/hostRegisterOverhead.hip
@@ -2,6 +2,9 @@
 #include <cstring>
 #include <cstdlib>
 #include <iostream>
+#include <vector>
+#include <numeric>
+#include <algorithm>
 #include "hip/hip_runtime.h"
 
 #define CHECK(cmd)                                                             \
@@ -29,7 +32,10 @@ __global__ void bench_kernel() {}
 
 int main() {
   CHECK(hipSetDevice(0));
-
+  
+  std::vector<double> timings_registered(N_KERNELS);
+  std::vector<double> timings_unregistered(N_KERNELS);
+  
   double *HostBuf = (double *)malloc(BUF_SIZE);
   memset(HostBuf, 0, BUF_SIZE);
 
@@ -43,36 +49,45 @@ int main() {
   CHECK(hipHostRegister(HostBuf, BUF_SIZE, 0));
 
   CHECK(hipDeviceSynchronize());
-  auto t0 = std::chrono::high_resolution_clock::now();
   for (int i = 0; i < N_KERNELS; ++i) {
+    auto t0 = std::chrono::high_resolution_clock::now();
     KERNEL_LAUNCH(DevPtrPtr);
     CHECK(hipDeviceSynchronize());
+    auto t1 = std::chrono::high_resolution_clock::now();
+    timings_registered[i] = std::chrono::duration<double, std::milli>(t1 - t0).count();
   }
-  auto t1 = std::chrono::high_resolution_clock::now();
 
   CHECK(hipHostUnregister(HostBuf));
 
   // --- without hipHostRegister ---
   CHECK(hipDeviceSynchronize());
-  auto t2 = std::chrono::high_resolution_clock::now();
   for (int i = 0; i < N_KERNELS; ++i) {
+    auto t0 = std::chrono::high_resolution_clock::now();
     KERNEL_LAUNCH(DevPtrPtr);
     CHECK(hipDeviceSynchronize());
+    auto t1 = std::chrono::high_resolution_clock::now();
+    timings_unregistered[i] = std::chrono::duration<double, std::milli>(t1 - t0).count();
   }
-  auto t3 = std::chrono::high_resolution_clock::now();
 
   free(HostBuf);
   CHECK(hipFree(DevBuf));
   CHECK(hipFree(DevPtrPtr));
 
-  double with_ms    = std::chrono::duration<double, std::milli>(t1 - t0).count();
-  double without_ms = std::chrono::duration<double, std::milli>(t3 - t2).count();
+  double with_ms    = std::accumulate(timings_registered.begin(),timings_registered.end(),0.0);
+  double without_ms = std::accumulate(timings_unregistered.begin(),timings_unregistered.end(),0.0);
+
+  double min_with_ms    = *std::min_element(timings_registered.begin(),timings_registered.end());
+  double min_without_ms = *std::min_element(timings_unregistered.begin(),timings_unregistered.end());
+  double max_with_ms    = *std::max_element(timings_registered.begin(),timings_registered.end());
+  double max_without_ms = *std::max_element(timings_unregistered.begin(),timings_unregistered.end());
 
   std::cout << N_KERNELS << " " KERNEL_LABEL " WITH    hipHostRegister: "
-            << with_ms << " ms  (" << with_ms / N_KERNELS << " ms/kernel)\n";
+            << with_ms << " ms  (avg,min,max: " << with_ms / N_KERNELS
+	    << ", " << min_with_ms << ", " << max_with_ms << " ms)\n";
   std::cout << N_KERNELS << " " KERNEL_LABEL " WITHOUT hipHostRegister: "
-            << without_ms << " ms  (" << without_ms / N_KERNELS << " ms/kernel)\n";
-  std::cout << "overhead factor: " << with_ms / without_ms << "x\n";
+            << without_ms << " ms  (avg,min,max: " << without_ms / N_KERNELS
+	    << ", " << min_without_ms << ", " << max_without_ms << " ms)\n";
+  std::cout << "overhead factor (avg): " << with_ms / without_ms << "x\n";
 
   if(  with_ms / without_ms > 5 ) {
       printf( "Fail");

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -84,6 +84,8 @@ add_hip_runtime_test(TestStlFunctionsDouble.hip)
 add_hip_runtime_test(TestHIPMathFunctions.hip)
 add_hip_runtime_test(TestAtomics.hip)
 add_hip_runtime_test(TestIndirectMappedHostAlloc.hip)
+add_hip_runtime_test(TestHostRegisterGetDevicePointer.hip)
+add_hip_runtime_test(TestHostRegisterLazyAlloc.hip)
 add_hip_runtime_test(TestThreadDetachCleanup.cpp)
 
 add_shell_test(TestAssert.bash)

--- a/tests/runtime/TestHostRegisterGetDevicePointer.hip
+++ b/tests/runtime/TestHostRegisterGetDevicePointer.hip
@@ -1,0 +1,48 @@
+// Functional test: hipHostRegister + hipGetDevicePointer + kernel write-back.
+// Registers malloc'd host memory, obtains the device pointer, runs a kernel
+// that writes 1 to it, then verifies the host side sees the change.
+#include <hip/hip_runtime.h>
+#include <cstdio>
+#include <cstdlib>
+
+#define CHECK(cmd)                                                             \
+  do {                                                                         \
+    hipError_t e = (cmd);                                                      \
+    if (e != hipSuccess) {                                                     \
+      fprintf(stderr, "HIP error %s at %s:%d\n",                              \
+              hipGetErrorString(e), __FILE__, __LINE__);                       \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (0)
+
+__global__ void set_one(int *ptr) { *ptr = 1; }
+
+int main() {
+  hipDeviceProp_t prop;
+  int dev;
+  CHECK(hipGetDevice(&dev));
+  CHECK(hipGetDeviceProperties(&prop, dev));
+  if (!prop.canMapHostMemory) {
+    printf("HIP_SKIP_THIS_TEST: requires canMapHostMemory\n");
+    return CHIP_SKIP_TEST;
+  }
+
+  int *host = (int *)malloc(sizeof(int));
+  *host = 0;
+
+  CHECK(hipHostRegister(host, sizeof(int), hipHostRegisterMapped));
+
+  int *device;
+  CHECK(hipHostGetDevicePointer((void **)&device, host, 0));
+
+  set_one<<<dim3(1), dim3(1)>>>(device);
+  CHECK(hipDeviceSynchronize());
+
+  bool passed = (*host == 1);
+  printf("*host = %d — %s\n", *host, passed ? "PASSED" : "FAILED");
+
+  CHECK(hipHostUnregister(host));
+  free(host);
+
+  return passed ? 0 : 1;
+}

--- a/tests/runtime/TestHostRegisterGetDevicePointer.hip
+++ b/tests/runtime/TestHostRegisterGetDevicePointer.hip
@@ -30,7 +30,7 @@ int main() {
   int *host = (int *)malloc(sizeof(int));
   *host = 0;
 
-  CHECK(hipHostRegister(host, sizeof(int), hipHostRegisterMapped));
+  CHECK(hipHostRegister(host, sizeof(int), 0));
 
   int *device;
   CHECK(hipHostGetDevicePointer((void **)&device, host, 0));

--- a/tests/runtime/TestHostRegisterLazyAlloc.hip
+++ b/tests/runtime/TestHostRegisterLazyAlloc.hip
@@ -40,7 +40,7 @@ int main() {
   // --- 1. hipHostGetDevicePointer called twice returns the same pointer ------
   {
     int *host = (int *)malloc(sizeof(int));
-    CHECK(hipHostRegister(host, sizeof(int), hipHostRegisterMapped));
+    CHECK(hipHostRegister(host, sizeof(int), 0));
 
     int *devA, *devB;
     CHECK(hipHostGetDevicePointer((void **)&devA, host, 0));
@@ -55,7 +55,7 @@ int main() {
   // --- 2. Unregister without GetDevicePointer (no device allocation) ---------
   {
     int *host = (int *)malloc(sizeof(int));
-    CHECK(hipHostRegister(host, sizeof(int), hipHostRegisterMapped));
+    CHECK(hipHostRegister(host, sizeof(int), 0));
     CHECK(hipHostUnregister(host));
     free(host);
     printf("%-55s %s\n", "Unregister without GetDevicePointer", "PASSED");
@@ -65,7 +65,7 @@ int main() {
   {
     int *host = (int *)malloc(sizeof(int));
     *host = 99;
-    CHECK(hipHostRegister(host, sizeof(int), hipHostRegisterMapped));
+    CHECK(hipHostRegister(host, sizeof(int), 0));
 
     int *device;
     CHECK(hipHostGetDevicePointer((void **)&device, host, 0));

--- a/tests/runtime/TestHostRegisterLazyAlloc.hip
+++ b/tests/runtime/TestHostRegisterLazyAlloc.hip
@@ -1,0 +1,91 @@
+// Tests for lazy device allocation in hipHostRegister:
+//   1. hipHostGetDevicePointer called twice returns the same pointer.
+//   2. hipHostUnregister without hipHostGetDevicePointer does not crash or leak.
+//   3. hipMemset via the device pointer after hipHostGetDevicePointer is
+//      visible to a subsequent kernel.
+#include <hip/hip_runtime.h>
+#include <cstdio>
+#include <cstdlib>
+
+#define CHECK(cmd)                                                             \
+  do {                                                                         \
+    hipError_t e = (cmd);                                                      \
+    if (e != hipSuccess) {                                                     \
+      fprintf(stderr, "HIP error %s at %s:%d\n",                              \
+              hipGetErrorString(e), __FILE__, __LINE__);                       \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (0)
+
+#define REPORT(label, cond)                                                    \
+  do {                                                                         \
+    printf("%-55s %s\n", label, (cond) ? "PASSED" : "FAILED");                \
+    passed &= (cond);                                                          \
+  } while (0)
+
+__global__ void read_val(int *out, int *in) { *out = *in; }
+
+int main() {
+  hipDeviceProp_t prop;
+  int dev;
+  CHECK(hipGetDevice(&dev));
+  CHECK(hipGetDeviceProperties(&prop, dev));
+  if (!prop.canMapHostMemory) {
+    printf("HIP_SKIP_THIS_TEST: requires canMapHostMemory\n");
+    return CHIP_SKIP_TEST;
+  }
+
+  bool passed = true;
+
+  // --- 1. hipHostGetDevicePointer called twice returns the same pointer ------
+  {
+    int *host = (int *)malloc(sizeof(int));
+    CHECK(hipHostRegister(host, sizeof(int), hipHostRegisterMapped));
+
+    int *devA, *devB;
+    CHECK(hipHostGetDevicePointer((void **)&devA, host, 0));
+    CHECK(hipHostGetDevicePointer((void **)&devB, host, 0));
+
+    REPORT("GetDevicePointer x2 returns same pointer", devA == devB);
+
+    CHECK(hipHostUnregister(host));
+    free(host);
+  }
+
+  // --- 2. Unregister without GetDevicePointer (no device allocation) ---------
+  {
+    int *host = (int *)malloc(sizeof(int));
+    CHECK(hipHostRegister(host, sizeof(int), hipHostRegisterMapped));
+    CHECK(hipHostUnregister(host));
+    free(host);
+    printf("%-55s %s\n", "Unregister without GetDevicePointer", "PASSED");
+  }
+
+  // --- 3. hipMemset after GetDevicePointer is visible to a kernel ------------
+  {
+    int *host = (int *)malloc(sizeof(int));
+    *host = 99;
+    CHECK(hipHostRegister(host, sizeof(int), hipHostRegisterMapped));
+
+    int *device;
+    CHECK(hipHostGetDevicePointer((void **)&device, host, 0));
+
+    CHECK(hipMemset(device, 0, sizeof(int)));
+
+    int *result;
+    CHECK(hipMalloc(&result, sizeof(int)));
+    read_val<<<dim3(1), dim3(1)>>>(result, device);
+    CHECK(hipDeviceSynchronize());
+
+    int got;
+    CHECK(hipMemcpy(&got, result, sizeof(int), hipMemcpyDeviceToHost));
+    REPORT("hipMemset after GetDevicePointer visible to kernel", got == 0);
+
+    CHECK(hipFree(result));
+    CHECK(hipHostUnregister(host));
+    free(host);
+  }
+
+  printf("\nOverall: %s\n", passed ? "PASSED" : "FAILED");
+  return passed ? 0 : 1;
+}


### PR DESCRIPTION
This is to help out with https://github.com/CHIP-SPV/chipStar/issues/1260.

By the CUDA/HIP spec, hipHostRegister says to pin and map the host memory to the device, so that there’s device memory backing it. But there’s no need to allocate backing device memory until the user actually calls hipHostGetDevicePointer on the registered host memory — one can't use the device memory without getting the device pointer. So we can be “lazy” in that we wait until the user calls hipHostGetDevicePointer before allocating it. This is useful since in applications like OpenSn, hipHostRegister may be used just for the performance boost of registering the memory before a copy and they don’t ever touch the device memory explicitly. This PR changes hipHostRegister to just note down the registered host memory, but it does not allocate it until a call to hipHostGetDevicePointer.

This changes the kernel launch to only do the mapping from registered host pointer to associated device pointer if the DevPtr in the AllocInfo is not null, since it will be null until hipHostGetDevicePointer is called on the host pointer.

Suggestions are welcome! 

Side note: I encountered an issue with the `Unit_hipFreeNegativeHost` HIP test, and I think the test is incorrect. More information here: https://github.com/CHIP-SPV/HIP/issues/14 .