### PR TITLE
feat: opt-in over-cap single allocations via CHIP_UNRESTRICTED_ALLOC_SIZE

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1495,9 +1495,10 @@ void *chipstar::Context::allocate(size_t Size, size_t Alignment,
     return HostPtr;
   }
 
-  if (Size > ChipDev->getMaxMallocSize()) {
+  if (Size > ChipDev->getMaxMallocSize() && !chipUnrestrictedAllocSize()) {
     logCritical("Requested allocation of {} exceeds the maximum size of a "
-                "single allocation of {}",
+                "single allocation of {} (set CHIP_UNRESTRICTED_ALLOC_SIZE=1 "
+                "to allow larger allocations)",
                 Size, ChipDev->getMaxMallocSize());
     CHIPERR_LOG_AND_THROW(
         "Allocation size exceeds limits for a single allocation",

--- a/src/CHIPDriver.cc
+++ b/src/CHIPDriver.cc
@@ -39,6 +39,7 @@ std::mutex ApiMtx;
 
 #include <string>
 #include <memory>
+#include <cstdlib>
 
 #include "backend/backends.hh"
 #include "Utils.hh"
@@ -51,6 +52,42 @@ chipstar::Backend *Backend = nullptr;
 std::atomic_ulong CHIPNumRegisteredFatBinaries;
 
 EnvVars ChipEnvVars;
+
+// Opt-in: allow a single allocation larger than the device's reported
+// maxMemAllocSize (e.g. the 4 GiB cap on Intel Arc / Data Center GPUs) to
+// succeed when sufficient device memory is available. Controlled by
+// CHIP_UNRESTRICTED_ALLOC_SIZE=1; OFF by default.
+//
+// This applies to both backends equally:
+//   - chipStar's own getMaxMallocSize() guard is bypassed (CHIPBackend.cc).
+//   - OpenCL: NEO requires AllowUnrestrictedSize=1, which is only honored when
+//     NEOReadDebugKeys=1 (set here, before any driver call).
+//   - Level Zero: the device allocation is made with the
+//     ze_relaxed_allocation_limits extension (CHIPBackendLevel0.cc).
+//
+// It is OFF by default because the OpenCL path is not free: NEOReadDebugKeys=1
+// switches the NEO driver into debug-key mode globally, which makes high
+// register-pressure / high-scratch kernels (e.g. unoptimized -O0 kernels) fail
+// at execution with CL_OUT_OF_RESOURCES even when they run fine without it.
+// That regression is far more common than the need for >4 GiB single
+// allocations, so we do not enable it unless explicitly requested.
+bool chipUnrestrictedAllocSize() {
+  static const bool Enabled = [] {
+    const char *Opt = std::getenv("CHIP_UNRESTRICTED_ALLOC_SIZE");
+    return Opt && Opt[0] == '1';
+  }();
+  return Enabled;
+}
+
+// NEO debug keys must be set before the OpenCL driver is loaded, so this runs
+// in a priority-101 constructor. setenv(..., overwrite=0) preserves any
+// user-provided override.
+__attribute__((constructor(101))) static void chipEnableNeoLargeAlloc() {
+  if (chipUnrestrictedAllocSize()) {
+    setenv("NEOReadDebugKeys", "1", /*overwrite=*/0);
+    setenv("AllowUnrestrictedSize", "1", /*overwrite=*/0);
+  }
+}
 
 // CUDA Driver API: "If cuInit() has not been called, any function
 // from the driver API will return CUDA_ERROR_NOT_INITIALIZED".

--- a/src/CHIPDriver.hh
+++ b/src/CHIPDriver.hh
@@ -109,6 +109,13 @@ extern hipError_t CHIPReinitialize(const uintptr_t *NativeHandles,
                                    int NumHandles);
 
 /**
+ * True when CHIP_UNRESTRICTED_ALLOC_SIZE=1, i.e. the user has opted in to
+ * allocating a single buffer larger than the device's reported
+ * maxMemAllocSize. Applies to both the OpenCL and Level Zero backends.
+ */
+bool chipUnrestrictedAllocSize();
+
+/**
  * Number of fat binaries registerer through __hipRegisterFatBinary(). On
  * program exit this value (non-zero) will postpone chipStar runtime
  * uninitialization until the all the registered binaries have been

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -2508,6 +2508,18 @@ void *CHIPContextLevel0::allocateImpl(size_t Size, size_t Alignment,
       /* DmaDesc.flags   = */ DeviceFlags,
       /* DmaDesc.ordinal = */ 0,
   };
+
+  // Opt-in: permit a single allocation larger than the device's reported
+  // maxMemAllocSize via the ze_relaxed_allocation_limits extension. This is
+  // the Level Zero equivalent of NEO's AllowUnrestrictedSize for OpenCL.
+  ze_relaxed_allocation_limits_exp_desc_t RelaxedDesc{
+      /* RelaxedDesc.stype = */
+      ZE_STRUCTURE_TYPE_RELAXED_ALLOCATION_LIMITS_EXP_DESC,
+      /* RelaxedDesc.pNext = */ nullptr,
+      /* RelaxedDesc.flags = */ ZE_RELAXED_ALLOCATION_LIMITS_EXP_FLAG_MAX_SIZE,
+  };
+  if (chipUnrestrictedAllocSize())
+    DmaDesc.pNext = &RelaxedDesc;
   ze_host_mem_alloc_flags_t HostFlags = ZE_DEVICE_MEM_ALLOC_FLAG_BIAS_CACHED;
   if (Flags.isWriteCombined())
     HostFlags += ZE_HOST_MEM_ALLOC_FLAG_BIAS_WRITE_COMBINED;


### PR DESCRIPTION
Allows a single allocation larger than the device's reported `maxMemAllocSize` (the ~4 GiB cap some Intel Arc / Data Center GPUs report) to succeed when enough VRAM is available. Off by default; enable with `CHIP_UNRESTRICTED_ALLOC_SIZE=1`. Applies to both backends equally: bypasses chipStar's `getMaxMallocSize()` guard, sets NEO's `AllowUnrestrictedSize`/`NEOReadDebugKeys` for OpenCL, and chains `ze_relaxed_allocation_limits` onto the L0 alloc descriptor.

Off by default because the OpenCL path is not free: `NEOReadDebugKeys=1` puts the NEO driver into debug-key mode globally, which makes high register-pressure / high-scratch kernels (e.g. unoptimized -O0 kernels) fail with `CL_OUT_OF_RESOURCES`. That regression is more common than the need for >4 GiB single allocations.

A single shared helper `chipUnrestrictedAllocSize()` gates all three sites.
