### PR TITLE
Bump hip-tests: hipMultiThreadStreams2 buffer-init fix

### DIFF
--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -25,7 +25,6 @@ ANY:
     TestAssertFail: 'Works only on dGPU, otherwise, things being printed out of order'
     abort: 'Works only on dGPU, otherwise, things being printed out of order'
     shfl_sync: 'masks outside of 0xFFFFFFFF are not supported'
-    'Unit_hipMultiThreadStreams2.*': 'Subprocess aborted'
     Unit_hipMemset_Negative_OutOfBoundsSize: 'Subprocess aborted'
     Unit_hipMemset_Negative_OutOfBoundsPtr: 'SEGFAULT'
     Print_Out_Attributes: 'old HIP tests + new HIP API'


### PR DESCRIPTION
Fixes and unmasks `Unit_hipMultiThreadStreams2`.

**Fix** (submodule bump to develop-chipstar, CHIP-SPV/hip-tests#1): `run()` copied the `Ah`/`Ahh` host buffers to the device without initializing them (unlike `run1()`). When the pages held NaN, the host assert `NaN == Ah+1` is false by IEEE-754 and the test aborted. It passed only where fresh pages were zeroed — the Intel CPU OpenCL runtime recycles dirty host memory, so it failed there, previously misattributed to #618 OUT_OF_HOST_MEMORY.

**Unmask**: with the buffers initialized the test passes on every backend, so the `ANY:ALL` `Subprocess aborted` known-failure entry is removed, exercising it in CI. Verified passing on Intel CPU OpenCL (3/3), Level Zero, and OpenCL dGPU.

Closes #618.