### PR TITLE
Fix device-side assert on Intel + omp.h on the LLVM-patches lane

### DIFF
--- a/.github/workflows/test-llvm-patches.yml
+++ b/.github/workflows/test-llvm-patches.yml
@@ -369,8 +369,14 @@ jobs:
           export MODULEPATH="/Users/paulius/modulefiles:$MODULEPATH"
           module load pocl
 
-          LLVM_BIN="$HOME/llvm-builds/22-${{ matrix.variant }}/llvm-project/llvm/build_22/bin"
+          # Build/test against the INSTALLED LLVM toolchain (staged above), not
+          # the build tree, which lacks install-only runtime headers such as
+          # omp.h (breaks TestHipccFopenmp with "'omp.h' file not found").
+          LLVM_PREFIX="$HOME/install/llvm/22.0-${{ matrix.variant }}"
+          LLVM_BIN="$HOME/llvm-stage/22-${{ matrix.variant }}${LLVM_PREFIX}/bin"
           test -f "${LLVM_BIN}/clang" || exit 1
+          test -f "${LLVM_BIN}/../lib/clang/22/include/omp.h" \
+            || { echo "ERROR: omp.h missing from LLVM install toolchain at ${LLVM_BIN}"; exit 1; }
 
           export PATH="/Users/paulius/.pyenv/shims:/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
           export CHIP_DEVICE_TYPE=pocl

--- a/.github/workflows/test-llvm-patches.yml
+++ b/.github/workflows/test-llvm-patches.yml
@@ -134,8 +134,15 @@ jobs:
           module use ~/modulefiles
           module load oneapi/2025.0.4 opencl/dgpu
 
-          LLVM_BIN="$HOME/llvm-builds/${{ matrix.build-id }}/llvm-project/llvm/build_${{ matrix.llvm-version }}/bin"
+          # Build/test against the INSTALLED LLVM toolchain (staged above), not
+          # the build tree. The build tree's clang resource dir lacks
+          # install-only runtime headers such as omp.h, which made
+          # TestHipccFopenmp fail with "'omp.h' file not found".
+          LLVM_PREFIX="$HOME/install/llvm/${{ matrix.llvm-version }}.0${{ matrix.install-suffix }}"
+          LLVM_BIN="$HOME/llvm-stage/${{ matrix.build-id }}${LLVM_PREFIX}/bin"
           test -f "${LLVM_BIN}/clang" || exit 1
+          test -f "${LLVM_BIN}/../lib/clang/${{ matrix.llvm-version }}/include/omp.h" \
+            || { echo "ERROR: omp.h missing from LLVM install toolchain at ${LLVM_BIN}"; exit 1; }
           cd ${{ github.workspace }}
           rm -rf build-llvm${{ matrix.build-id }}
           mkdir -p build-llvm${{ matrix.build-id }}

--- a/.github/workflows/x86-intel-gpu-ci.yml
+++ b/.github/workflows/x86-intel-gpu-ci.yml
@@ -422,7 +422,9 @@ jobs:
 
   unit-tests-llvm-22-translator-debug:
     needs: build-and-test-libceed
-    if: ${{ !cancelled() && github.event_name == 'workflow_dispatch' }}
+    # Run on PRs too (not just manual dispatch): Debug llvm-22 exercises code
+    # paths (e.g. device-side assert) that Release optimizes differently.
+    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') }}
     runs-on: [self-hosted, Linux, X64]
     env:
       CHIP_MODULE_CACHE_DIR: ""
@@ -453,7 +455,9 @@ jobs:
 
   unit-tests-llvm-22-native-debug:
     needs: build-and-test-libceed
-    if: ${{ !cancelled() && github.event_name == 'workflow_dispatch' }}
+    # Run on PRs too (not just manual dispatch): Debug llvm-22 exercises code
+    # paths (e.g. device-side assert) that Release optimizes differently.
+    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') }}
     runs-on: [self-hosted, Linux, X64]
     env:
       CHIP_MODULE_CACHE_DIR: ""

