### PR TITLE
hipRTC cache: include compiler version in the cache key

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -819,6 +819,8 @@ set(CHIP_DEBUG_BUILD 0)
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(CHIP_DEBUG_BUILD 1)
 endif()
+# Toolchain version for the hipRTC compilation cache key (see spirv_hiprtc.cc).
+set(CHIP_LLVM_VERSION_STRING "${LLVM_VERSION}")
 configure_file(chipStarConfig.hh.in include/chipStarConfig.hh @ONLY)
 
 # PROJECT CONFIGURATION HEADER

--- a/chipStarConfig.hh.in
+++ b/chipStarConfig.hh.in
@@ -29,6 +29,11 @@
 
 #cmakedefine CHIPSTAR_VERSION "@CHIPSTAR_VERSION@"
 
+// Full version string of the LLVM/Clang toolchain chipStar was built against
+// (from `llvm-config --version`). Used as part of the hipRTC compilation cache
+// key so that an LLVM/Clang upgrade invalidates cached SPIR-V.
+#cmakedefine CHIP_LLVM_VERSION_STRING "@CHIP_LLVM_VERSION_STRING@"
+
 // not implemented yet
 #undef OCML_BASIC_ROUNDED_OPERATIONS
 

--- a/src/spirv_hiprtc.cc
+++ b/src/spirv_hiprtc.cc
@@ -23,6 +23,7 @@ THE SOFTWARE.
 
 #include <hip/hiprtc.h>
 // #include "macros.hh"
+#include "chipStarConfig.hh"
 #include "CHIPBackend.hh"
 #include "Utils.hh"
 #include "logging.hh"
@@ -431,6 +432,19 @@ static std::string computeHiprtcCacheKey(const chipstar::Program &Program,
   for (auto &[expr, lowered] : Program.getNameExpressionMap()) {
     combined += expr + "\n";
   }
+
+  // Compiler identity. An LLVM/Clang or chipStar upgrade changes the produced
+  // SPIR-V (frontend codegen, optimizations); without this, a warm cache would
+  // silently serve SPIR-V compiled by the old toolchain after an upgrade.
+  combined += "\n---compiler---\n";
+#ifdef CHIP_LLVM_VERSION_STRING
+  combined += CHIP_LLVM_VERSION_STRING;
+#endif
+  combined += "/";
+#ifdef CHIPSTAR_VERSION
+  combined += CHIPSTAR_VERSION;
+#endif
+
   return std::to_string(fnv1a64(combined));
 }
 


### PR DESCRIPTION
## Problem

`computeHiprtcCacheKey()` (`src/spirv_hiprtc.cc`) currently hashes only
`source + hiprtcCreateProgram headers + options + name-expression keys`. It does
**not** include any toolchain identity.

After a user upgrades LLVM/Clang (or chipStar) and reruns the same program, the
source hashes to the same key, so the warm hipRTC cache returns SPIR-V compiled
by the **old** frontend — silently. Depending on what changed between toolchains
this can mean stale codegen, missed optimizations, or a hard-to-diagnose
miscompile, with no signal to the user that a stale artifact was served.

Note this is chipStar's to fix even though POCL's own kernel cache *does*
version-guard (its key seed includes `LLVM_VERSION`): on a hipRTC cache hit
chipStar returns the cached SPIR-V and never re-runs the frontend, so POCL never
sees fresh input. This is the sibling of #1335 (filesystem `#include` content not
in the key); both are cache-key soundness gaps in the same function.

## Fix

Fold the toolchain identity into the key:

- **LLVM/Clang version** — `llvm-config --version`, already computed by
  `cmake/FindLLVM.cmake` as `LLVM_VERSION`, exposed to C++ as a new
  `CHIP_LLVM_VERSION_STRING` in `chipStarConfig.hh`.
- **chipStar version** — the existing `CHIPSTAR_VERSION`.

Three-line surface: one `set()` in `CMakeLists.txt`, one `#cmakedefine` in
`chipStarConfig.hh.in`, and the key-composition lines in `computeHiprtcCacheKey`.

## Testing (LLVM 21.1.8 / POCL main / Apple M4)

- **Regression** — cold run logs `Saved SPIRV to cache`, warm run logs
  `Cache hit — skipped clang compilation` at the same key. Normal caching intact.
- **Invalidation** — with a warm cache from "21.1.8", simulated an upgrade by
  bumping `CHIP_LLVM_VERSION_STRING` to a fake value and recompiling. The next
  run computed a **new** key and re-saved (a miss) instead of reusing the stale
  entry — confirming a toolchain change now invalidates the cache. Reverting the
  version restores the original key.

## Open question for reviewers

Is the **build-time** LLVM version the right granularity, or would you prefer a
**runtime** identity (e.g. hashing the resolved `clang`/`hipcc` binary, or
`clang --version`) so that swapping the compiler binary without rebuilding
chipStar also invalidates? Build-time matches POCL/Comgr precedent and is
zero-cost; runtime is more robust to out-of-tree toolchain swaps. Also open to
adding a git SHA if you'd want per-commit granularity.
