### PR TITLE
coalesced_threads: size-1 fallback so warp-aggregated atomics work on SPIR-V

### DIFF
--- a/include/hip/spirv_hip_cooperative_groups.h
+++ b/include/hip/spirv_hip_cooperative_groups.h
@@ -434,6 +434,12 @@ public:
   template <class T> __CG_QUALIFIER__ T shfl(T var, int srcRank) const {
     static_assert(is_valid_type<T>::value, "Neither an integer or float type.");
 
+    // Singleton coalesced group (chipStar SPIR-V fallback when the active-
+    // lane mask is unavailable): the only valid source rank is 0 and the
+    // result is the caller's own value.
+    if (size() == 1)
+      return var;
+
     srcRank = srcRank % static_cast<int>(size());
 
     int lane = (size() == __AMDGCN_WAVEFRONT_SIZE) ? srcRank
@@ -508,7 +514,12 @@ public:
  */
 
 __CG_QUALIFIER__ coalesced_group coalesced_threads() {
-  return cooperative_groups::coalesced_group(__builtin_amdgcn_read_exec());
+  // chipStar's SPIR-V backend has no way to query the active-lane mask
+  // (the AMDGCN exec register), so we conservatively model each thread
+  // as its own coalesced group of size 1. This keeps semantics correct
+  // for common patterns such as warp-aggregated atomics (atomicAggInc)
+  // at the cost of the warp-level optimisation.
+  return cooperative_groups::coalesced_group(static_cast<lane_mask>(1));
 }
 
 /**

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_hip_test(test_stream_wait_event_sync.cpp)
 add_hip_test(test_hipMemcpyHtoD_link.cpp)
 add_hip_test(test_atomicmax_unsigned.cpp)
+add_hip_test(TestFixCoalescedThreadsAtomicAggInc.hip)
+set_tests_properties(TestFixCoalescedThreadsAtomicAggInc PROPERTIES PASS_REGULAR_EXPRESSION "PASS" FAIL_REGULAR_EXPRESSION "FAIL")

--- a/tests/regression/TestFixCoalescedThreadsAtomicAggInc.hip
+++ b/tests/regression/TestFixCoalescedThreadsAtomicAggInc.hip
@@ -1,0 +1,59 @@
+// Reproduces: cooperative_groups::coalesced_threads() relies on the AMDGCN
+// exec register (__builtin_amdgcn_read_exec) to identify active lanes in
+// the current warp. chipStar's SPIR-V backend has no way to query the
+// active-lane mask, and the existing stub returns 0 -> empty group with
+// size()==0. Any warp-aggregated pattern that uses g.size() then degenerates
+// silently:
+//
+//   __device__ int atomicAggInc(int *ctr) {
+//     auto g = cooperative_groups::coalesced_threads();
+//     // g.size() returns 0 before the fix
+//     return atomicAdd(ctr, (int)g.size());
+//   }
+//
+// Without the fix every thread's atomicAdd contributes 0, so the global
+// counter never advances. The fix is to model each thread as its own
+// coalesced group of size 1, which keeps semantics correct (every thread
+// performs an atomicAdd(ctr, 1)) at the cost of warp-level aggregation.
+//
+// Surfaced by HeCBench filter-hip.
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_cooperative_groups.h>
+#include <cstdio>
+
+namespace cg = cooperative_groups;
+
+__global__ void agg_count(int *ctr, int n) {
+  int gid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (gid >= n) return;
+  cg::coalesced_group g = cg::coalesced_threads();
+  // Use only .size() and .thread_rank() — both must be >= 1 for an
+  // active lane. The buggy stub makes both 0 because the underlying
+  // member_mask is 0.
+  if (g.thread_rank() == 0)
+    atomicAdd(ctr, (int)g.size());
+}
+
+int main() {
+  const int N = 1024;
+  int *d_ctr;
+  hipMalloc(&d_ctr, sizeof(int));
+  hipMemset(d_ctr, 0, sizeof(int));
+
+  agg_count<<<(N + 63) / 64, 64>>>(d_ctr, N);
+  hipDeviceSynchronize();
+
+  int counter = -1;
+  hipMemcpy(&counter, d_ctr, sizeof(int), hipMemcpyDeviceToHost);
+
+  // After the fix, every thread forms a singleton group with size()==1
+  // and thread_rank()==0, so every thread adds 1 -> counter == N.
+  // Before the fix, size()==0 so atomicAdd adds 0 -> counter == 0.
+  int ok = (counter == N);
+  printf("agg counter: %d (expected %d) => %s\n", counter, N,
+         ok ? "PASS" : "FAIL");
+
+  hipFree(d_ctr);
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
Replaces the size()==0 stub of cooperative_groups::coalesced_threads() with a size-1 singleton group, so patterns like atomicAggInc behave correctly instead of silently degenerating to all-threads-write-dst[0].