### PR TITLE
Minor fixes, typo in gitlab file and moving addDependenciesQueueSync before the commandlistmtx in two places

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,7 +93,7 @@ chipStar_script_install_llvm22:
     - cd ${WRK_DIR}/chipStar_llvm22
     - module use /soft/modulefiles
     - module load cmake chipStar/.llvm22/20260311-22/release
-    - sed -i '/name="chipstar",/a\        cmake_flags=["-DCHIP_LZ_API_QUERY_QUEUE_EMPTY=ON","-DCHIP_L0_KERNEL_TIMESTAMPS=OFF"],' ./install_chipstar.py 
+    - sed -i '/name="chipstar",/a\        cmake_flags=["-DCHIP_LZ_API_QUERY_QUEUE_EMPTY=ON","-DCHIP_L0_KERNEL_TIMESTAMPS=OFF","-DHIPCC_VERIFY_DEVICES=pvc"],' ./install_chipstar.py 
     - ./install_chipstar.py --all --install-dir ${WRK_DIR}/install/ --staging-dir $PWD/stage
 
 chipStar_script_test_llvm22:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ stages:
     - performance_hoMusic
     - builds_zeroRK
     - runs_zeroRK
-    - perforamce_zeroRK
+    - performance_zeroRK
     - builds_opensn
     - runs_opensn
     - performance_opensn
@@ -244,7 +244,7 @@ zeroRK_run:
   - ./submit_job.sh |& tee -a output
 
 zeroRK_performance:
-  stage: perforamce_zeroRK
+  stage: performance_zeroRK
   resource_group: aurora_pipeline  
   extends: .aurora-shell-runner
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,7 +93,7 @@ chipStar_script_install_llvm22:
     - cd ${WRK_DIR}/chipStar_llvm22
     - module use /soft/modulefiles
     - module load cmake chipStar/.llvm22/20260311-22/release
-    - sed -i '/name="chipstar",/a\        cmake_flags=["-DCHIP_LZ_API_QUERY_QUEUE_EMPTY=ON -DCHIP_L0_KERNEL_TIMESTAMPS=OFF"],' ./install_chipstar.py 
+    - sed -i '/name="chipstar",/a\        cmake_flags=["-DCHIP_LZ_API_QUERY_QUEUE_EMPTY=ON","-DCHIP_L0_KERNEL_TIMESTAMPS=OFF"],' ./install_chipstar.py 
     - ./install_chipstar.py --all --install-dir ${WRK_DIR}/install/ --staging-dir $PWD/stage
 
 chipStar_script_test_llvm22:

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1891,12 +1891,13 @@ CHIPQueueLevel0::memPrefetchImpl(const void *Ptr, size_t Count, int DstDevId) {
         static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(
             ChipCtxZe, chipstar::EventFlags(), "memPrefetch");
     
+    auto [EventHandles, EventLocks] = addDependenciesQueueSync(PrefetchEvent);
+
     // For CPU prefetch, just create an event that's already complete
     // The memory will be accessible on CPU by default for managed memory
     LOCK(CommandListMtx);
     IsEmptyQueue_.store(false);
     auto CommandList = this->getCmdListImmCopy();
-    auto [EventHandles, EventLocks] = addDependenciesQueueSync(PrefetchEvent);
     
     // Append a barrier to signal completion (no actual prefetch command)
     zeStatus = zeCommandListAppendBarrier(
@@ -1915,10 +1916,11 @@ CHIPQueueLevel0::memPrefetchImpl(const void *Ptr, size_t Count, int DstDevId) {
       static_cast<CHIPBackendLevel0 *>(Backend)->createEventShared(
           ChipCtxZe, chipstar::EventFlags(), "memPrefetch");
   
+  auto [EventHandles, EventLocks] = addDependenciesQueueSync(PrefetchEvent);
+
   LOCK(CommandListMtx);
   IsEmptyQueue_.store(false);
   auto CommandList = this->getCmdListImmCopy();
-  auto [EventHandles, EventLocks] = addDependenciesQueueSync(PrefetchEvent);
   
   // Append memory prefetch command to the command list
   zeStatus = zeCommandListAppendMemoryPrefetch(


### PR DESCRIPTION
This does some minor fixes, mostly for the gitlab CI:
- typos in gitlab file and missing cmake flags
- moving addDependenciesQueueSync to before the locked commandlistmtx in two places since that's the convention and it avoids deadlock that could happen if A and B commandlists lock their mutexes and then try to access each other's lock inside addDependenciesQueueSync (since addDependenciesQueueSync loops over command lists and mutexes)