### PR TITLE
Fix atomicMax<unsigned int> emitting signed OpAtomicSMax

### DIFF
--- a/bitcode/devicelib.cl
+++ b/bitcode/devicelib.cl
@@ -590,29 +590,29 @@ EXPORT long __chip_ctz_li(long var) { return ctz(var); }
 */
 
 #define DEF_CHIP_ATOMIC2_ORDER_SCOPE(NAME, OP, ORDER, SCOPE)                  \
-  int OVLD atomic_##OP##_explicit (volatile __generic int *, int,             \
+  int OVLD atomic_##OP##_explicit (volatile __generic atomic_int *, int,      \
                                    memory_order order, memory_scope scope);   \
-  uint OVLD atomic_##OP##_explicit (volatile __generic uint *, uint,          \
+  uint OVLD atomic_##OP##_explicit (volatile __generic atomic_uint *, uint,   \
                                     memory_order order, memory_scope scope);  \
-  ulong OVLD atomic_##OP##_explicit (volatile __generic ulong *, ulong,       \
+  ulong OVLD atomic_##OP##_explicit (volatile __generic atomic_ulong *, ulong,\
                                      memory_order order, memory_scope scope); \
   int __chip_atomic_##NAME##_i (DEFAULT_AS int *address, int i)               \
   {                                                                           \
-    return atomic_##OP##_explicit ((volatile __generic int *)address, i,      \
-                                   memory_order_##ORDER,                      \
-                                   memory_scope_##SCOPE);                     \
+    return atomic_##OP##_explicit (                                           \
+        (volatile __generic atomic_int *)address, i,                          \
+        memory_order_##ORDER, memory_scope_##SCOPE);                          \
   }                                                                           \
   uint __chip_atomic_##NAME##_u (DEFAULT_AS uint *address, uint ui)           \
   {                                                                           \
-    return atomic_##OP##_explicit ((volatile __generic uint *)address, ui,    \
-                                   memory_order_##ORDER,                      \
-                                   memory_scope_##SCOPE);                     \
+    return atomic_##OP##_explicit (                                           \
+        (volatile __generic atomic_uint *)address, ui,                        \
+        memory_order_##ORDER, memory_scope_##SCOPE);                          \
   }                                                                           \
   ulong __chip_atomic_##NAME##_l (DEFAULT_AS ulong *address, ulong ull)       \
   {                                                                           \
-    return atomic_##OP##_explicit ((volatile __generic ulong *)address, ull,  \
-                                   memory_order_##ORDER,                      \
-                                   memory_scope_##SCOPE);                     \
+    return atomic_##OP##_explicit (                                           \
+        (volatile __generic atomic_ulong *)address, ull,                      \
+        memory_order_##ORDER, memory_scope_##SCOPE);                          \
   }
 
 // CUDA's atomicAdd / atomicSub / atomicMin / ... provide atomicity only,

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_hip_test(test_stream_wait_event_sync.cpp)
 add_hip_test(test_hipMemcpyHtoD_link.cpp)
+add_hip_test(test_atomicmax_unsigned.cpp)

