### PR TITLE
Add patch and regression test for invalid SPIR-V produced from duplicate-predecessor phi nodes   

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -197,7 +197,7 @@ performance_hoMusic:
       THRESHOLD=$(echo "$BASELINE * 0.06" | bc -l)
       UPPER_BOUND=$(echo "$BASELINE + $THRESHOLD" | bc -l)
 
-      echo "Actual: $ACTUAL_TIME s | Target: $BASELINE s (+/- $THRESHOLD s)"
+      echo "Actual: $ACTUAL_TIME s | Target: < $BASELINE s + $THRESHOLD s)"
 
       # Compare using bc (returns 1 for true, 0 for false)
       IS_WITHIN_LIMITS=$(echo "$ACTUAL_TIME <= $UPPER_BOUND" | bc -l)
@@ -257,7 +257,7 @@ zeroRK_performance:
     THRESHOLD=$(echo "$BASELINE * 0.06" | bc -l)
     UPPER_BOUND=$(echo "$BASELINE + $THRESHOLD" | bc -l)
 
-    echo "Actual: $ACTUAL_TIME s | Target: $BASELINE s (+/- $THRESHOLD s)"
+    echo "Actual: $ACTUAL_TIME s | Target: < $BASELINE s + $THRESHOLD s)"
 
     # Compare using bc (returns 1 for true, 0 for false)
     IS_WITHIN_LIMITS=$(echo "$ACTUAL_TIME <= $UPPER_BOUND" | bc -l)

