### PR TITLE
[L0] Fix shutdown heap corruption: destroy device before event pools (#1311)

### DIFF
--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -2485,14 +2485,21 @@ CHIPContextLevel0::~CHIPContextLevel0() {
     Backend->Events.clear();  // This releases all shared_ptr, triggering returnEvent()
   }
 
-  // delete all event pools
+  // Delete the device (and thus its queues) BEFORE deleting the event pools.
+  // Queues hold shared_ptr<Event> in PendingCrossQueueDeps_ whose custom
+  // deleter (LZEventPool::returnEvent) pushes the raw event back onto the
+  // owning pool. At shutdown finish() may be skipped or throw before clearing
+  // those refs, so they are released only when ~CHIPQueueLevel0 destroys its
+  // event vector. If the pools were freed first, returnEvent would push onto
+  // freed memory, corrupting the heap (issue #1311).
+  delete static_cast<CHIPDeviceLevel0 *>(ChipDevice_);
+
+  // Now that all queues are gone and have returned their events, the pools
+  // can be safely deleted.
   for (LZEventPool *Pool : EventPools_)
     delete Pool;
 
   EventPools_.clear();
-
-  // delete all devicesA
-  delete static_cast<CHIPDeviceLevel0 *>(ChipDevice_);
 
   while (!this->FencedCmdListsPool_.empty())
     this->FencedCmdListsPool_.pop();

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -24,6 +24,7 @@
 #include "Utils.hh"
 
 #include <chrono>
+#include <cstdlib>
 #include <ctime>
 #include <fstream>
 
@@ -2005,7 +2006,17 @@ void CHIPQueueLevel0::finish() {
 
   // All GPU work on this queue has completed. Release cross-queue dependency
   // marker events so their ze_events can be recycled by the event pool.
-  PendingCrossQueueDeps_.clear();
+  //
+  // Test-only fault injection for issue #1311: when the environment variable
+  // CHIP_L0_TEST_RETAIN_CROSSQUEUE_DEPS is set, skip clearing the markers. This
+  // deterministically reproduces the production condition (seen with Zero-RK on
+  // Aurora) where finish() does not reach this point at shutdown -- e.g. one of
+  // the Level Zero synchronize calls above throws -- leaving the marker events
+  // alive until the queue is destroyed during context teardown.
+  static const bool RetainCrossQueueDepsForTest =
+      std::getenv("CHIP_L0_TEST_RETAIN_CROSSQUEUE_DEPS") != nullptr;
+  if (!RetainCrossQueueDepsForTest)
+    PendingCrossQueueDeps_.clear();
   IsEmptyQueue_.store(true);
   CmdListInitialized_.store(true);
   return;

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -11,3 +11,5 @@ add_hip_test(TestFixUmul64hi.hip)
 set_tests_properties(TestFixUmul64hi PROPERTIES
   PASS_REGULAR_EXPRESSION "PASS"
   TIMEOUT 60)
+
+add_hip_test(test_shutdown_crossqueue_dep.cpp)

--- a/tests/regression/test_shutdown_crossqueue_dep.cpp
+++ b/tests/regression/test_shutdown_crossqueue_dep.cpp
@@ -1,0 +1,74 @@
+// Reproducer for issue #1311: heap corruption ("malloc(): unsorted double
+// linked list corrupted", SIGABRT) at process shutdown -- a regression from
+// the shared-immediate-command-list change (#1293).
+//
+// Mechanism: mixing the default stream with explicit blocking streams makes
+// CHIPQueueLevel0 store cross-queue sync marker events in
+// PendingCrossQueueDeps_. Those markers' shared_ptr deleter is
+// LZEventPool::returnEvent, which pushes the raw event back onto the owning
+// pool. CHIPContextLevel0::~CHIPContextLevel0 must delete the device (and thus
+// its queues, releasing those markers back into the pools) BEFORE deleting the
+// event pools. The pre-fix ordering freed the pools first, so returnEvent
+// pushed onto freed memory at teardown and corrupted the heap.
+//
+// In normal runs chipStar's shutdown safety net (CHIPUninitializeCallOnce ->
+// Queue::finish() -> PendingCrossQueueDeps_.clear()) hides the bug. Zero-RK
+// defeats that net (a finish() whose Level Zero sync throws before the clear).
+// This test reproduces that condition deterministically via the test-only env
+// var CHIP_L0_TEST_RETAIN_CROSSQUEUE_DEPS, which makes finish() retain the
+// markers. It then exits WITHOUT destroying streams/events so all teardown runs
+// through the runtime shutdown destructors -- the path that corrupted the heap.
+//
+// Expected: exits cleanly ("PASS"). Pre-fix: aborts in libc during shutdown.
+#include <hip/hip_runtime.h>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#define CHECK(expr) do {                                                    \
+  hipError_t e = (expr);                                                    \
+  if (e != hipSuccess) {                                                    \
+    printf("FAIL %s = %d (%s)\n", #expr, (int)e, hipGetErrorString(e));     \
+    return 1;                                                               \
+  }                                                                         \
+} while (0)
+
+__global__ void scale(float *a) {
+  int i = threadIdx.x + blockIdx.x * blockDim.x;
+  a[i] = a[i] * 2.0f + 1.0f;
+}
+
+int main() {
+  // Force the cross-queue dependency markers to survive until teardown,
+  // reproducing the Zero-RK shutdown condition. Must be set before any HIP
+  // call so the runtime observes it on the first finish().
+  setenv("CHIP_L0_TEST_RETAIN_CROSSQUEUE_DEPS", "1", 1);
+
+  const int NS = 16;
+  const int N = 1 << 14;
+  const size_t sz = N * sizeof(float);
+
+  float *d;
+  CHECK(hipMalloc(&d, sz));
+  std::vector<float *> bufs(NS);
+  std::vector<hipStream_t> streams(NS);
+  for (int i = 0; i < NS; i++) {
+    CHECK(hipMalloc(&bufs[i], sz));
+    CHECK(hipStreamCreate(&streams[i]));
+  }
+
+  // Interleave default-stream and blocking-stream work so each queue
+  // accumulates cross-queue dependency markers.
+  for (int it = 0; it < 64; ++it) {
+    hipLaunchKernelGGL(scale, dim3(N / 256), dim3(256), 0, 0, d);
+    for (int i = 0; i < NS; i++)
+      hipLaunchKernelGGL(scale, dim3(N / 256), dim3(256), 0, streams[i], bufs[i]);
+  }
+
+  CHECK(hipDeviceSynchronize());
+
+  // Intentionally no hipStreamDestroy / hipFree: leave teardown to the runtime
+  // shutdown destructors, which is where #1311 corrupted the heap.
+  printf("PASS\n");
+  return 0;
+}


### PR DESCRIPTION
## Problem

After #1293, Zero-RK CI on Aurora aborts at process exit with `malloc(): unsorted double linked list corrupted` (rank 0, SIGABRT) — issue #1311.

## Root cause

`CHIPContextLevel0::~CHIPContextLevel0()` deleted the `LZEventPool`s **before** deleting the device. The device dtor deletes its queues, and each `CHIPQueueLevel0` holds cross-queue sync marker events in `PendingCrossQueueDeps_` whose `shared_ptr` deleter (`LZEventPool::returnEvent`) pushes the raw event back onto its owning pool. `finish()` — which clears `PendingCrossQueueDeps_` — is skipped or may throw at shutdown, so those events are released only when `~CHIPQueueLevel0` destroys its event vector, by which point the pools are already freed. `returnEvent` then `push_back`s onto freed memory → heap corruption. This matches the gdb backtrace in #1311 exactly.

## Fix

Reorder the destructor to delete the device (draining its queues back into the still-live pools) before deleting the pools.

`tests/regression/test_shutdown_crossqueue_dep.cpp` exercises the default-stream + blocking-stream path that populates `PendingCrossQueueDeps_`, then exits without explicit cleanup so teardown runs through the shutdown destructors.

The shutdown safety net (`CHIPUninitializeCallOnce` → `finish()` → clear) normally hides the bug; Zero-RK defeats it. To reproduce deterministically, a test-only fault-injection env var `CHIP_L0_TEST_RETAIN_CROSSQUEUE_DEPS` (default off, set by the test itself) makes `finish()` retain the markers, mirroring the production condition.

Verified on Aurora (PVC Max 1550):

| State | Result |
|---|---|
| reproducer commit (pre-fix) | **10/10 crashed** — `malloc(): unsorted double linked list corrupted` (rc=134) |
| fix commit | **10/10 PASS** |


Fixes #1311