--- a/tests/regression/test_atomicmax_unsigned.cpp
+++ b/tests/regression/test_atomicmax_unsigned.cpp
@@ -1,0 +1,108 @@
+// Regression test: atomicMax<unsigned int> must use unsigned comparison.
+//
+// chipStar's bitcode/devicelib.cl declared atomic_fetch_max_explicit with
+// `uint *` instead of `atomic_uint *`. SPIRV-LLVM-Translator's
+// containsUnsignedAtomicType() inspects the *Itanium mangling* and only
+// recognizes an unsigned-atomic operation when the pointer is `_Atomic uint`
+// (mangled `U7_Atomic`). Without that, the translator emits OpAtomicSMax
+// instead of OpAtomicUMax — so `atomicMax<unsigned int>(...)` on values
+// with the high bit set used signed comparison and produced wrong results
+// (e.g. it considered 0x80000001u "less than" 0x7fffffffu).
+//
+// This test exercises the wrong-result case end-to-end on the device.
+//
+// See: bitcode/devicelib.cl  (DEF_CHIP_ATOMIC2 macros)
+
+#include <hip/hip_runtime.h>
+#include <cstdio>
+
+__global__ void k_single(unsigned int *out, unsigned int v) {
+    atomicMax(out, v);
+}
+
+__global__ void k_two_threads(unsigned int *out) {
+    unsigned int v = (threadIdx.x == 0) ? 0x80000001u : 0xfffffff0u;
+    atomicMax(out, v);
+}
+
+__global__ void k_many(unsigned int *out, const unsigned int *vals, int n) {
+    int tid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (tid < n) atomicMax(out, vals[tid]);
+}
+
+#define CHK(x) do { hipError_t e = (x); if (e != hipSuccess) { \
+    fprintf(stderr, "HIP error %d at %s:%d\n", (int)e, __FILE__, __LINE__); \
+    return 2; } } while(0)
+
+int main() {
+    int fails = 0;
+
+    // T1: initial 0x7fffffff, atomicMax with 0x80000001 -> expect 0x80000001
+    {
+        unsigned int *d_out;
+        CHK(hipMalloc(&d_out, sizeof(unsigned int)));
+        unsigned int init = 0x7fffffffu;
+        CHK(hipMemcpy(d_out, &init, sizeof(init), hipMemcpyHostToDevice));
+        k_single<<<1, 1>>>(d_out, 0x80000001u);
+        CHK(hipDeviceSynchronize());
+        unsigned int r = 0;
+        CHK(hipMemcpy(&r, d_out, sizeof(r), hipMemcpyDeviceToHost));
+        unsigned int expected = 0x80000001u;
+        int ok = (r == expected);
+        printf("[T1] init=0x%08x arg=0x%08x got=0x%08x expected=0x%08x %s\n",
+               init, 0x80000001u, r, expected, ok ? "PASS" : "FAIL");
+        if (!ok) ++fails;
+        CHK(hipFree(d_out));
+    }
+
+    // T2: two threads, both high-bit-set values
+    {
+        unsigned int *d_out;
+        CHK(hipMalloc(&d_out, sizeof(unsigned int)));
+        unsigned int init = 0u;
+        CHK(hipMemcpy(d_out, &init, sizeof(init), hipMemcpyHostToDevice));
+        k_two_threads<<<1, 2>>>(d_out);
+        CHK(hipDeviceSynchronize());
+        unsigned int r = 0;
+        CHK(hipMemcpy(&r, d_out, sizeof(r), hipMemcpyDeviceToHost));
+        unsigned int expected = 0xfffffff0u;
+        int ok = (r == expected);
+        printf("[T2] init=0x%08x got=0x%08x expected=0x%08x %s\n",
+               init, r, expected, ok ? "PASS" : "FAIL");
+        if (!ok) ++fails;
+        CHK(hipFree(d_out));
+    }
+
+    // T3: many threads, mix of low/high values
+    {
+        const int N = 1024;
+        unsigned int *d_vals, *d_out;
+        CHK(hipMalloc(&d_vals, N * sizeof(unsigned int)));
+        CHK(hipMalloc(&d_out, sizeof(unsigned int)));
+        unsigned int *h_vals = new unsigned int[N];
+        unsigned int expected = 0;
+        for (int i = 0; i < N; ++i) {
+            if (i == 500) h_vals[i] = 0xfffffffeu;
+            else if (i % 3 == 0) h_vals[i] = 0x80000000u + (unsigned)i;
+            else h_vals[i] = (unsigned)i * 7u;
+            if (h_vals[i] > expected) expected = h_vals[i];
+        }
+        CHK(hipMemcpy(d_vals, h_vals, N * sizeof(unsigned int), hipMemcpyHostToDevice));
+        unsigned int init = 0u;
+        CHK(hipMemcpy(d_out, &init, sizeof(init), hipMemcpyHostToDevice));
+        k_many<<<(N + 63) / 64, 64>>>(d_out, d_vals, N);
+        CHK(hipDeviceSynchronize());
+        unsigned int r = 0;
+        CHK(hipMemcpy(&r, d_out, sizeof(r), hipMemcpyDeviceToHost));
+        int ok = (r == expected);
+        printf("[T3] got=0x%08x expected=0x%08x %s\n", r, expected,
+               ok ? "PASS" : "FAIL");
+        if (!ok) ++fails;
+        delete[] h_vals;
+        CHK(hipFree(d_vals));
+        CHK(hipFree(d_out));
+    }
+
+    printf("\n%d test(s) failed\n", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
chipStar's atomic primitive macros declared OpenCL atomic builtins with plain pointer types so the SPIR-V translator's unsigned-atomic detection (which keys off the `U7_Atomic` substring in the mangled name) missed the unsigned overloads and emitted signed `OpAtomicSMax` / `OpAtomicSMin` instead — fixed by switching to typed `atomic_uint*` / `atomic_int*` / `atomic_ulong*` pointers in `DEF_CHIP_ATOMIC2_ORDER_SCOPE`.