### PR TITLE
tests/hipcc-verify: retire obsolete IGC #403 dropped-kernel reproducer

### DIFF
--- a/tests/hipcc-verify/CMakeLists.txt
+++ b/tests/hipcc-verify/CMakeLists.txt
@@ -1,33 +1,11 @@
 # Tests for chip-kernel-verify (HIPCC_VERIFY post-compile check).
 
-# Reproducer for intel/intel-graphics-compiler#403. Fixture is real-world
-# SPIR-V from rocThrust set_difference_by_key, dumped via
-# CHIP_DUMP_PROCESSED_SPIRV. On dg2 IGC silently drops 3 lookback_set_op_kernel
-# template instantiations (ff/ii/jj element types) under the SIMD32
-# register-pressure retry path.
-#
-# WILL_FAIL flips the exit-code interpretation: while the bug is present
-# chip-kernel-verify exits 1 (3 kernels missing), ctest reports the test as
-# Passed, and the verifier output naming the dropped symbols is still visible
-# in ctest -V / CI logs. If IGC is eventually fixed the verifier will exit 0
-# and this test starts FAILING — that's the signal to retire the fixture.
-# When ocloc is unavailable (e.g. macOS / aarch64 CI) the verifier prints
-# "ocloc not found" and exits 0; SKIP_REGULAR_EXPRESSION marks the test as
-# Skipped so it doesn't get flagged as an unexpected pass.
-#
-# IGC_EnableDPEmulation=1 lets fp64-less (e.g. dg2) compile the
-# fixture's double kernels instead of hard-erroring; the dropped ff/ii/jj
-# kernels aren't fp64, so the #403 drop is unchanged. The extra
-# SKIP_REGULAR_EXPRESSION term Skips rather than fails if ocloc still can't
-# compile the fixture.
-add_test(NAME hipcc_verify_detects_dropped_kernels
-  COMMAND ${CMAKE_BINARY_DIR}/bin/chip-kernel-verify
-          ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/lookback_set_ops.spv)
-set_tests_properties(hipcc_verify_detects_dropped_kernels PROPERTIES
-  ENVIRONMENT "HIPCC_VERIFY_DEVICES=dg2;IGC_EnableDPEmulation=1"
-  WILL_FAIL TRUE
-  SKIP_REGULAR_EXPRESSION "ocloc not found;skipping verification for this device"
-  TIMEOUT 120)
+# The IGC intel/intel-graphics-compiler#403 reproducer
+# (hipcc_verify_detects_dropped_kernels) has been retired: current Intel
+# drivers (ocloc 26.22.38646.4 and newer) compile the lookback_set_ops.spv
+# fixture without dropping any kernels, so the verifier exits 0 and the
+# WILL_FAIL reproducer can no longer pass. The fixture is kept as a generic
+# real-world SPIR-V input for the off-mode sanity check below.
 
 # Sanity: off mode must produce no output and exit 0 regardless of input.
 add_test(NAME hipcc_verify_off_mode_silent


### PR DESCRIPTION
Current Intel drivers (ocloc 26.22.38646.4+) no longer drop kernels when compiling the lookback_set_ops.spv fixture for dg2, so chip-kernel-verify exits 0 and the WILL_FAIL hipcc_verify_detects_dropped_kernels test can no longer pass — it now fails on CI. Remove the reproducer; keep the off-mode sanity test.