--- a/bitcode/_cl_print_str.cl
+++ b/bitcode/_cl_print_str.cl
@@ -31,3 +31,32 @@ void _cl_print_str(__generic const char *S) {
     ++Pos;
   }
 }
+
+/*
+ * Prints a device-side assertion-failure message:
+ *
+ *   <file>:<line>: <function>: Device-side assertion `<assertion>' failed.
+ *
+ * Implemented here in OpenCL C (rather than directly in the HIP C++
+ * __assert_fail in spirv_hip.hh) so the printf *format* string literals live
+ * in the constant address space. A HIP C++ definition places the literals in
+ * the generic address space, which forces the SPIR-V translator to emit
+ * SPV_EXT_relaxed_printf_string_address_space -- an extension the Intel
+ * compute runtime rejects at clBuildProgram. CUDA and ROCm likewise keep
+ * assert message handling in their device libraries for this reason.
+ *
+ * The user-visible assertion/file/function strings are generic pointers, so
+ * they are printed via _cl_print_str (one %c at a time with a constant format
+ * string) instead of being passed to a %s conversion. Aborting is left to the
+ * caller (HIP's abort(), handled by the HipAbort pass).
+ */
+void _cl_assert_fail_print(__generic const char *file, unsigned int line,
+                           __generic const char *function,
+                           __generic const char *assertion) {
+  _cl_print_str(file);
+  printf(":%u: ", line);
+  _cl_print_str(function);
+  printf(": Device-side assertion `");
+  _cl_print_str(assertion);
+  printf("' failed.\n");
+}

--- a/include/hip/spirv_hip.hh
+++ b/include/hip/spirv_hip.hh
@@ -168,6 +168,16 @@ extern "C" __device__ void abort();
 // compiler may give obscure warnings about it.
 
 extern "C" {
+// Message printing is delegated to _cl_assert_fail_print in chipStar's device
+// library (bitcode/_cl_print_str.cl). Printing there (OpenCL C) keeps the
+// printf format strings in the constant address space; emitting them from a
+// HIP C++ device function would place the literals in the generic address
+// space and force SPV_EXT_relaxed_printf_string_address_space, which the Intel
+// runtime rejects at clBuildProgram. Aborting stays here so abort() resolves
+// to the flag-based __chipspv_abort path (handled by the HipAbort pass).
+__device__ void _cl_assert_fail_print(const char *file, unsigned int line,
+                                      const char *function,
+                                      const char *assertion);
 #if defined(_WIN32) || defined(_WIN64)
 __device__ __attribute__((noinline)) __attribute__((weak)) void
 _wassert(const wchar_t *_msg, const wchar_t *_file, unsigned _line)
@@ -181,16 +191,14 @@ _wassert(const wchar_t *_msg, const wchar_t *_file, unsigned _line)
 __device__ __attribute__((noinline)) __attribute__((weak)) void
 __assert_rtn(const char *function, const char *file, int line,
              const char *assertion) {
-  printf("%s:%d: %s: Device-side assertion `%s' failed.\n", file, line,
-         function, assertion);
+  _cl_assert_fail_print(file, line, function, assertion);
   abort();
 }
 #else  // defined(_WIN32) || defined(_WIN64) || defined(__APPLE__)
 __device__ __attribute__((noinline)) __attribute__((weak)) void
 __assert_fail(const char *assertion, const char *file, unsigned int line,
               const char *function) {
-  printf("%s:%u: %s: Device-side assertion `%s' failed.\n", file, line,
-         function, assertion);
+  _cl_assert_fail_print(file, line, function, assertion);
   abort();
 }
 #endif // defined(_WIN32) || defined(_WIN64) || defined(__APPLE__)

--- a/llvm-patches/llvm-21-macos.patch
+++ b/llvm-patches/llvm-21-macos.patch
@@ -208,7 +208,7 @@ index 53649ca40d99..3be6a97c2581 100644
 +  // Strictly put we'd need 1.3 for the standard non-extension shuffle
 +  // operations, but it's not supported by any target yet.
 +  llvm::opt::ArgStringList TrArgs{"--spirv-max-version=1.2",
-+                                  "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups,+SPV_EXT_shader_atomic_float_add,+SPV_EXT_relaxed_printf_string_address_space"};
++                                  "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups,+SPV_EXT_shader_atomic_float_add"};
    InputInfo TrInput = InputInfo(types::TY_LLVM_BC, TempFile, "");
    SPIRV::constructTranslateCommand(C, *this, JA, Output, TrInput, TrArgs);
  }

