### PR TITLE
known_failures: exclude TestHipLaunchHostFuncMultiStream on all backends

### DIFF
--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -1,6 +1,7 @@
 TOTAL_TESTS: 1872
 ANY:
   ALL:
+    TestHipLaunchHostFuncMultiStream: 'Intermittent hipLaunchHostFunc callback deadlock (pre-existing race, #1062/#1067); rare timeout, surfaces under full-suite runs incl. Level Zero/Aurora'
     TestTypeCastIntrinsics: 'iGPU failure'
     '.*[Gg]raph.*': 'All HIP graph API and stream capture tests'
     '.*[Cc]aptur.*': 'Stream capture tests (Capture/Capturing)'
@@ -828,7 +829,6 @@ ANY:
     TestDefaultStreamImplicitSync: 'Failed'
     TestHipLaunchHostFunc: 'Failed'
     TestBoolKernelParam: 'Failed'
-    TestHipLaunchHostFuncMultiStream: 'Failed'
     TestDefaultBackend: 'Failed'
     TestNativeHandlesBackendName: 'Failed'
     TestHeCBenchF16Max: 'Failed'


### PR DESCRIPTION
TestHipLaunchHostFuncMultiStream is a pre-existing intermittent hipLaunchHostFunc callback deadlock (#1062/#1067) that surfaces under full-suite runs on Level Zero/Aurora but was only categorized under OPENCL_POCL, so Aurora CI didn't exclude it. Moves it to ALL until the underlying callback deadlock is fixed.