--- a/llvm-patches/spirv-translator/0005-coalesce-duplicate-phi-predecessors.patch
+++ b/llvm-patches/spirv-translator/0005-coalesce-duplicate-phi-predecessors.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: chipStar <noreply@chip-spv>
+Date: Wed, 18 Jun 2026 00:00:00 +0000
+Subject: [PATCH] Coalesce duplicate predecessors when emitting OpPhi
+
+LLVM IR allows a PHI to list the same predecessor block more than once
+(e.g. a switch with several cases branching to the same block); the LLVM
+verifier guarantees the duplicate entries carry identical incoming values.
+SPIR-V's OpPhi requires exactly one (value, parent block) pair per
+predecessor, so emitting the duplicates verbatim yields invalid SPIR-V
+("OpPhi's number of incoming blocks does not match block's predecessor
+count"), which IGC then mis-handles (nondeterministic crash / miscompile).
+
+Skip duplicate predecessor entries when building the OpPhi operand list.
+---
+ lib/SPIRV/SPIRVWriter.cpp | 13 +++++++++++--
+ 1 file changed, 11 insertions(+)
+
+diff --git a/lib/SPIRV/SPIRVWriter.cpp b/lib/SPIRV/SPIRVWriter.cpp
+index b3cb24b..eb14297 100644
+--- a/lib/SPIRV/SPIRVWriter.cpp
++++ b/lib/SPIRV/SPIRVWriter.cpp
+@@ -2546,7 +2546,18 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
+     std::vector<SPIRVValue *> IncomingPairs;
+     SPIRVType *Ty = transScavengedType(Phi);
+ 
++    // SPIR-V requires OpPhi to have exactly one (value, parent block) pair per
++    // predecessor block. LLVM IR, however, permits a PHI to list the same
++    // predecessor multiple times (e.g. a switch with several cases branching
++    // to this block); the LLVM verifier guarantees those duplicate entries
++    // carry identical incoming values. Emitting them verbatim produces an
++    // invalid OpPhi (more parent blocks than the block has predecessors), so
++    // coalesce duplicate predecessors to a single entry.
++    SmallPtrSet<const BasicBlock *, 8> SeenPreds;
+     for (size_t I = 0, E = Phi->getNumIncomingValues(); I != E; ++I) {
++      const BasicBlock *IncomingBB = Phi->getIncomingBlock(I);
++      if (!SeenPreds.insert(IncomingBB).second)
++        continue; // duplicate predecessor; value is identical, skip it
+       SPIRVValue *Val = transValue(Phi->getIncomingValue(I), BB, true,
+                                    FuncTransMode::Pointer);
+       if (Val->getType() != Ty)

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -155,6 +155,13 @@ add_test(NAME "TestHipccMultiSource" COMMAND
   ${CMAKE_BINARY_DIR}/bin/hipcc ${CMAKE_CURRENT_SOURCE_DIR}/TestHipccCompileThenLinkMain.cpp ${CMAKE_CURRENT_SOURCE_DIR}/TestHipccCompileThenLinkKernel.cpp -o TestHipccMultiSource)
 add_shell_test(TestPrintfStaticString.bash)
 
+# Regression test for llvm-patches/spirv-translator/0005 (coalesce
+# duplicate-predecessor OpPhi). Translates to SPIR-V and run spirv-val;
+# without 0005 the writer emits an invalid OpPhi and validation fails. This skips
+# when the in-tree SPIR-V backend is used (LLVM_SPIRV=NOT_NEEDED), since 0005
+# patches the external translator. 
+add_shell_test(TestSpirvDuplicatePhiHip.bash)
+
 add_hipcc_test(TestLdg.hip HIPCC_OPTIONS -fsyntax-only)
 add_hipcc_test(TestSwitchCase.hip HIPCC_OPTIONS -O1 -c)
 add_hipcc_test(TestHostSideHIPVectors.hip HIPCC_OPTIONS -fsyntax-only)

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -104,7 +104,10 @@ add_hipcc_test(TestHipccAcceptCppFiles.cpp HIPCC_OPTIONS)
 
 # HIP device kernel + host (CPU) OpenMP in one TU must compile and link with
 # -fopenmp.
-add_hipcc_test(TestHipccFopenmp.cc HIPCC_OPTIONS -fopenmp)
+find_package(OpenMP)
+if(OpenMP_CXX_FOUND)
+  add_hipcc_test(TestHipccFopenmp.cc HIPCC_OPTIONS -fopenmp)
+endif()
 
 add_hipcc_test(Test513Regression.hip HIPCC_OPTIONS)
 

--- a/tests/compiler/TestSpirvDuplicatePhiHip.bash
+++ b/tests/compiler/TestSpirvDuplicatePhiHip.bash
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Regression test for llvm-patches/spirv-translator/0005
+# (coalesce duplicate-predecessor OpPhi). Compiles a small HIP kernel that
+# mirrors a real-world crash pattern, keeps the lowered device bitcode, translates
+# it to SPIR-V with the build's llvm-spirv, and validates it.
+#
+# Without 0005 the SPIR-V writer emits an OpPhi that lists a predecessor block
+# more than once and spirv-val rejects the module; with 0005 it is valid.
+#
+set -eu
+
+SRC_DIR="@CMAKE_CURRENT_SOURCE_DIR@"
+HIPCC="@CMAKE_BINARY_DIR@/bin/hipcc"
+LLVM_SPIRV="@LLVM_SPIRV@"
+SPIRV_VAL="@CMAKE_BINARY_DIR@/external/spirv-tools/bin/spirv-val"
+OUT="@CMAKE_CURRENT_BINARY_DIR@/@TEST_NAME@.d"
+
+# 0005 patches the external SPIRV-LLVM-Translator. When chipStar uses the in-tree
+# LLVM SPIR-V backend (LLVM_SPIRV=NOT_NEEDED) the patch does not apply -- skip.
+if [ "${LLVM_SPIRV}" = "NOT_NEEDED" ] || [ ! -x "${LLVM_SPIRV}" ]; then
+  echo "external llvm-spirv not in use; skipping (0005 not applicable)"
+  exit 0
+fi
+if [ ! -x "${SPIRV_VAL}" ]; then
+  echo "spirv-val not found; skipping"
+  exit 0
+fi
+
+rm -rf "${OUT}"
+mkdir -p "${OUT}"
+cd "${OUT}"
+
+# -O3 so the optimizer threads the shared-return switch; --save-temps keeps the
+# lowered device bitcode (the input the SPIR-V writer consumes).
+"${HIPCC}" -O3 --save-temps=cwd -c "${SRC_DIR}/TestSpirvDuplicatePhiHip.hip" \
+  -o "${OUT}/TestSpirvDuplicatePhiHip.o"
+
+BC=$(ls "${OUT}"/*-generic-lower.bc 2>/dev/null | head -1)
+if [ -z "${BC}" ]; then
+  echo "FAIL: no lowered device bitcode (*-generic-lower.bc) produced by hipcc"
+  exit 1
+fi
+
+"${LLVM_SPIRV}" --spirv-max-version=1.2 "${BC}" -o "${OUT}/TestSpirvDuplicatePhiHip.spv"
+"${SPIRV_VAL}" "${OUT}/TestSpirvDuplicatePhiHip.spv"
+echo "PASSED"

--- a/tests/compiler/TestSpirvDuplicatePhiHip.hip
+++ b/tests/compiler/TestSpirvDuplicatePhiHip.hip
@@ -1,0 +1,23 @@
+#include <hip/hip_runtime.h>
+
+// Regression test for llvm-patches/spirv-translator/0005
+// (coalesce duplicate-predecessor OpPhi).
+// This results in LLVM IR produced to have a phi node with
+// duplicate entries (for at least LLVM22) which then
+// produces invalid SPIRV since SPIRV does not allow dupilcate entries. 
+
+__device__ int grad(int sel) {
+  int v = 7;
+  switch (sel) {
+    case 0:
+    case 4:
+    case 10:
+      return v;      // 3 cases share one return -> switch block has 3 edges to the merge
+    default:
+      v = 9;
+  }
+  return v;
+}
+
+__global__ __attribute__((optnone))
+void k(int *out, int sel) { out[0] = grad(sel); }


### PR DESCRIPTION
TLDR: This is a patch for the SPIRV translator to avoid producing invalid SPIRV. A C++ reproducer and test is included. Feedback on the patch is needed since it was done with the help of Claude and although it seems correct I am not a SPIRV expert.

Background: The SPIRV translator produces invalid SPV from LLVM IR for the case where LLVM IR has a phi node with multiple entries that have the same predecessor.
For example:
```
 %r = phi i32 [ 7, %sw ], [ 7, %sw ], [ 9, %def ]    
```
In LLVM IR, duplicate entries are legal only if in the value in the entries which have the same predecessor are all the same (https://github.com/llvm/llvm-project/blob/ca7933e47d3a3451d81e72ac174dcb5aa28b59d1/llvm/lib/IR/Verifier.cpp#L3406 ). LLVM may generate IR with the entries with the same predecessor and the same value in code with switch/case statements (see the C++ example in `tests/compiler/TestSpirvDuplicatePhiHip.hip`)

However, if the SPIRV translator encounters code like this, it currently produces:
```
%retval_0_i = OpPhi %uint %uint_9 %sw_default_i %uint_7 %entry %uint_7 %entry %uint_7 %entry 
```
This SPIRV is invalid since SPIRV does not allow multiple entries in the `OpPhi` with the same predecessor (https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpPh "There must be exactly one Parent i for each parent block of the current block in the CFG.”), and running `spirv-val` fails on it (https://github.com/KhronosGroup/SPIRV-Tools/blob/58fe144fdc8847b303be51d4f8fcc9e7da17056e/source/val/validate_cfg.cpp#L88)

```
> spirv-val p.spv
error: line 59: OpPhi's number of incoming blocks (4) does not match block's predecessor count (4).
  %retval_0_i = OpPhi %uint %uint_9 %sw_default_i %uint_7 %entry %uint_7 %entry %uint_7 %entry
```

This is also discussed in https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/2702 . The PR that closed it (https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/2736) is only for the translation of SPIRV to LLVM IR, not the LLVM IR to SPIRV direction. (`This PR partially fixes issue #2702 in the part that is responsible for SPIR-V to LLVM IR translation.`).

This patch collapses the duplicate entries into one entry. In my understanding, this shouldn’t lose any information as all the duplicate entries are the same.