### PR TITLE
Workaround for issue with fopenmp flag and LLVM22

### DIFF
--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -102,6 +102,10 @@ add_hipcc_test(TestHipComplexInclude.hip HIPCC_OPTIONS)
 add_hipcc_test(TestHipccAcceptCcFiles.cc HIPCC_OPTIONS)
 add_hipcc_test(TestHipccAcceptCppFiles.cpp HIPCC_OPTIONS)
 
+# HIP device kernel + host (CPU) OpenMP in one TU must compile and link with
+# -fopenmp.
+add_hipcc_test(TestHipccFopenmp.cc HIPCC_OPTIONS -fopenmp)
+
 add_hipcc_test(Test513Regression.hip HIPCC_OPTIONS)
 
 add_test(NAME "TestHipccNeedsDashO"

--- a/tests/compiler/TestHipccFopenmp.cc
+++ b/tests/compiler/TestHipccFopenmp.cc
@@ -1,0 +1,18 @@
+#include <hip/hip_runtime.h>
+#include <omp.h>
+#include <cstdio>
+
+// Regression test: a single translation unit mixing a HIP device kernel and
+// host (CPU) OpenMP must compile and link.
+__global__ void k() {
+}
+
+int main() {
+  k<<<1, 1>>>(); // empty kernel
+  hipDeviceSynchronize();
+#pragma omp parallel num_threads(2)
+  if (omp_get_thread_num() == 0)
+    printf("threads: %d\n", omp_get_num_threads());
+
+  return 0;
+}


### PR DESCRIPTION
When compiling code with `-fopenmp` and chipStar built with LLVM22, I get the following error:
```
> hipcc -fopenmp g.cpp
clang++: error: mixed HIP and OPENMP offloading compilation is not supported
```

This compiled fine with chipStar built on LLVM19, so it looks like it's a change in how LLVM handles flags.

If `-fopenmp` and the `--offload=...` flag are passed to LLVM22 it treats it as OpenMP offload. chipStar uses the `--offload` flag for spirv, so it does not intend to imply anything about OpenMP offload, but it is what LLVM22 does. Possibly this can be adjusted in LLVM in the future, but for now, we can work around it in hipcc by any time we see `-fopenmp` or `-fopenmp=`  we replace it with `-Xarch_host -fopenmp`. `-Xarch_host` says that the flag after it will be used only for compiling on the host, so this allows us to only send `-fopenmp` to the host and not the device.

This PR adds the hipcc workaround and a new test which compiles a code with HIP and host-side OpenMP with`-fopenmp`. This is important for HPC applications as some (including those on Aurora) use OpenMP on the host side and HIP on the device side. If we need to guard this test for some systems, let me know how to adjust it, or feel free to change however. 