### PR TITLE
HipVerify: enable validation by default in Debug builds

### DIFF
--- a/llvm_passes/CMakeLists.txt
+++ b/llvm_passes/CMakeLists.txt
@@ -135,6 +135,12 @@ if(APPLE)
   target_link_libraries(LLVMHipDefrost PRIVATE LLVM)
 endif()
 
+# In Debug builds, default HipVerify to "failures" mode so the IR/SPIR-V
+# validation pipeline runs automatically (see HipVerify.cpp::getVerificationMode).
+# Release builds keep it off due to the compile-time cost (CHIP-SPV/chipStar#1047).
+target_compile_definitions(LLVMHipPasses PRIVATE
+  $<$<CONFIG:Debug>:CHIP_DEBUG_BUILD>)
+
 # If trying to recompile with LLVM unloaded, the inlcude path is not found
 target_compile_options(LLVMHipDynMem PRIVATE -I/${LLVM_INCLUDE_DIRS})
 target_compile_options(LLVMHipStripUsedIntrinsics PRIVATE -I/${LLVM_INCLUDE_DIRS})

--- a/llvm_passes/HipVerify.cpp
+++ b/llvm_passes/HipVerify.cpp
@@ -101,9 +101,16 @@ std::string HipVerifyPass::getVerificationMode() {
   // Check environment variable
   const char* env = std::getenv("CHIP_VERIFY_MODE");
 
-  // Default to "off" due to pathological compilation time issue
-  // (CHIP-SPV/chipStar#1047).
+  // Default to "off" in release builds due to the pathological compilation
+  // time issue (CHIP-SPV/chipStar#1047). In debug builds default to "failures"
+  // so the IR/SPIR-V validation pipeline runs and surfaces invalid SPIR-V
+  // (e.g. the duplicate-predecessor OpPhi from CHIP-SPV/chipStar#1306) without
+  // requiring CHIP_VERIFY_MODE to be set manually.
+#ifdef CHIP_DEBUG_BUILD
+  const std::string DefaultMode = "failures";
+#else
   const std::string DefaultMode = "off";
+#endif
 
   if (!env)
     return DefaultMode;


### PR DESCRIPTION
Default `CHIP_VERIFY_MODE` to `failures` in Debug builds (via a `CHIP_DEBUG_BUILD` compile definition), so the IR/SPIR-V validation pipeline runs automatically without anyone having to set the env var; Release builds stay off due to the compile-time cost

This is a follow-up to #1306, which fixed the SPIRV translator emitting an invalid duplicate-predecessor `OpPhi`. That bug shipped because HipVerify — which would have caught it — defaults to `off` for everyone. Verified against the pre-#1306 (unpatched) translator: `llvm-spirv` produces the module silently (SPIRV Compile = PASS) but `spirv-val` rejects it (`OpPhi's number of incoming blocks (4) does not match block's predecessor count`), which is exactly HipVerify's validation stage. With this change, a Debug build compiling that reproducer now prints the failure table automatically with no env var set:

```
| LLVM Pass        | IR Validate | SPIRV Compile | SPIR-V Validate                            |
| Post-HIP passes  | PASS        | PASS          | error: ... OpPhi's number of incoming ... |
SPIR-V Validation: 0/27 passed
```

So defects of this class will now be caught at build/test time in Debug builds going forward.