--- a/llvm-patches/llvm/0001-0004-spirv-version-and-extensions-llvm22.patch
+++ b/llvm-patches/llvm/0001-0004-spirv-version-and-extensions-llvm22.patch
@@ -13,7 +13,7 @@ index f797573a5725..99bf1dc16b3b 100644
 +  // Strictly put we'd need 1.3 for the standard non-extension shuffle
 +  // operations, but it's not supported by any target yet.
 +  llvm::opt::ArgStringList TrArgs{"--spirv-max-version=1.2",
-+                                  "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups,+SPV_EXT_shader_atomic_float_add,+SPV_EXT_relaxed_printf_string_address_space"};
++                                  "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups,+SPV_EXT_shader_atomic_float_add"};
    InputInfo TrInput = InputInfo(types::TY_LLVM_BC, TempFile, "");
    SPIRV::constructTranslateCommand(C, *this, JA, Output, TrInput, TrArgs);
  }

--- a/llvm-patches/llvm/0004-only-necessary-exts.patch
+++ b/llvm-patches/llvm/0004-only-necessary-exts.patch
@@ -7,7 +7,7 @@ index 69816057d72c..5785786aec2d 100644
    // operations, but it's not supported by any target yet.
    llvm::opt::ArgStringList TrArgs{"--spirv-max-version=1.2",
 -                                  "--spirv-ext=+all"};
-+                                  "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups,+SPV_EXT_shader_atomic_float_add,+SPV_EXT_relaxed_printf_string_address_space"};
++                                  "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups,+SPV_EXT_shader_atomic_float_add"};
    InputInfo TrInput = InputInfo(types::TY_LLVM_BC, TempFile, "");
    SPIRV::constructTranslateCommand(C, *this, JA, Output, TrInput, TrArgs);
  }

--- a/llvm_passes/HipVerify.cpp
+++ b/llvm_passes/HipVerify.cpp
@@ -466,7 +466,7 @@ std::vector<uint32_t> HipVerifyPass::convertIRToSPIRV(Module &M, std::string &er
   SmallVector<StringRef, 8> Args{
     LLVMSpirvPath,
     "--spirv-max-version=1.2",
-    "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups,+SPV_EXT_shader_atomic_float_add,+SPV_EXT_relaxed_printf_string_address_space",
+    "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups,+SPV_EXT_shader_atomic_float_add",
     "-o", SPVTempFile,
     BCTempFile
   };


### PR DESCRIPTION
Combines the omp.h CI fix (formerly #1307) with the device-side assert fix so the Test LLVM Patches lane can go green.

- ci: build/test chipStar against the installed LLVM (has omp.h), fixing TestHipccFopenmp.
- assert: print the assertion message from the OpenCL-C device library (constant-AS format strings) and drop SPV_EXT_relaxed_printf_string_address_space from chipStar's --spirv-ext lists — the Intel runtime rejects that extension, which made Unit_Assert_Positive_Basic_KernelPass hang (200s) on the GPU.
- ci: also run Debug llvm-22 Intel-GPU unit tests on PRs (Debug is where the assert issue surfaced).

Verified on Intel Arc B570: Unit_Assert_Positive_Basic_KernelPass passes (was timing out); printf unaffected.