### PR TITLE
Modifying isEmptyQueue to check LZ to confirm if the queue is empty so we can catch when it has finished early

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,22 +193,21 @@ performance_hoMusic:
       # Convert to total seconds using awk (handles 1m50.315s -> 110.315)
       ACTUAL_TIME=$(echo $TIME_STR | awk -F'[ms]' '{print ($1 * 60) + $2}')
       
-      # Define baseline and 6% threshold
+      # Define baseline and 6% upper threshold
       BASELINE=90.0
       THRESHOLD=$(echo "$BASELINE * 0.06" | bc -l)
-      LOWER_BOUND=$(echo "$BASELINE - $THRESHOLD" | bc -l)
       UPPER_BOUND=$(echo "$BASELINE + $THRESHOLD" | bc -l)
 
       echo "Actual: $ACTUAL_TIME s | Target: $BASELINE s (+/- $THRESHOLD s)"
 
       # Compare using bc (returns 1 for true, 0 for false)
-      IS_WITHIN_LIMITS=$(echo "$ACTUAL_TIME >= $LOWER_BOUND && $ACTUAL_TIME <= $UPPER_BOUND" | bc -l)
+      IS_WITHIN_LIMITS=$(echo $ACTUAL_TIME <= $UPPER_BOUND" | bc -l)
 
       if [ "$IS_WITHIN_LIMITS" -eq 1 ]; then
         echo "Performance check passed: $ACTUAL_TIME is within 5% of $BASELINE"
         exit 0
       else
-        echo "Performance check failed: $ACTUAL_TIME is outside the range [$LOWER_BOUND, $UPPER_BOUND]"
+        echo "Performance check failed: $ACTUAL_TIME is above $UPPER_BOUND"
         exit 1
       fi
   allow_failure: true
@@ -257,7 +256,6 @@ zeroRK_performance:
     # Define baseline and 6% threshold
     BASELINE=85
     THRESHOLD=$(echo "$BASELINE * 0.06" | bc -l)
-    LOWER_BOUND=$(echo "$BASELINE - $THRESHOLD" | bc -l)
     UPPER_BOUND=$(echo "$BASELINE + $THRESHOLD" | bc -l)
 
     echo "Actual: $ACTUAL_TIME s | Target: $BASELINE s (+/- $THRESHOLD s)"
@@ -269,7 +267,7 @@ zeroRK_performance:
       echo "Performance check passed: $ACTUAL_TIME is within 5% of $BASELINE"
       exit 0
     else
-      echo "Performance check failed: $ACTUAL_TIME is outside the range [$LOWER_BOUND, $UPPER_BOUND]"
+      echo "Performance check failed: $ACTUAL_TIME is above $UPPER_BOUND"
       exit 1
     fi
 
@@ -337,23 +335,21 @@ opensn_performance:
     echo "Extracted time: $TIME_STR -> $ACTUAL_TIME s"
 
     # Define baseline and 6% threshold
-    BASELINE=28
+    BASELINE=29
     THRESHOLD=$(echo "$BASELINE * 0.1" | bc -l)
-    LOWER_BOUND=$(echo "$BASELINE - $THRESHOLD" | bc -l)
     UPPER_BOUND=$(echo "$BASELINE + $THRESHOLD" | bc -l)
 
     echo "Actual: $ACTUAL_TIME s | Target: $BASELINE s (+/- $THRESHOLD s)"
 
-    IS_WITHIN_LIMITS=$(echo "$ACTUAL_TIME >= $LOWER_BOUND && $ACTUAL_TIME <= $UPPER_BOUND" | bc -l)
+    IS_WITHIN_LIMITS=$(echo "$ACTUAL_TIME <= $UPPER_BOUND" | bc -l)
 
     if [ "$IS_WITHIN_LIMITS" -eq 1 ]; then
       echo "Performance check passed: $ACTUAL_TIME is within 6% of $BASELINE"
       exit 0
     else
-      echo "Performance check failed: $ACTUAL_TIME is outside the range [$LOWER_BOUND, $UPPER_BOUND]"
+      echo "Performance check failed: $ACTUAL_TIME is above $UPPER_BOUND"
       exit 1
     fi
-  allow_failure: true
 
 cleanup:
   stage: cleanup

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -263,7 +263,7 @@ zeroRK_performance:
     echo "Actual: $ACTUAL_TIME s | Target: $BASELINE s (+/- $THRESHOLD s)"
 
     # Compare using bc (returns 1 for true, 0 for false)
-    IS_WITHIN_LIMITS=$(echo "$ACTUAL_TIME >= $LOWER_BOUND && $ACTUAL_TIME <= $UPPER_BOUND" | bc -l)
+    IS_WITHIN_LIMITS=$(echo $ACTUAL_TIME <= $UPPER_BOUND" | bc -l)
 
     if [ "$IS_WITHIN_LIMITS" -eq 1 ]; then
       echo "Performance check passed: $ACTUAL_TIME is within 5% of $BASELINE"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,8 +21,6 @@ variables:
 stages:
     - .pre
     - build_chipstar
-    - builds_chipstar_install_script_llvm19
-    - runs_tests_chipstar_install_script_llvm19
     - builds_chipstar_install_script_llvm22
     - runs_tests_chipstar_install_script_llvm22
     - builds_chipstar_aurora_script_llvm19
@@ -84,34 +82,6 @@ aurora_build_test:
     - cd ..
     - rm -rf build
 
-# testing with install script
-chipStar_script_install:
-  stage: builds_chipstar_install_script_llvm19
-  resource_group: aurora_pipeline  
-  extends: .aurora-shell-runner
-  script:
-    - hostname
-    - echo "Running on $(hostname) with setuid shell runner"
-    - cp -r ${WRK_DIR}/chipStar ${WRK_DIR}/chipStar_llvm19
-    - cd ${WRK_DIR}/chipStar_llvm19
-    - module use /soft/modulefiles
-    - module load cmake chipStar/.llvm19/20251107-19/release
-    - ./install_chipstar.py --all --install-dir ${WRK_DIR}/install/ --staging-dir $PWD/stage
-  allow_failure: true
-  
-chipStar_script_test:
-  stage: runs_tests_chipstar_install_script_llvm19
-  resource_group: aurora_pipeline  
-  extends: .aurora-batch-runner
-  script:
-    - cd ${WRK_DIR}/chipStar_llvm19/build
-    - module use /soft/modulefiles
-    - module load cmake chipStar/.llvm19/20251107-19/release
-    - rm -rf $HOME/.cache/chipStar
-    - CHIP_BE=level0 make build_tests -j
-    - CHIP_MODULE_CACHE_DIR="" ZE_AFFINITY_MASK=0.0 ../scripts/check.py ./ dgpu level0 --timeout 60 --num-tries=1 --num-threads=1
-  allow_failure: true
-
 chipStar_script_install_llvm22:
   stage: builds_chipstar_install_script_llvm22
   resource_group: aurora_pipeline  
@@ -123,8 +93,8 @@ chipStar_script_install_llvm22:
     - cd ${WRK_DIR}/chipStar_llvm22
     - module use /soft/modulefiles
     - module load cmake chipStar/.llvm22/20260311-22/release
+    - sed -i '/name="chipstar",/a\        cmake_flags=["-DCHIP_LZ_API_QUERY_QUEUE_EMPTY=ON -DCHIP_L0_KERNEL_TIMESTAMPS=OFF"],' ./install_chipstar.py 
     - ./install_chipstar.py --all --install-dir ${WRK_DIR}/install/ --staging-dir $PWD/stage
-  allow_failure: true
 
 chipStar_script_test_llvm22:
   stage: runs_tests_chipstar_install_script_llvm22
@@ -137,7 +107,6 @@ chipStar_script_test_llvm22:
     - rm -rf $HOME/.cache/chipStar
     - CHIP_BE=level0 make build_tests -j
     - CHIP_MODULE_CACHE_DIR="" ZE_AFFINITY_MASK=0.0 ../scripts/check.py ./ dgpu level0 --timeout 60 --num-tries=1 --num-threads=1
-  allow_failure: true
 
 # testing with install script
 chipStar_aurora_script_test:
@@ -166,7 +135,8 @@ chipStar_aurora_script_test_run:
     - CHIP_BE=level0 make build_tests -j
     - module load cmake
     - CHIP_MODULE_CACHE_DIR="" ZE_AFFINITY_MASK=0.0 ../scripts/check.py ./ dgpu level0 --timeout 60 --num-tries=1 --num-threads=1
-
+  allow_failure: true
+  
 chipStar_aurora_script_test_llvm22:
   stage: builds_chipstar_aurora_script_llvm22
   resource_group: aurora_pipeline  
@@ -258,7 +228,6 @@ zeroRK_build:
    - mkdir -p build_aurora
    - cd build_aurora
    - sh ../scripts/build_aurora.sh  --no-module-loads
-  allow_failure: true
   
 zeroRK_run:
   stage: runs_zeroRK
@@ -274,7 +243,6 @@ zeroRK_run:
   - module load chipStar/llvm19
   - rm -f output
   - ./submit_job.sh |& tee -a output
-  allow_failure: true
 
 zeroRK_performance:
   stage: perforamce_zeroRK
@@ -304,7 +272,6 @@ zeroRK_performance:
       echo "Performance check failed: $ACTUAL_TIME is outside the range [$LOWER_BOUND, $UPPER_BOUND]"
       exit 1
     fi
-  allow_failure: true  
 
 # OpenSn application build and run
 opensn_build:
@@ -371,7 +338,7 @@ opensn_performance:
 
     # Define baseline and 6% threshold
     BASELINE=28
-    THRESHOLD=$(echo "$BASELINE * 0.06" | bc -l)
+    THRESHOLD=$(echo "$BASELINE * 0.1" | bc -l)
     LOWER_BOUND=$(echo "$BASELINE - $THRESHOLD" | bc -l)
     UPPER_BOUND=$(echo "$BASELINE + $THRESHOLD" | bc -l)
 

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -400,6 +400,7 @@ CHIPEventLevel0::CHIPEventLevel0(CHIPContextLevel0 *ChipCtx,
       EventPoolHandle_(nullptr), EventPoolIndex(0) {}
 
 void CHIPQueueLevel0::recordEvent(chipstar::Event *ChipEvent) {
+  LOCK(UpdateEmptyQueueViaLZMtx_);
   IsEmptyQueue_.store(false);
   auto ChipEventLz = static_cast<CHIPEventLevel0 *>(ChipEvent);
 
@@ -651,6 +652,8 @@ CHIPCallbackDataLevel0::CHIPCallbackDataLevel0(hipStreamCallback_t CallbackF,
   auto ChipQueueLz = static_cast<CHIPQueueLevel0 *>(ChipQueue);
   auto ChipContextLz =
       static_cast<CHIPContextLevel0 *>(ChipQueue->getContext());
+  LOCK(ChipQueueLz->UpdateEmptyQueueViaLZMtx_);
+  ChipQueueLz->IsEmptyQueue_.store(false);
 
   // Use dedicated events for callbacks (not from shared pool).
   // Workaround for Intel Data Center GPU Max driver bug where events used on
@@ -961,9 +964,11 @@ CHIPQueueLevel0::addDependenciesQueueSync(
     
     // Signal this marker in the other queue's command list
     auto OtherQueue = static_cast<CHIPQueueLevel0 *>(q);
+    // move IsEmptyQueue_ above CommandListMtx lock
+    LOCK(OtherQueue->UpdateEmptyQueueViaLZMtx_);
+    OtherQueue->IsEmptyQueue_.store(false);
     LOCK(OtherQueue->CommandListMtx);
     auto OtherCommandList = OtherQueue->getCmdListImm();
-    OtherQueue->IsEmptyQueue_.store(false);
 
     zeStatus = zeCommandListAppendSignalEvent(OtherCommandList, MarkerEventLz->peek());
     CHIPERR_CHECK_LOG_AND_THROW_TABLE(zeCommandListAppendSignalEvent);
@@ -1351,6 +1356,7 @@ ze_command_queue_desc_t CHIPDeviceLevel0::getNextCopyQueueDesc(int Priority) {
 
 std::shared_ptr<chipstar::Event>
 CHIPQueueLevel0::launchImpl(chipstar::ExecItem *ExecItem) {
+  LOCK(UpdateEmptyQueueViaLZMtx_);
   IsEmptyQueue_.store(false);
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
   CHIPKernelLevel0 *ChipKernel = (CHIPKernelLevel0 *)ExecItem->getKernel();
@@ -1432,6 +1438,7 @@ CHIPQueueLevel0::launchImpl(chipstar::ExecItem *ExecItem) {
 std::shared_ptr<chipstar::Event>
 CHIPQueueLevel0::memFillAsyncImpl(void *Dst, size_t Size, const void *Pattern,
                                   size_t PatternSize) {
+  LOCK(UpdateEmptyQueueViaLZMtx_);
   IsEmptyQueue_.store(false);
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
   std::shared_ptr<chipstar::Event> MemFillEvent =
@@ -1483,6 +1490,7 @@ CHIPQueueLevel0::memCopy3DAsyncImpl(void *Dst, size_t Dpitch, size_t Dspitch,
                                     const void *Src, size_t Spitch,
                                     size_t Sspitch, size_t Width, size_t Height,
                                     size_t Depth, hipMemcpyKind Kind) {
+  LOCK(UpdateEmptyQueueViaLZMtx_);
   IsEmptyQueue_.store(false);
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
   std::shared_ptr<chipstar::Event> MemCopyRegionEvent =
@@ -1529,7 +1537,10 @@ void CHIPQueueLevel0::memFillAsync3D(hipPitchedPtr PitchedDevPtr, int Value,
                                      hipExtent Extent) {
   logTrace("CHIPQueueLevel0::memFillAsync3D - using "
            "zeCommandListAppendMemoryCopyRegion implementation");
-  IsEmptyQueue_.store(false);
+  // NOTE: the IsEmptyQueue_ store is not at the top anymore here.
+  // it is moved below to near the zeCommandListAppendMemoryCopyRegion call. 
+  // the other paths of this routine calls memFillAsyncImpl
+  // (which has the lock and IsEmptyQueue_ inside it already and so would deadlock)
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
 
   size_t Width = Extent.width;
@@ -1594,6 +1605,9 @@ void CHIPQueueLevel0::memFillAsync3D(hipPitchedPtr PitchedDevPtr, int Value,
   std::shared_ptr<chipstar::Event> CopyEvent =
       static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(
           ChipCtxZe, chipstar::EventFlags(), "memFillAsync3D_region");
+
+  LOCK(UpdateEmptyQueueViaLZMtx_);
+  IsEmptyQueue_.store(false);
 
   // Get dependencies before acquiring command list lock to avoid deadlock
   auto [EventHandles, EventLocks] = addDependenciesQueueSync(CopyEvent);
@@ -1676,6 +1690,7 @@ std::shared_ptr<chipstar::Event>
 CHIPQueueLevel0::memCopyToImage(ze_image_handle_t Image, const void *Src,
                                 const chipstar::RegionDesc &SrcRegion) {
   logTrace("CHIPQueueLevel0::memCopyToImage");
+  LOCK(UpdateEmptyQueueViaLZMtx_);
   IsEmptyQueue_.store(false);
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
   std::shared_ptr<chipstar::Event> ImageCopyEvent =
@@ -1837,6 +1852,8 @@ std::shared_ptr<chipstar::Event> CHIPQueueLevel0::enqueueBarrierImpl(
 std::shared_ptr<chipstar::Event>
 CHIPQueueLevel0::memCopyAsyncImpl(void *Dst, const void *Src, size_t Size,
                                   hipMemcpyKind Kind) {
+  LOCK(UpdateEmptyQueueViaLZMtx_);
+  IsEmptyQueue_.store(false);
   logTrace("CHIPQueueLevel0::memCopyAsync");
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
   std::shared_ptr<chipstar::Event> MemCopyEvent =
@@ -1864,6 +1881,8 @@ CHIPQueueLevel0::memCopyAsyncImpl(void *Dst, const void *Src, size_t Size,
 
 std::shared_ptr<chipstar::Event>
 CHIPQueueLevel0::memPrefetchImpl(const void *Ptr, size_t Count, int DstDevId) {
+  LOCK(UpdateEmptyQueueViaLZMtx_);
+  IsEmptyQueue_.store(false);
   logTrace("CHIPQueueLevel0::memPrefetchImpl");
   
   // Level0 doesn't support explicit CPU prefetch - zeCommandListAppendMemoryPrefetch

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -700,7 +700,6 @@ CHIPCallbackDataLevel0::CHIPCallbackDataLevel0(hipStreamCallback_t CallbackF,
   // Lock before using immediate command list
   LOCK(ChipQueueLz->CommandListMtx);
   ze_command_list_handle_t CommandList = ChipQueueLz->getCmdListImm();
-  ChipQueueLz->IsEmptyQueue_.store(false);
 
   // Add a barrier so that it signals
   zeStatus = zeCommandListAppendBarrier(
@@ -952,7 +951,8 @@ CHIPQueueLevel0::createMarkerEventWithLock(CHIPContextLevel0* Ctx, const std::st
 std::pair<std::vector<ze_event_handle_t>, chipstar::LockGuardVector>
 CHIPQueueLevel0::addDependenciesQueueSync(
     std::shared_ptr<chipstar::Event> TargetEvent) {
-  IsEmptyQueue_.store(false);
+  // Caller must hold UpdateEmptyQueueViaLZMtx_; IsEmptyQueue_ is expected
+  // to be false on entry (set by the caller's submit-site LOCK + store).
   auto Ctx = static_cast<CHIPContextLevel0 *>(ChipCtxLz_);
   auto BackendLz = static_cast<CHIPBackendLevel0 *>(Backend);
 
@@ -1959,6 +1959,7 @@ void CHIPQueueLevel0::finish() {
   // All GPU work on this queue has completed. Release cross-queue dependency
   // marker events so their ze_events can be recycled by the event pool.
   PendingCrossQueueDeps_.clear();
+  LOCK(UpdateEmptyQueueViaLZMtx_);
   IsEmptyQueue_.store(true);
   return;
 }

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -400,8 +400,6 @@ CHIPEventLevel0::CHIPEventLevel0(CHIPContextLevel0 *ChipCtx,
       EventPoolHandle_(nullptr), EventPoolIndex(0) {}
 
 void CHIPQueueLevel0::recordEvent(chipstar::Event *ChipEvent) {
-  LOCK(UpdateEmptyQueueViaLZMtx_);
-  IsEmptyQueue_.store(false);
   auto ChipEventLz = static_cast<CHIPEventLevel0 *>(ChipEvent);
 
   {
@@ -430,6 +428,7 @@ void CHIPQueueLevel0::recordEvent(chipstar::Event *ChipEvent) {
   CHIPERR_CHECK_LOG_AND_THROW_TABLE(zeDeviceGetGlobalTimestamps);
 
   LOCK(CommandListMtx);
+  IsEmptyQueue_.store(false);
   auto CommandList = this->getCmdListImm();
   auto CommandListCopy = this->getCmdListImmCopy();
 
@@ -652,8 +651,6 @@ CHIPCallbackDataLevel0::CHIPCallbackDataLevel0(hipStreamCallback_t CallbackF,
   auto ChipQueueLz = static_cast<CHIPQueueLevel0 *>(ChipQueue);
   auto ChipContextLz =
       static_cast<CHIPContextLevel0 *>(ChipQueue->getContext());
-  LOCK(ChipQueueLz->UpdateEmptyQueueViaLZMtx_);
-  ChipQueueLz->IsEmptyQueue_.store(false);
 
   // Use dedicated events for callbacks (not from shared pool).
   // Workaround for Intel Data Center GPU Max driver bug where events used on
@@ -699,6 +696,7 @@ CHIPCallbackDataLevel0::CHIPCallbackDataLevel0(hipStreamCallback_t CallbackF,
 
   // Lock before using immediate command list
   LOCK(ChipQueueLz->CommandListMtx);
+  ChipQueueLz->IsEmptyQueue_.store(false);
   ze_command_list_handle_t CommandList = ChipQueueLz->getCmdListImm();
 
   // Add a barrier so that it signals
@@ -951,8 +949,6 @@ CHIPQueueLevel0::createMarkerEventWithLock(CHIPContextLevel0* Ctx, const std::st
 std::pair<std::vector<ze_event_handle_t>, chipstar::LockGuardVector>
 CHIPQueueLevel0::addDependenciesQueueSync(
     std::shared_ptr<chipstar::Event> TargetEvent) {
-  // Caller must hold UpdateEmptyQueueViaLZMtx_; IsEmptyQueue_ is expected
-  // to be false on entry (set by the caller's submit-site LOCK + store).
   auto Ctx = static_cast<CHIPContextLevel0 *>(ChipCtxLz_);
   auto BackendLz = static_cast<CHIPBackendLevel0 *>(Backend);
 
@@ -964,10 +960,8 @@ CHIPQueueLevel0::addDependenciesQueueSync(
     
     // Signal this marker in the other queue's command list
     auto OtherQueue = static_cast<CHIPQueueLevel0 *>(q);
-    // move IsEmptyQueue_ above CommandListMtx lock
-    LOCK(OtherQueue->UpdateEmptyQueueViaLZMtx_);
-    OtherQueue->IsEmptyQueue_.store(false);
     LOCK(OtherQueue->CommandListMtx);
+    OtherQueue->IsEmptyQueue_.store(false);
     auto OtherCommandList = OtherQueue->getCmdListImm();
 
     zeStatus = zeCommandListAppendSignalEvent(OtherCommandList, MarkerEventLz->peek());
@@ -1356,8 +1350,6 @@ ze_command_queue_desc_t CHIPDeviceLevel0::getNextCopyQueueDesc(int Priority) {
 
 std::shared_ptr<chipstar::Event>
 CHIPQueueLevel0::launchImpl(chipstar::ExecItem *ExecItem) {
-  LOCK(UpdateEmptyQueueViaLZMtx_);
-  IsEmptyQueue_.store(false);
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
   CHIPKernelLevel0 *ChipKernel = (CHIPKernelLevel0 *)ExecItem->getKernel();
   ze_kernel_handle_t KernelZe = ChipKernel->get();
@@ -1386,6 +1378,7 @@ CHIPQueueLevel0::launchImpl(chipstar::ExecItem *ExecItem) {
 
   // if using immediate command lists, lock the mutex
   LOCK(CommandListMtx); // TODO this is probably not needed when using RCL
+  IsEmptyQueue_.store(false);
   auto CommandList = this->getCmdListImm();
 
   // Do we need to annotate indirect buffer accesses?
@@ -1438,8 +1431,6 @@ CHIPQueueLevel0::launchImpl(chipstar::ExecItem *ExecItem) {
 std::shared_ptr<chipstar::Event>
 CHIPQueueLevel0::memFillAsyncImpl(void *Dst, size_t Size, const void *Pattern,
                                   size_t PatternSize) {
-  LOCK(UpdateEmptyQueueViaLZMtx_);
-  IsEmptyQueue_.store(false);
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
   std::shared_ptr<chipstar::Event> MemFillEvent =
       static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(
@@ -1463,6 +1454,7 @@ CHIPQueueLevel0::memFillAsyncImpl(void *Dst, size_t Size, const void *Pattern,
   auto [EventHandles, EventLocks] = addDependenciesQueueSync(MemFillEvent);
   
   LOCK(CommandListMtx);
+  IsEmptyQueue_.store(false);
   auto CommandList = this->getCmdListImmCopy();
   // The application must not call this function from
   // simultaneous threads with the same command list handle.
@@ -1490,8 +1482,6 @@ CHIPQueueLevel0::memCopy3DAsyncImpl(void *Dst, size_t Dpitch, size_t Dspitch,
                                     const void *Src, size_t Spitch,
                                     size_t Sspitch, size_t Width, size_t Height,
                                     size_t Depth, hipMemcpyKind Kind) {
-  LOCK(UpdateEmptyQueueViaLZMtx_);
-  IsEmptyQueue_.store(false);
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
   std::shared_ptr<chipstar::Event> MemCopyRegionEvent =
       static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(
@@ -1517,6 +1507,7 @@ CHIPQueueLevel0::memCopy3DAsyncImpl(void *Dst, size_t Dpitch, size_t Dspitch,
       addDependenciesQueueSync(MemCopyRegionEvent);
   
   LOCK(CommandListMtx);
+  IsEmptyQueue_.store(false);
   auto CommandList = this->getCmdListImmCopy();
   // The application must not call this function from
   // simultaneous threads with the same command list handle.
@@ -1537,10 +1528,6 @@ void CHIPQueueLevel0::memFillAsync3D(hipPitchedPtr PitchedDevPtr, int Value,
                                      hipExtent Extent) {
   logTrace("CHIPQueueLevel0::memFillAsync3D - using "
            "zeCommandListAppendMemoryCopyRegion implementation");
-  // NOTE: the IsEmptyQueue_ store is not at the top anymore here.
-  // it is moved below to near the zeCommandListAppendMemoryCopyRegion call. 
-  // the other paths of this routine calls memFillAsyncImpl
-  // (which has the lock and IsEmptyQueue_ inside it already and so would deadlock)
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
 
   size_t Width = Extent.width;
@@ -1606,13 +1593,12 @@ void CHIPQueueLevel0::memFillAsync3D(hipPitchedPtr PitchedDevPtr, int Value,
       static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(
           ChipCtxZe, chipstar::EventFlags(), "memFillAsync3D_region");
 
-  LOCK(UpdateEmptyQueueViaLZMtx_);
-  IsEmptyQueue_.store(false);
 
   // Get dependencies before acquiring command list lock to avoid deadlock
   auto [EventHandles, EventLocks] = addDependenciesQueueSync(CopyEvent);
 
   LOCK(CommandListMtx);
+  IsEmptyQueue_.store(false);
   auto CommandList = this->getCmdListImmCopy();
 
   // Wait for pattern buffer to be filled
@@ -1690,8 +1676,6 @@ std::shared_ptr<chipstar::Event>
 CHIPQueueLevel0::memCopyToImage(ze_image_handle_t Image, const void *Src,
                                 const chipstar::RegionDesc &SrcRegion) {
   logTrace("CHIPQueueLevel0::memCopyToImage");
-  LOCK(UpdateEmptyQueueViaLZMtx_);
-  IsEmptyQueue_.store(false);
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
   std::shared_ptr<chipstar::Event> ImageCopyEvent =
       static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(
@@ -1699,6 +1683,7 @@ CHIPQueueLevel0::memCopyToImage(ze_image_handle_t Image, const void *Src,
   auto [EventHandles, EventLocks] = addDependenciesQueueSync(ImageCopyEvent);
   if (!SrcRegion.isPitched()) {
     LOCK(CommandListMtx);
+    IsEmptyQueue_.store(false);
     auto CommandList = this->getCmdListImm();
     // The application must not call this function from
     // simultaneous threads with the same command list handle.
@@ -1718,6 +1703,7 @@ CHIPQueueLevel0::memCopyToImage(ze_image_handle_t Image, const void *Src,
              "UNIMPLEMENTED: 3D pitched image copy.");
   const char *SrcRow = (const char *)Src;
   LOCK(CommandListMtx);
+  IsEmptyQueue_.store(false);
   auto CommandList = this->getCmdListImm();
   for (size_t Row = 0; Row < SrcRegion.Size[1]; Row++) {
     bool LastRow = Row == SrcRegion.Size[1] - 1;
@@ -1788,6 +1774,7 @@ std::shared_ptr<chipstar::Event> CHIPQueueLevel0::enqueueMarkerImpl() {
   addDependenciesQueueSync(MarkerEvent);
   
   LOCK(CommandListMtx);
+  IsEmptyQueue_.store(false);
   auto CommandList = this->getCmdListImm();
   // The application must not call this function from
   // simultaneous threads with the same command list handle.
@@ -1834,6 +1821,7 @@ std::shared_ptr<chipstar::Event> CHIPQueueLevel0::enqueueBarrierImpl(
 
   // TODO Should this be memory or compute?
   LOCK(CommandListMtx);
+  IsEmptyQueue_.store(false);
   auto CommandList = this->getCmdListImm();
   // The application must not call this function from
   // simultaneous threads with the same command list handle.
@@ -1852,8 +1840,6 @@ std::shared_ptr<chipstar::Event> CHIPQueueLevel0::enqueueBarrierImpl(
 std::shared_ptr<chipstar::Event>
 CHIPQueueLevel0::memCopyAsyncImpl(void *Dst, const void *Src, size_t Size,
                                   hipMemcpyKind Kind) {
-  LOCK(UpdateEmptyQueueViaLZMtx_);
-  IsEmptyQueue_.store(false);
   logTrace("CHIPQueueLevel0::memCopyAsync");
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
   std::shared_ptr<chipstar::Event> MemCopyEvent =
@@ -1865,6 +1851,7 @@ CHIPQueueLevel0::memCopyAsyncImpl(void *Dst, const void *Src, size_t Size,
   auto [EventHandles, EventLocks] = addDependenciesQueueSync(MemCopyEvent);
   
   LOCK(CommandListMtx);
+  IsEmptyQueue_.store(false);
   auto CommandList = this->getCmdListImmCopy();
   // The application must not call this function from simultaneous threads with
   // the same command list handle
@@ -1881,8 +1868,6 @@ CHIPQueueLevel0::memCopyAsyncImpl(void *Dst, const void *Src, size_t Size,
 
 std::shared_ptr<chipstar::Event>
 CHIPQueueLevel0::memPrefetchImpl(const void *Ptr, size_t Count, int DstDevId) {
-  LOCK(UpdateEmptyQueueViaLZMtx_);
-  IsEmptyQueue_.store(false);
   logTrace("CHIPQueueLevel0::memPrefetchImpl");
   
   // Level0 doesn't support explicit CPU prefetch - zeCommandListAppendMemoryPrefetch
@@ -1896,6 +1881,7 @@ CHIPQueueLevel0::memPrefetchImpl(const void *Ptr, size_t Count, int DstDevId) {
     // For CPU prefetch, just create an event that's already complete
     // The memory will be accessible on CPU by default for managed memory
     LOCK(CommandListMtx);
+    IsEmptyQueue_.store(false);
     auto CommandList = this->getCmdListImmCopy();
     auto [EventHandles, EventLocks] = addDependenciesQueueSync(PrefetchEvent);
     
@@ -1917,6 +1903,7 @@ CHIPQueueLevel0::memPrefetchImpl(const void *Ptr, size_t Count, int DstDevId) {
           ChipCtxZe, chipstar::EventFlags(), "memPrefetch");
   
   LOCK(CommandListMtx);
+  IsEmptyQueue_.store(false);
   auto CommandList = this->getCmdListImmCopy();
   auto [EventHandles, EventLocks] = addDependenciesQueueSync(PrefetchEvent);
   
@@ -1959,7 +1946,6 @@ void CHIPQueueLevel0::finish() {
   // All GPU work on this queue has completed. Release cross-queue dependency
   // marker events so their ze_events can be recycled by the event pool.
   PendingCrossQueueDeps_.clear();
-  LOCK(UpdateEmptyQueueViaLZMtx_);
   IsEmptyQueue_.store(true);
   return;
 }

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -387,22 +387,6 @@ public:
   /// ze_events while GPU operations on this queue still reference them.
   std::vector<std::shared_ptr<chipstar::Event>> PendingCrossQueueDeps_;
 
-  // this mutex is necessary to avoid a race in the isEmptyQueue
-  // routine. to improve performance of ZeroRK we now added a
-  // check where if the atomic is false (queue not empty), we
-  // check if it really is with a LZ call. however, then there
-  // can be a race due to the gap between the LZ call and the store/load of
-  // the atomic, where another thread could start submitting but isEmptyQueue
-  // incorrectly returns true.
-  // this is held by submitters from just before the store(false) to the finish of submission
-  // so the atomic cannot be updated while a submit is underway but not completed.
-  //
-  // Every submit site should do at the start of critical sections:
-  //
-  //   LOCK(UpdateEmptyQueueViaLZMtx_);          // acquire lock first
-  //   IsEmptyQueue_.store(false);   // then mark queue busy
-  std::mutex UpdateEmptyQueueViaLZMtx_;
-
   // this returns whether or not a queue is empty.
   // if the per-queue atomic tracking isEmpty is true, return
   // true since it is only true at initial state or after we've confirmed via L0 call.
@@ -412,7 +396,7 @@ public:
   // (a concurrent submitter could IsEmptyQueue_.store(false) between the L0 check
   // and a IsEmptyQueue_.store(true)
   // resulting in setting IsEmptyQueue_ true while there actually is work in the queue)
-  // we have to use a lock (UpdateEmptyQueueViaLZMtx_)
+  // we use the command list lock (CommandListMtx)
   // if we can't get the lock, someone is submitting, so return false.
   // if we get the lock, check if it's really busy with zeCommandListHostSynchronize.
   // if it's true (not busy), update IsEmptyQueue_ and return true. else, return false.
@@ -422,7 +406,7 @@ public:
 #else
     bool is_empty = IsEmptyQueue_.load(std::memory_order_relaxed);
     if (is_empty) return true;
-    std::unique_lock<std::mutex> lock_guard(UpdateEmptyQueueViaLZMtx_, std::try_to_lock);
+    std::unique_lock<std::mutex> lock_guard(CommandListMtx, std::try_to_lock);
     if (!lock_guard.owns_lock()) {
       // Submitter holds the lock; conservatively say busy.
       return false;

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -386,11 +386,53 @@ public:
   /// is finished. Without this, checkEvents() may recycle their underlying
   /// ze_events while GPU operations on this queue still reference them.
   std::vector<std::shared_ptr<chipstar::Event>> PendingCrossQueueDeps_;
+
+  // this mutex is necessary to avoid a race in the isEmptyQueue
+  // routine. to improve performance of ZeroRK we now added a
+  // check where if the atomic is false (queue not empty), we
+  // check if it really is with a LZ call. however, then there
+  // can be a race due to the gap between the LZ call and the store/load of
+  // the atomic, where another thread could start submitting but isEmptyQueue
+  // incorrectly returns true.
+  // this is held by submitters from just before the store(false) to the finish of submission
+  // so the atomic cannot be updated while a submit is underway but not completed.
+  //
+  // Every submit site should do at the start of critical sections:
+  //
+  //   LOCK(UpdateEmptyQueueViaLZMtx_);          // acquire lock first
+  //   IsEmptyQueue_.store(false);   // then mark queue busy
+  std::mutex UpdateEmptyQueueViaLZMtx_;
+
+  // this returns whether or not a queue is empty.
+  // if the per-queue atomic tracking isEmpty is true, return
+  // true since it is only true at initial state or after we've confirmed via L0 call.
+  // if it is false, the queue may be busy or it may have finished
+  // all work, so we check with a call to zeCommandListHostSynchronize(ZeCmdListImm_, 0).
+  // because there is a possible race due to the gap between reading this value and returning
+  // (a concurrent submitter could IsEmptyQueue_.store(false) between the L0 check
+  // and a IsEmptyQueue_.store(true)
+  // resulting in setting IsEmptyQueue_ true while there actually is work in the queue)
+  // we have to use a lock (UpdateEmptyQueueViaLZMtx_)
+  // if we can't get the lock, someone is submitting, so return false.
+  // if we get the lock, check if it's really busy with zeCommandListHostSynchronize.
+  // if it's true (not busy), update IsEmptyQueue_ and return true. else, return false.
   bool isEmptyQueue() override {
-#ifndef CHIP_LZ_API_QUERY_QUEUE_EMPTY
-    return IsEmptyQueue_.load();
-#else
+#ifdef CHIP_LZ_API_QUERY_QUEUE_EMPTY
     return (zeCommandListHostSynchronize(ZeCmdListImm_, 0) == ZE_RESULT_SUCCESS);
+#else
+    bool is_empty = IsEmptyQueue_.load(std::memory_order_relaxed);
+    if (is_empty) return true;
+    std::unique_lock<std::mutex> lock_guard(UpdateEmptyQueueViaLZMtx_, std::try_to_lock);
+    if (!lock_guard.owns_lock()) {
+      // Submitter holds the lock; conservatively say busy.
+      return false;
+    }
+    // Re-check under lock (another thread may have just updated to true while waiting for the lock)
+    is_empty = IsEmptyQueue_.load(std::memory_order_relaxed);
+    if (is_empty) return true;
+    is_empty = (zeCommandListHostSynchronize(ZeCmdListImm_, 0) == ZE_RESULT_SUCCESS);
+    if (is_empty) IsEmptyQueue_.store(true, std::memory_order_relaxed);
+    return is_empty;
 #endif
   }
 


### PR DESCRIPTION
TLDR: ZeroRK has had a ~30% regression after the switch to in-order queues due to the marker events and isEmptyQueue which aren't in the out-of-order version. This PR adds extra checking to isEmptyQueue to avoid markers if we know the queue is empty due to LZ API call. From testing this seems to result in ZeroRK performance being similar to the out-of-order-queue performance.

Longer description:
As discussed a little in https://github.com/CHIP-SPV/chipStar/pull/1162, codes like ZeroRK which have a lot of streams had a slowdown due to the extra time adding in markers after the switch to in-order queues. That PR helped a lot, but ZeroRK had about a 30% slowdown still. This PR adjusts isEmptyQueue so that we now match pre in-order queue times. It does this by using the IsEmptyQueue_ atomic to avoid adding markers if IsEmptyQueue_=true, but if IsEmptyQueue_=false, instead of adding the marker, it first checks with LZ if the queue is actually busy. If it's not busy, it will avoid adding the marker. 

Doing this without locks leads to a possible race due to the gap between calling `zeCommandListHostSynchronize(ZeCmdListImm_, 0)` and setting IsEmptyQueue_ to the new value. That is, a concurrent submitter could `IsEmptyQueue_.store(false)` between the L0 check and a `IsEmptyQueue_.store(true)` (if the LZ check says the queue is empty (true) since it missed the `store(false)`), resulting in setting IsEmptyQueue_ true while there actually is work in the queue. ~Thus a lock (UpdateEmptyQueueViaLZMtx_) was added to gate whether or not someone is submitting to the queue.  If there's a cleaner way to do this, let me know. I liked the new mutex instead of using CommandListMtx for easier reasoning about the correctness.~ Thus CommandListMtx is used to guard it. We could alternatively have a new mutex to just lock for IsEmptyQueue_ and submitting to the queue, but using CommandListMtx causes less line changes and is conceptually simpler -- we lock whenever someone adds to the command list, which should be the same as when people submit to the queue.

For the ZeroRK timings (150 iterations):
```
Pre-in-order-queue baseline: ~14.4s  
Current main: ~19.4s
This PR: ~14.4s
```
This PR also updates the Aurora tests to remove one older LLVM build test to help speed up testing and to allow the ZeroRK performance test to hard fail if the performance isn't met, and thus any future regression should ideally be caught.                                                                                                                                 

I took a look at https://github.com/CHIP-SPV/chipStar/pull/1293 and it looks like a complementary fix (targeting different issues). I'm happy to rebase this on top of that PR if desired.