### PR TITLE
Avoid crashing on unsupported mixed texture uses

### DIFF
--- a/llvm_passes/HipTextureLowering.cpp
+++ b/llvm_passes/HipTextureLowering.cpp
@@ -200,10 +200,10 @@ static void analyze(Value *V, TextureUseGroup &TexUseGroup,
   };
 
   if (TexUseGroupMap.count(V)) { // Already visited and processed?
-    // Check this analysis run does not overlap with a previous one.
-    // FIXME/TODO: Only accepted overlap is nodes that are classified as unknown
-    //             source and texture user.
-    assert(TexUseGroupMap[V] == &TexUseGroup);
+    // The same texture value can be reached from multiple texture calls in
+    // unsupported use cases such as a single texture object used as both 1D
+    // and 2D image. Do not assert/crash while analyzing those cases; the
+    // lowering step will diagnose unsupported groups below.
     return;
   }
 
@@ -402,7 +402,10 @@ static void lowerTextureObjectUses(Function *F,
     // 2) the texture use case can not be implemented using OpenCL image read
     //    functions. In this case the texture function calls should be emulated
     //    (which is not implemented).
-    llvm_unreachable("Don't know how to lower this texture use case.");
+    C.emitError("unsupported HIP texture object use in " + F->getName() +
+                ": a texture object must be used with exactly one "
+                "OpenCL-supported texture dimensionality");
+    return;
   }
 
   for (auto *ToErase : EraseList)

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -162,8 +162,10 @@ add_shell_test(TestPrintfStaticString.bash)
 # duplicate-predecessor OpPhi). Translates to SPIR-V and run spirv-val;
 # without 0005 the writer emits an invalid OpPhi and validation fails. This skips
 # when the in-tree SPIR-V backend is used (LLVM_SPIRV=NOT_NEEDED), since 0005
-# patches the external translator. 
+# patches the external translator.
 add_shell_test(TestSpirvDuplicatePhiHip.bash)
+
+add_shell_test(TestTextureUnsupportedMixedDim.bash)
 
 add_hipcc_test(TestLdg.hip HIPCC_OPTIONS -fsyntax-only)
 add_hipcc_test(TestSwitchCase.hip HIPCC_OPTIONS -O1 -c)

--- a/tests/compiler/TestTextureUnsupportedMixedDim.bash
+++ b/tests/compiler/TestTextureUnsupportedMixedDim.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -u
+out=/tmp/TestTextureUnsupportedMixedDim.$$.out
+trap 'rm -f "$out"' EXIT
+
+@CMAKE_BINARY_DIR@/bin/hipcc -c \
+  @CMAKE_CURRENT_SOURCE_DIR@/TestTextureUnsupportedMixedDim.hip \
+  -o /dev/null > "$out" 2>&1
+rc=$?
+cat "$out"
+
+test $rc -ne 0
+! grep -Eq "UNREACHABLE|Assertion .* failed|PLEASE submit a bug report" "$out"
+grep -q "unsupported HIP texture object use" "$out"

--- a/tests/compiler/TestTextureUnsupportedMixedDim.hip
+++ b/tests/compiler/TestTextureUnsupportedMixedDim.hip
@@ -1,0 +1,21 @@
+// Regression test for issue #177: unsupported mixed-dimensional texture
+// use must produce a diagnostic instead of crashing HipTextureLowering.
+#include <hip/hip_runtime.h>
+
+template <typename T>
+__global__ void mixedTexture(T *output, hipTextureObject_t texObj, size_t width,
+                             size_t height) {
+  const unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+  const unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+  const float u = x / static_cast<float>(width);
+
+  if (height == 0) {
+    output[x] = tex1D<T>(texObj, u);
+  } else {
+    const float v = y / static_cast<float>(height);
+    output[y * width + x] = tex2D<T>(texObj, u, v);
+  }
+}
+
+template __global__ void mixedTexture<float>(float *, hipTextureObject_t, size_t,
+                                             size_t);


### PR DESCRIPTION
## Summary
- replace the HipTextureLowering assertion/unreachable path for unsupported texture-use groups with a regular LLVM diagnostic
- allow overlapping texture analysis visits to fall through to the unsupported-use diagnostic instead of crashing assertion builds
- add a regression test for a kernel that uses the same texture object as both tex1D and tex2D

Closes #177

## Testing
- `make -j$(nproc) LLVMHipPasses`
- `ctest -R "TestTextureUnsupportedMixedDim|TestLdg|TestSwitchCase" --output-on-failure`
