### PR TITLE
Restore hipPointerAttribute_t::memoryType as union alias for type

### DIFF
--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -102,6 +102,7 @@ add_hip_runtime_test(TestHipInit.hip)
 add_shell_test(TestRuntimeWarnings.bash)
 
 add_hip_runtime_test(TestAPIs.hip)
+add_hip_runtime_test(TestHipPointerAttributesMemoryType.hip)
 add_hip_runtime_test(TestMemFunctions.hip)
 add_hip_runtime_test(TestAlignAttrRuntime.hip)
 

--- a/tests/runtime/TestHipPointerAttributesMemoryType.hip
+++ b/tests/runtime/TestHipPointerAttributesMemoryType.hip
@@ -1,0 +1,39 @@
+// Verify that hipPointerAttribute_t exposes both 'type' (CUDA-aligned name)
+// and 'memoryType' (deprecated AMD/ROCm name) as aliases for the same field.
+// Many older HIP/ROCm and ported CUDA codebases (e.g. HecBench's
+// warpselect-hip/DeviceUtils.cu) read `attr.memoryType` and fail to compile
+// when only `type` is provided. AMD historically kept both via an anonymous
+// union (see ROCm/HIP commit 99c48bfc / SWDEV-399623), which we mirror.
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <hip/hip_runtime.h>
+#include <cassert>
+#include <iostream>
+
+int main() {
+  void *dPtr = nullptr;
+  assert(hipMalloc(&dPtr, 1024) == hipSuccess);
+
+  hipPointerAttribute_t attr{};
+  assert(hipPointerGetAttributes(&attr, dPtr) == hipSuccess);
+
+  // Both names must compile and must refer to the same storage. The exact
+  // memory-type value chipStar reports for hipMalloc'd memory is backend-
+  // dependent (Device on real GPUs, but possibly Managed/Unified on pocl-CPU
+  // where the device is the host), so don't assert on a specific enum value —
+  // only that the two names see identical bits.
+  static_assert(sizeof(attr.type) == sizeof(attr.memoryType),
+                "type and memoryType must alias the same field");
+  assert(static_cast<int>(attr.type) == static_cast<int>(attr.memoryType));
+
+  // Writing through one alias must be visible via the other.
+  attr.memoryType = hipMemoryTypeHost;
+  assert(attr.type == hipMemoryTypeHost);
+  attr.type = hipMemoryTypeDevice;
+  assert(attr.memoryType == hipMemoryTypeDevice);
+
+  assert(hipFree(dPtr) == hipSuccess);
+  std::cout << "PASSED\n";
+  return 0;
+}


### PR DESCRIPTION
Many existing HIP and HecBench applications (e.g. warpselect-hip/DeviceUtils.cu) read the historical `hipPointerAttribute_t::memoryType` field that AMD removed in ROCm commit 99c48bfc (SWDEV-399623, Aug 2023) in favor of `type` — restore the layout via an anonymous union so both names alias the same storage and both old and new code compile.