### PR TITLE
Implement hipModuleLoad (file-based loader) instead of a no-op stub

### DIFF
--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -6258,27 +6258,22 @@ hipError_t hipModuleLoad(hipModule_t *Module, const char *FuncName) {
   CHIPInitialize();
   NULLCHECK(Module, FuncName);
 
-#if 0
-  // TODO: This is likely bit-rotted (due to lack of testing).
-  //       Reimplement this again.
-
+  // The file is a Clang offload bundle, identical in format to the image
+  // accepted by hipModuleLoadData, so read it and reuse the same load path.
+  // (Previously this function was a no-op stub: it returned hipSuccess
+  // without initializing *Module, leaving callers with a garbage module
+  // handle that produced a "kernel not found" error or a segfault.)
   std::ifstream ModuleFile(FuncName,
                            std::ios::in | std::ios::binary | std::ios::ate);
   ERROR_IF((ModuleFile.fail()), hipErrorFileNotFound);
 
   size_t Size = ModuleFile.tellg();
-  char *MemBlock = new char[Size];
+  std::string Content(Size, '\0');
   ModuleFile.seekg(0, std::ios::beg);
-  ModuleFile.read(MemBlock, Size);
+  ModuleFile.read(&Content[0], Size);
   ModuleFile.close();
-  std::string Content(MemBlock, Size);
-  delete[] MemBlock;
 
-  // chipstar::Module *chip_module = new Module(std::move(content));
-  for (auto &Dev : Backend->getDevices())
-    Dev->addModule(&Content);
-#endif
-  RETURN(hipSuccess);
+  RETURN(hipModuleLoadDataInternal(Module, Content.data()));
   CHIP_CATCH
 }
 

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -89,6 +89,7 @@ add_hip_runtime_test(TestThreadDetachCleanup.cpp)
 add_shell_test(TestAssert.bash)
 add_shell_test(TestAssertFail.bash)
 add_shell_test(TestForgottenModuleUnload.bash)
+add_shell_test(TestModuleLoadFromFile.bash)
 add_shell_test(TestLinkHiprtc.bash)
 
 add_hip_runtime_test(TestIndirectCall.hip)

--- a/tests/runtime/TestModuleLoadFromFile.bash
+++ b/tests/runtime/TestModuleLoadFromFile.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Regression test for hipModuleLoad (file-based loader).
+# See inputs/TestModuleLoadFromFile.hip.
+set -eu
+
+SRC_DIR=@CMAKE_CURRENT_SOURCE_DIR@
+OUT_DIR=@CMAKE_CURRENT_BINARY_DIR@/@TEST_NAME@.d
+HIPCC=@CMAKE_BINARY_DIR@/bin/hipcc
+
+mkdir -p ${OUT_DIR}
+cd ${OUT_DIR}
+
+${HIPCC} ${SRC_DIR}/inputs/TestModuleLoadFromFile.hip -o prog
+
+CHIP_LOGLEVEL=warn ./prog ${SRC_DIR}/inputs/Module.bin

--- a/tests/runtime/inputs/TestModuleLoadFromFile.hip
+++ b/tests/runtime/inputs/TestModuleLoadFromFile.hip
@@ -1,0 +1,30 @@
+// Regression test: hipModuleLoad (the file-based module loader) used to be a
+// no-op stub whose body was #if 0'd out. It returned hipSuccess without ever
+// initializing *Module, so callers received a garbage/null module handle and a
+// subsequent hipModuleGetFunction reported "kernel not found" or segfaulted.
+// This test loads a valid module file and resolves a known kernel from it.
+#include <hip/hip_runtime_api.h>
+#include <cstdio>
+
+int main(int ArgC, char *ArgV[]) {
+  if (ArgC != 2) {
+    printf("usage: %s <module-file>\n", ArgV[0]);
+    return 2;
+  }
+  hipModule_t Module = nullptr;
+  if (hipModuleLoad(&Module, ArgV[1]) != hipSuccess) {
+    printf("FAIL: hipModuleLoad returned an error\n");
+    return 3;
+  }
+  if (Module == nullptr) {
+    printf("FAIL: hipModuleLoad returned success but left Module unset\n");
+    return 4;
+  }
+  hipFunction_t Fn = nullptr;
+  if (hipModuleGetFunction(&Fn, Module, "add1") != hipSuccess || Fn == nullptr) {
+    printf("FAIL: hipModuleGetFunction(add1) failed after hipModuleLoad\n");
+    return 5;
+  }
+  printf("PASS: hipModuleLoad + hipModuleGetFunction resolved 'add1'\n");
+  return 0;
+}


### PR DESCRIPTION
hipModuleLoad was a no-op stub that returned hipSuccess without initializing \*Module, causing callers to get a null/garbage handle that failed kernel lookup or segfaulted; this reads the module file and delegates to the working hipModuleLoadDataInternal, with a regression test, verified on Intel PVC (Aurora).