### PR TITLE
Relax kernel arg promotion to i1 only (#1261)

### DIFF
--- a/llvm_passes/HipPromoteInts.cpp
+++ b/llvm_passes/HipPromoteInts.cpp
@@ -1228,17 +1228,18 @@ Value*processInstruction(Instruction *I, Type *NonStdType, Type *PromotedTy,
 }
 
 /// Check if a kernel argument type needs promotion to i32 for SPIR-V
-/// conformance. OpenCL requires kernel arguments to be at least 32 bits wide.
+/// conformance. The SPIR-V OpTypeInt supported widths are 8, 16, 32 and 64,
+/// so i8/i16/i32/i64 kernel arguments are already conformant. Only i1 (bool)
+/// maps to OpTypeBool, which is not a valid kernel argument type, so it is the
+/// only integer type that must be promoted to i32.
 static bool needsKernelArgPromotion(Type *T) {
-  if (auto *IntTy = dyn_cast<IntegerType>(T)) {
-    unsigned BW = IntTy->getBitWidth();
-    return BW < 32; // i1 (bool), i8 (char), i16 (short)
-  }
+  if (auto *IntTy = dyn_cast<IntegerType>(T))
+    return IntTy->getBitWidth() == 1; // i1 (bool) only
   return false;
 }
 
-/// Promote narrow (< i32) integer kernel arguments to i32 for SPIR-V/OpenCL
-/// conformance. Modifies the kernel function in-place: replaces narrow
+/// Promote i1 (bool) integer kernel arguments to i32 for SPIR-V/OpenCL
+/// conformance. Modifies the kernel function in-place: replaces bool
 /// params with i32 and inserts trunc instructions at the entry block.
 ///
 /// Previous implementation created a wrapper+unpromoted-function pattern
@@ -1322,7 +1323,7 @@ static bool promoteKernelArgs(Module &M) {
 PreservedAnalyses HipPromoteIntsPass::run(Module &M,
                                           ModuleAnalysisManager &AM) {
 
-  // Promote narrow (i1, i8, i16) kernel arguments to i32 for SPIR-V/OpenCL
+  // Promote i1 (bool) kernel arguments to i32 for SPIR-V/OpenCL
   // conformance before doing anything else.
   bool Changed = promoteKernelArgs(M);
 

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -191,6 +191,7 @@ add_hip_runtime_test(TestHipLaunchHostFunc.cpp)
 
 add_hip_runtime_test(TestBoolKernelParam.hip)
 add_hip_runtime_test(TestBoolParamShuffle.cpp)
+add_hip_runtime_test(TestCharShortKernelParam.hip)
 find_program(SPIRV_DIS spirv-dis)
 find_program(
   CLANG_OFFLOAD_BUNDLER
@@ -198,6 +199,7 @@ find_program(
   PATHS ${HIP_CLANG_PATH})
 if(SPIRV_DIS AND (NOT USE_NEW_OFFLOAD_DRIVER OR CLANG_OFFLOAD_BUNDLER))
   add_shell_test(TestBoolKernelParamSPIRV.bash)
+  add_shell_test(TestCharShortKernelParamSPIRV.bash)
 endif()
 # Test hipLaunchHostFunc with multi-stream and events (from PR #1071)
 add_hip_runtime_test(TestHipLaunchHostFuncMultiStream.cpp)

--- a/tests/runtime/TestCharShortKernelParam.hip
+++ b/tests/runtime/TestCharShortKernelParam.hip
@@ -1,0 +1,59 @@
+#include <hip/hip_runtime.h>
+#include <cstdio>
+
+// Regression test for issue #1261: char (i8) and short (i16) kernel arguments
+// are valid SPIR-V OpTypeInt widths (8, 16, 32, 64) and must NOT be promoted
+// to i32. This checks that narrow integer parameters are passed and used
+// correctly by the runtime.
+
+__global__ void charKernel(char c, int *out) { *out = (int)c; }
+
+__global__ void shortKernel(short s, int *out) { *out = (int)s; }
+
+__global__ void unsignedNarrowKernel(unsigned char uc, unsigned short us,
+                                     int *out) {
+  *out = (int)uc + (int)us;
+}
+
+__global__ void mixedKernel(char a, short b, int c, int *out) {
+  *out = (int)a + (int)b + c;
+}
+
+int main() {
+  int *d_out;
+  int h_out;
+  hipMalloc(&d_out, sizeof(int));
+
+  charKernel<<<1, 1>>>((char)-7, d_out);
+  hipMemcpy(&h_out, d_out, sizeof(int), hipMemcpyDeviceToHost);
+  if (h_out != -7) {
+    printf("FAIL: charKernel(-7) got %d\n", h_out);
+    return 1;
+  }
+
+  shortKernel<<<1, 1>>>((short)-1234, d_out);
+  hipMemcpy(&h_out, d_out, sizeof(int), hipMemcpyDeviceToHost);
+  if (h_out != -1234) {
+    printf("FAIL: shortKernel(-1234) got %d\n", h_out);
+    return 1;
+  }
+
+  unsignedNarrowKernel<<<1, 1>>>((unsigned char)200, (unsigned short)60000,
+                                 d_out);
+  hipMemcpy(&h_out, d_out, sizeof(int), hipMemcpyDeviceToHost);
+  if (h_out != 200 + 60000) {
+    printf("FAIL: unsignedNarrowKernel got %d\n", h_out);
+    return 1;
+  }
+
+  mixedKernel<<<1, 1>>>((char)5, (short)500, 50000, d_out);
+  hipMemcpy(&h_out, d_out, sizeof(int), hipMemcpyDeviceToHost);
+  if (h_out != 5 + 500 + 50000) {
+    printf("FAIL: mixedKernel got %d\n", h_out);
+    return 1;
+  }
+
+  printf("PASS\n");
+  hipFree(d_out);
+  return 0;
+}

--- a/tests/runtime/TestCharShortKernelParamSPIRV.bash
+++ b/tests/runtime/TestCharShortKernelParamSPIRV.bash
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Regression test for issue #1261: char (i8) and short (i16) kernel parameters
+# are valid SPIR-V OpTypeInt widths and must NOT be promoted to i32. This test
+# compiles a HIP kernel with char/short parameters and checks the generated
+# SPIR-V to ensure the narrow integer parameters are preserved.
+
+set -e
+
+HIPCC="@CMAKE_BINARY_DIR@/bin/hipcc"
+SPIRV_DIS="@SPIRV_DIS@"
+SRC="@CMAKE_CURRENT_SOURCE_DIR@/TestCharShortKernelParam.hip"
+WORKDIR=$(mktemp -d)
+trap "rm -rf $WORKDIR" EXIT
+
+if [ ! -x "$SPIRV_DIS" ]; then
+  echo "HIP_SKIP_THIS_TEST: spirv-dis not found at $SPIRV_DIS"
+  exit 0
+fi
+
+cd "$WORKDIR"
+
+if [ "@USE_NEW_OFFLOAD_DRIVER@" = "ON" ]; then
+    "$HIPCC" --offload-device-only -c "$SRC" -o device.o 2>/dev/null
+    "@CLANG_OFFLOAD_BUNDLER@" -unbundle --type=o \
+                              --targets=hip-@OFFLOAD_TRIPLE@--generic \
+                              --inputs=device.o --output=spv_binary.out
+    SPV_FILE=spv_binary.out
+else
+    "$HIPCC" --save-temps "$SRC" -o test_charshort 2>/dev/null
+    SPV_FILE=$(ls *.out 2>/dev/null | head -1)
+fi
+
+if [ -z "$SPV_FILE" ]; then
+  echo "FAIL: No .out SPIR-V file produced by hipcc --save-temps"
+  exit 1
+fi
+
+DISASM=$("$SPIRV_DIS" "$SPV_FILE" 2>/dev/null)
+DISASM_FILE="$WORKDIR/disasm.txt"
+echo "$DISASM" > "$DISASM_FILE"
+
+# The charKernel entry point should have an 8-bit integer parameter and
+# shortKernel a 16-bit integer parameter, i.e. they were not promoted.
+# Grab the type ids for the 8- and 16-bit integer types.
+I8_TYPE=$(grep -oE "%[a-zA-Z0-9_]+ = OpTypeInt 8 0" "$DISASM_FILE" | \
+  head -1 | awk '{print $1}')
+I16_TYPE=$(grep -oE "%[a-zA-Z0-9_]+ = OpTypeInt 16 0" "$DISASM_FILE" | \
+  head -1 | awk '{print $1}')
+
+if [ -z "$I8_TYPE" ]; then
+  echo "FAIL: No 8-bit integer type (OpTypeInt 8 0) found; char param was promoted."
+  exit 1
+fi
+if [ -z "$I16_TYPE" ]; then
+  echo "FAIL: No 16-bit integer type (OpTypeInt 16 0) found; short param was promoted."
+  exit 1
+fi
+
+# Ensure at least one kernel entry point actually takes the narrow type as a
+# function parameter (not only used internally).
+if ! grep -q "OpFunctionParameter ${I8_TYPE}\b" "$DISASM_FILE"; then
+  echo "FAIL: No kernel takes an 8-bit integer parameter; char param was promoted."
+  exit 1
+fi
+if ! grep -q "OpFunctionParameter ${I16_TYPE}\b" "$DISASM_FILE"; then
+  echo "FAIL: No kernel takes a 16-bit integer parameter; short param was promoted."
+  exit 1
+fi
+
+echo "PASS: char/short kernel parameters preserved as i8/i16 (not promoted)"


### PR DESCRIPTION
## Summary

Fixes #1261.

`HipPromoteInts`'s `needsKernelArgPromotion()` promoted **all** sub-32-bit integer kernel arguments (`i1`, `i8`, `i16`) to `i32`. But the SPIR-V `OpTypeInt` supported widths are **8, 16, 32, 64**, so `i8` (char) and `i16` (short) kernel arguments are already conformant. Only `i1` (bool) maps to `OpTypeBool`, which is the type conformant OpenCL implementations reject (`CL_INVALID_ARG_SIZE`).

This narrows the predicate to `i1` only, so char/short parameters are left untouched. The over-broad promotion originated in #1174 (issue #849), whose comment claimed "kernel arguments must be at least 32 bits wide" — stricter than the actual spec.

## Changes

- `llvm_passes/HipPromoteInts.cpp`: `needsKernelArgPromotion()` now returns true only for `i1`; comments updated.
- `tests/runtime/TestCharShortKernelParam.hip`: runtime correctness for char/short/unsigned-narrow/mixed kernel params.
- `tests/runtime/TestCharShortKernelParamSPIRV.bash`: asserts the emitted SPIR-V preserves `OpTypeInt 8`/`OpTypeInt 16` function parameters (i.e. they are not promoted). Fails under the old behavior.

## Testing (local)

- New + existing bool/narrow-param tests: 5/5 passed (`TestBoolKernelParam`, `TestBoolParamShuffle`, `TestBoolKernelParamSPIRV`, `TestCharShortKernelParam`, `TestCharShortKernelParamSPIRV`).
- `promoteInt` compiler lit suite: 11/11 passed — no regression in the pass.