### PR TITLE
[backend] disable IGC RetryManager recompilation

### DIFF
--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -3197,6 +3197,20 @@ void CHIPModuleLevel0::compile(chipstar::Device *ChipDev) {
   auto Flags = ChipEnvVars.hasJitOverride() ? ChipEnvVars.getJitFlagsOverride()
                                             : ChipEnvVars.getJitFlags() + " " +
                                                   Backend->getDefaultJitFlags();
+  // On Intel GPUs, IGC's RetryManager can convert high-register-pressure
+  // kernels into stack-call functions and merge them into a single
+  // Intel_Symbol_Table_Void_Program "kernel", making the originals invisible
+  // to zeModuleGetKernelNames / clCreateKernels. Disable IGC recompilation
+  // to keep all OpEntryPoint Kernel entries as standalone kernels.
+  ze_device_properties_t DevProps{};
+  DevProps.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
+  bool IsIntelGPU = false;
+  if (zeDeviceGetProperties(LzDev->get(), &DevProps) == ZE_RESULT_SUCCESS) {
+    IsIntelGPU = (DevProps.vendorId == 0x8086) &&
+                 (DevProps.type == ZE_DEVICE_TYPE_GPU);
+  }
+  if (IsIntelGPU && Flags.find("DisableRecompilation") == std::string::npos)
+    Flags += " -igc_opts 'DisableRecompilation=1'";
   logInfo("JIT flags: {}", Flags);
   std::vector<const char *> BuildFlags(1, Flags.c_str());
 

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -918,6 +918,16 @@ static cl::Program compileIL(cl::Context Ctx, CHIPDeviceOpenCL &ChipDev,
   auto Flags = ChipEnvVars.hasJitOverride() ? ChipEnvVars.getJitFlagsOverride()
                                             : ChipEnvVars.getJitFlags() + " " +
                                                   Backend->getDefaultJitFlags();
+  // See note in CHIPModuleOpenCL::compile() — disable IGC recompilation on
+  // Intel GPUs to prevent the RetryManager from collapsing high-register-
+  // pressure kernels into Intel_Symbol_Table_Void_Program (stack-call ABI),
+  // which makes them invisible to clCreateKernels.
+  std::string IlVendor = ChipDev.get()->getInfo<CL_DEVICE_VENDOR>();
+  bool IlIsIntelGPU =
+      (IlVendor.find("Intel") != std::string::npos) &&
+      (ChipDev.get()->getInfo<CL_DEVICE_TYPE>() & CL_DEVICE_TYPE_GPU);
+  if (IlIsIntelGPU && Flags.find("DisableRecompilation") == std::string::npos)
+    Flags += " -igc_opts 'DisableRecompilation=1'";
   logInfo("JIT flags: {}", Flags);
   Err = clCompileProgram(Prog.get(), 1, &DevId, Flags.c_str(), 0, nullptr,
                          nullptr, nullptr, nullptr);
@@ -1260,6 +1270,19 @@ void CHIPModuleOpenCL::compile(chipstar::Device *ChipDev) {
                        ? ChipEnvVars.getJitFlagsOverride()
                        : ChipEnvVars.getJitFlags() + " " +
                              Backend->getDefaultJitFlags();
+      // On Intel GPUs (IGC), if a kernel has high register pressure (e.g.,
+      // very large argument lists), IGC's RetryManager may recompile it with
+      // a stack-call ABI. The recompiled kernels are then merged into a
+      // single Intel_Symbol_Table_Void_Program section and are no longer
+      // exposed via clCreateKernels, causing host-side launch lookups to
+      // fail. Disable IGC recompilation to keep all OpEntryPoint Kernel
+      // entries as standalone, callable OpenCL kernels.
+      std::string Vendor = ChipDevOcl->get()->getInfo<CL_DEVICE_VENDOR>();
+      bool IsIntelGPU =
+          (Vendor.find("Intel") != std::string::npos) &&
+          (ChipDevOcl->get()->getInfo<CL_DEVICE_TYPE>() & CL_DEVICE_TYPE_GPU);
+      if (IsIntelGPU && Flags.find("DisableRecompilation") == std::string::npos)
+        Flags += " -igc_opts 'DisableRecompilation=1'";
       Err = clBuildProgram(Program_.get(), 1, &DevId, Flags.c_str(),
                            nullptr, nullptr);
       dumpProgramLog(*ChipDevOcl, Program_);


### PR DESCRIPTION
Disable IGC's RetryManager so kernels are not silently recompiled with reduced optimization, avoiding the associated performance cliff.