### PR TITLE
Expose hipDeviceAttributeHostNativeAtomicSupported

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -916,6 +916,9 @@ int chipstar::Device::getAttr(hipDeviceAttribute_t Attr) const {
   case hipDeviceAttributeMemoryPoolsSupported:
     return Prop.memoryPoolsSupported;
     break;
+  case hipDeviceAttributeHostNativeAtomicSupported:
+    return Prop.hostNativeAtomicSupported;
+    break;
   default:
     CHIPERR_LOG_AND_THROW("Device::getAttr asked for an unkown attribute",
                           hipErrorInvalidValue);

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -232,3 +232,4 @@ add_hip_runtime_test(TestEventResetWarnFlood.hip)
 set_tests_properties(TestEventResetWarnFlood PROPERTIES
   ENVIRONMENT "CHIP_LOGLEVEL=warn"
   FAIL_REGULAR_EXPRESSION "FAIL;reset\\(\\) called while event is recording")
+add_hip_runtime_test(TestFixHostNativeAtomicSupported.hip)

--- a/tests/runtime/TestFixHostNativeAtomicSupported.hip
+++ b/tests/runtime/TestFixHostNativeAtomicSupported.hip
@@ -1,0 +1,18 @@
+// Reproduces: hipDeviceGetAttribute(hipDeviceAttributeHostNativeAtomicSupported)
+// throws hipErrorInvalidValue because chipstar::Device::getAttr() has no case
+// for this attribute, even though hipDeviceProp_t::hostNativeAtomicSupported is
+// populated. CUDA/ROCm expose this attribute; consumers (e.g. PyTorch, HecBench
+// atomicSystemWide) call it to gate code paths.
+
+#include <hip/hip_runtime.h>
+#include <cstdio>
+
+int main() {
+  int value = -1;
+  hipError_t err =
+      hipDeviceGetAttribute(&value, hipDeviceAttributeHostNativeAtomicSupported, 0);
+  int pass = (err == hipSuccess) && (value == 0 || value == 1);
+  printf("hipDeviceAttributeHostNativeAtomicSupported: err=%d value=%d => %s\n",
+         (int)err, value, pass ? "PASS" : "FAIL");
+  return pass ? 0 : 1;
+}


### PR DESCRIPTION
Maps hipDeviceAttributeHostNativeAtomicSupported to hipDeviceProp_t::hostNativeAtomicSupported in chipstar::Device::getAttr() so callers receive 0/1 instead of hipErrorInvalidValue.