### PR TITLE
ci: test-llvm-patches builds chipStar against installed LLVM, not build tree

### DIFF
--- a/.github/workflows/test-llvm-patches.yml
+++ b/.github/workflows/test-llvm-patches.yml
@@ -134,8 +134,15 @@ jobs:
           module use ~/modulefiles
           module load oneapi/2025.0.4 opencl/dgpu
 
-          LLVM_BIN="$HOME/llvm-builds/${{ matrix.build-id }}/llvm-project/llvm/build_${{ matrix.llvm-version }}/bin"
+          # Build/test against the INSTALLED LLVM toolchain (staged above), not
+          # the build tree. The build tree's clang resource dir lacks
+          # install-only runtime headers such as omp.h, which made
+          # TestHipccFopenmp fail with "'omp.h' file not found".
+          LLVM_PREFIX="$HOME/install/llvm/${{ matrix.llvm-version }}.0${{ matrix.install-suffix }}"
+          LLVM_BIN="$HOME/llvm-stage/${{ matrix.build-id }}${LLVM_PREFIX}/bin"
           test -f "${LLVM_BIN}/clang" || exit 1
+          test -f "${LLVM_BIN}/../lib/clang/${{ matrix.llvm-version }}/include/omp.h" \
+            || { echo "ERROR: omp.h missing from LLVM install toolchain at ${LLVM_BIN}"; exit 1; }
           cd ${{ github.workspace }}
           rm -rf build-llvm${{ matrix.build-id }}
           mkdir -p build-llvm${{ matrix.build-id }}


### PR DESCRIPTION
Fixes TestHipccFopenmp failing on the Test LLVM Patches lane by building/testing chipStar against the staged LLVM install (which has omp.h) instead of the build tree (which doesn't).