### PR TITLE
fix: add __half/__half2 __shfl* overloads (#797)

### DIFF
--- a/include/hip/spirv_hip_fp16.h
+++ b/include/hip/spirv_hip_fp16.h
@@ -1747,6 +1747,66 @@ THE SOFTWARE.
             }
         } // Anonymous namespace.
 
+        // Warp shuffle overloads for __half / __half2 (CHIP-SPV/chipStar#797).
+        // sync_and_util.hh only declares integer/float/double __shfl* overloads,
+        // so a __half argument was ambiguous (it converts to several of them).
+        // Implement the half variants by shuffling the raw bits through the
+        // existing integer __shfl* overloads, which is bit-exact and therefore
+        // value-preserving.
+        #define __CHIP_DEF_HALF_SHFL(OP_, SEL_T_)                              \
+          __device__ inline __half OP_(__half var, SEL_T_ selector,           \
+                                       int width = CHIP_DEFAULT_WARP_SIZE) {  \
+            unsigned short bits;                                               \
+            __builtin_memcpy(&bits, &var, sizeof(bits));                      \
+            int shuffled = OP_(static_cast<int>(bits), selector, width);      \
+            unsigned short out = static_cast<unsigned short>(shuffled);       \
+            __half result;                                                    \
+            __builtin_memcpy(&result, &out, sizeof(out));                     \
+            return result;                                                    \
+          }                                                                   \
+          __device__ inline __half2 OP_(__half2 var, SEL_T_ selector,         \
+                                        int width = CHIP_DEFAULT_WARP_SIZE) { \
+            int bits;                                                         \
+            __builtin_memcpy(&bits, &var, sizeof(bits));                     \
+            int shuffled = OP_(bits, selector, width);                       \
+            __half2 result;                                                   \
+            __builtin_memcpy(&result, &shuffled, sizeof(shuffled));          \
+            return result;                                                    \
+          }
+        __CHIP_DEF_HALF_SHFL(__shfl, int)
+        __CHIP_DEF_HALF_SHFL(__shfl_xor, int)
+        __CHIP_DEF_HALF_SHFL(__shfl_up, unsigned int)
+        __CHIP_DEF_HALF_SHFL(__shfl_down, unsigned int)
+        #undef __CHIP_DEF_HALF_SHFL
+
+        #define __CHIP_DEF_HALF_SHFL_SYNC(OP_, SEL_T_)                         \
+          __device__ inline __half OP_(unsigned mask, __half var,             \
+                                       SEL_T_ selector,                       \
+                                       int width = CHIP_DEFAULT_WARP_SIZE) {  \
+            unsigned short bits;                                               \
+            __builtin_memcpy(&bits, &var, sizeof(bits));                      \
+            int shuffled = OP_(mask, static_cast<int>(bits), selector, width);\
+            unsigned short out = static_cast<unsigned short>(shuffled);       \
+            __half result;                                                    \
+            __builtin_memcpy(&result, &out, sizeof(out));                     \
+            return result;                                                    \
+          }                                                                   \
+          __device__ inline __half2 OP_(unsigned mask, __half2 var,           \
+                                        SEL_T_ selector,                      \
+                                        int width = CHIP_DEFAULT_WARP_SIZE) { \
+            int bits;                                                         \
+            __builtin_memcpy(&bits, &var, sizeof(bits));                     \
+            int shuffled = OP_(mask, bits, selector, width);                 \
+            __half2 result;                                                   \
+            __builtin_memcpy(&result, &shuffled, sizeof(shuffled));          \
+            return result;                                                    \
+          }
+        __CHIP_DEF_HALF_SHFL_SYNC(__shfl_sync, int)
+        __CHIP_DEF_HALF_SHFL_SYNC(__shfl_xor_sync, int)
+        __CHIP_DEF_HALF_SHFL_SYNC(__shfl_up_sync, unsigned int)
+        __CHIP_DEF_HALF_SHFL_SYNC(__shfl_down_sync, unsigned int)
+        #undef __CHIP_DEF_HALF_SHFL_SYNC
+
         #if !defined(HIP_NO_HALF)
             using half = __half;
             using half2 = __half2;

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -97,6 +97,7 @@ add_hipcc_test(TestFloat128Macros.hip TEST_NAME TestFloat128gnupp14
   HIPCC_OPTIONS -std=gnu++14 -fsyntax-only)
 
 add_hipcc_test(TestDoubleShuffleOverloads.hip HIPCC_OPTIONS -fsyntax-only)
+add_hipcc_test(TestFix797ShflHalf.hip HIPCC_OPTIONS -fsyntax-only)
 add_hipcc_test(TestHipComplexInclude.hip HIPCC_OPTIONS)
 
 add_hipcc_test(TestHipccAcceptCcFiles.cc HIPCC_OPTIONS)

--- a/tests/compiler/TestFix797ShflHalf.hip
+++ b/tests/compiler/TestFix797ShflHalf.hip
@@ -1,0 +1,35 @@
+// Regression test for CHIP-SPV/chipStar#797.
+// __shfl(__half, ...) was ambiguous because only integer/float/double
+// overloads were declared; __half implicitly converts to several of them.
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+__global__ void callShflHalf(__half *InOut, int LaneSel) {
+  *InOut = __shfl(*InOut, LaneSel);
+}
+__global__ void callShflUpHalf(__half *InOut, int LaneSel) {
+  *InOut = __shfl_up(*InOut, LaneSel);
+}
+__global__ void callShflDownHalf(__half *InOut, int LaneSel) {
+  *InOut = __shfl_down(*InOut, LaneSel);
+}
+__global__ void callShflXorHalf(__half *InOut, int LaneSel) {
+  *InOut = __shfl_xor(*InOut, LaneSel);
+}
+
+__global__ void callShflHalf2(__half2 *InOut, int LaneSel) {
+  *InOut = __shfl(*InOut, LaneSel);
+}
+
+__global__ void callShflSyncHalf(__half *InOut, int LaneSel) {
+  *InOut = __shfl_sync(0xffffffff, *InOut, LaneSel);
+}
+__global__ void callShflUpSyncHalf(__half *InOut, int LaneSel) {
+  *InOut = __shfl_up_sync(0xffffffff, *InOut, LaneSel);
+}
+__global__ void callShflDownSyncHalf(__half *InOut, int LaneSel) {
+  *InOut = __shfl_down_sync(0xffffffff, *InOut, LaneSel);
+}
+__global__ void callShflXorSyncHalf(__half *InOut, int LaneSel) {
+  *InOut = __shfl_xor_sync(0xffffffff, *InOut, LaneSel);
+}


### PR DESCRIPTION
Fixes #797 by adding `__half`/`__half2` overloads for the `__shfl`/`__shfl_up`/`__shfl_down`/`__shfl_xor` families (and their `_sync` variants), which shuffle the raw bits through the existing integer overloads so a `__half` argument is no longer ambiguous.