### PR TITLE
[L0] allow >4 GiB single allocations on Intel GPUs

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1360,13 +1360,20 @@ void *chipstar::Context::allocate(size_t Size, size_t Alignment,
     return HostPtr;
   }
 
+  // NOTE: Drivers (Intel L0/OpenCL on discrete GPUs) commonly report a
+  // conservative CL_DEVICE_MAX_MEM_ALLOC_SIZE / ze_device_properties.maxMemAllocSize
+  // (often 4 GiB) even though larger single allocations are achievable via
+  // Level Zero relaxed allocation limits or Intel USM. Rather than rejecting
+  // the request up-front, log a warning when exceeding the reported cap and
+  // let the backend allocator attempt the allocation. The backend
+  // (CHIPContextLevel0::allocateImpl / CHIPContextOpenCL::allocateImpl) will
+  // pass the appropriate relaxed flags and surface a real OOM if the driver
+  // truly cannot satisfy the request.
   if (Size > ChipDev->getMaxMallocSize()) {
-    logCritical("Requested allocation of {} exceeds the maximum size of a "
-                "single allocation of {}",
-                Size, ChipDev->getMaxMallocSize());
-    CHIPERR_LOG_AND_THROW(
-        "Allocation size exceeds limits for a single allocation",
-        hipErrorOutOfMemory);
+    logWarn("Requested allocation of {} exceeds the device-reported maximum "
+            "single-allocation size of {}; attempting with relaxed allocation "
+            "limits.",
+            Size, ChipDev->getMaxMallocSize());
   }
   assert(ChipDev->getContext() == this);
 

--- a/src/CHIPDriver.cc
+++ b/src/CHIPDriver.cc
@@ -52,6 +52,19 @@ std::atomic_ulong CHIPNumRegisteredFatBinaries;
 
 EnvVars ChipEnvVars;
 
+// Best-effort: enable Intel Compute Runtime (NEO) "unrestricted size"
+// allocations so that single OpenCL/L0 allocations larger than the device's
+// reported maxMemAllocSize (e.g. the 4 GiB cap on Arc / Data Center GPUs)
+// succeed when sufficient device memory is available. These env vars are
+// honored only by Intel's NEO driver and ignored elsewhere; setting them
+// before any OpenCL/L0 driver call (via a static initializer) is required
+// so that the driver picks them up at load time. Using setenv with
+// overwrite=0 preserves any user-provided override.
+__attribute__((constructor(101))) static void chipEnableNeoLargeAlloc() {
+  setenv("NEOReadDebugKeys", "1", /*overwrite=*/0);
+  setenv("AllowUnrestrictedSize", "1", /*overwrite=*/0);
+}
+
 // CUDA Driver API: "If cuInit() has not been called, any function
 // from the driver API will return CUDA_ERROR_NOT_INITIALIZED".
 //

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -2435,9 +2435,20 @@ void *CHIPContextLevel0::allocateImpl(size_t Size, size_t Alignment,
   ze_device_mem_alloc_flags_t DeviceFlags =
       ZE_DEVICE_MEM_ALLOC_FLAG_BIAS_CACHED;
 
+  // Always opt into the relaxed allocation limits extension so single
+  // allocations larger than ze_device_properties.maxMemAllocSize (e.g. the
+  // 4 GiB cap reported by Intel Arc / Data Center GPU drivers) succeed when
+  // sufficient device memory is available. The descriptor is harmless for
+  // smaller allocations.
+  ze_relaxed_allocation_limits_exp_desc_t RelaxedDesc{
+      /* stype = */ ZE_STRUCTURE_TYPE_RELAXED_ALLOCATION_LIMITS_EXP_DESC,
+      /* pNext = */ nullptr,
+      /* flags = */ ZE_RELAXED_ALLOCATION_LIMITS_EXP_FLAG_MAX_SIZE,
+  };
+
   ze_device_mem_alloc_desc_t DmaDesc{
       /* DmaDesc.stype   = */ ZE_STRUCTURE_TYPE_DEVICE_MEM_ALLOC_DESC,
-      /* DmaDesc.pNext   = */ nullptr,
+      /* DmaDesc.pNext   = */ &RelaxedDesc,
       /* DmaDesc.flags   = */ DeviceFlags,
       /* DmaDesc.ordinal = */ 0,
   };
@@ -2446,7 +2457,7 @@ void *CHIPContextLevel0::allocateImpl(size_t Size, size_t Alignment,
     HostFlags += ZE_HOST_MEM_ALLOC_FLAG_BIAS_WRITE_COMBINED;
   ze_host_mem_alloc_desc_t HmaDesc{
       /* HmaDesc.stype = */ ZE_STRUCTURE_TYPE_HOST_MEM_ALLOC_DESC,
-      /* HmaDesc.pNext = */ nullptr,
+      /* HmaDesc.pNext = */ &RelaxedDesc,
       /* HmaDesc.flags = */ HostFlags,
   };
   if (MemTy == hipMemoryType::hipMemoryTypeUnified) {


### PR DESCRIPTION
Permit single device allocations larger than the driver-reported 4 GiB cap on Intel Arc / Data Center GPUs via ZE_RELAXED_ALLOCATION_LIMITS and NEO unrestricted-size env vars.