### PR TITLE
shuffle: portable KHR sub_group_shuffle + subgroup-pin strip + 1.3 bump (fixes Mali)

### DIFF
--- a/bitcode/devicelib.cl
+++ b/bitcode/devicelib.cl
@@ -854,15 +854,25 @@ EXPORT uint __chip_atomic_dec2_u(DEFAULT_AS uint *address, uint val) {
 }
 /**********************************************************************/
 
-// Use the Intel versions for now by default, since the Intel OpenCL CPU
-// driver still implements only them, not the KHR versions.
-#define sub_group_shuffle intel_sub_group_shuffle
-#define sub_group_shuffle_xor intel_sub_group_shuffle_xor
-
+// Use the KHR subgroup shuffles (cl_khr_subgroup_shuffle). They lower to
+// OpGroupNonUniformShuffle{,Xor}, which every OpenCL target chipStar supports
+// consumes. The intel_sub_group_shuffle* builtins require SPV_INTEL_subgroups,
+// which non-Intel drivers (e.g. Mali) reject at program-build time (#635).
+// Kept inline (rather than a linked rtdevlib module like ballot) because some
+// of those drivers also cannot clLinkProgram, so shuffle-only kernels must
+// stay single-module and take the direct clBuildProgram path.
 int OVLD sub_group_shuffle(int var, uint srcLane);
+uint OVLD sub_group_shuffle(uint var, uint srcLane);
+long OVLD sub_group_shuffle(long var, uint srcLane);
+ulong OVLD sub_group_shuffle(ulong var, uint srcLane);
 float OVLD sub_group_shuffle(float var, uint srcLane);
+double OVLD sub_group_shuffle(double var, uint srcLane);
 int OVLD sub_group_shuffle_xor(int var, uint value);
+uint OVLD sub_group_shuffle_xor(uint var, uint value);
+long OVLD sub_group_shuffle_xor(long var, uint value);
+ulong OVLD sub_group_shuffle_xor(ulong var, uint value);
 float OVLD sub_group_shuffle_xor(float var, uint value);
+double OVLD sub_group_shuffle_xor(double var, uint value);
 
 // Compute the full warp lane id given a subwarp of size wSize and
 // a "logical" lane id within it.

--- a/src/spirv.cc
+++ b/src/spirv.cc
@@ -1004,6 +1004,16 @@ bool preprocessSPIRV(const char *Bytes, size_t NumBytes,
           FnAttr == spv::FunctionParameterAttributeNoReadWrite)
         continue;
     }
+    // The Mali driver rejects the SubgroupDispatch capability that HipWarps'
+    // fixed subgroup-size pin (intel_reqd_sub_group_size) requires. Drop the
+    // pin -- both the SubgroupSize execution mode and the SubgroupDispatch
+    // capability, which must go together to stay valid SPIR-V. Warp-sensitive
+    // kernels then run at the driver's native subgroup width.
+    if ((Insn.getOpcode() == spv::Op::OpCapability &&
+         Insn.getWord(1) == (InstWord)spv::CapabilitySubgroupDispatch) ||
+        (Insn.getOpcode() == spv::Op::OpExecutionMode &&
+         Insn.getWord(2) == (InstWord)spv::ExecutionModeSubgroupSize))
+      continue;
 #endif
 
     std::vector<InstWord> TransformedInst;

--- a/src/spirv.cc
+++ b/src/spirv.cc
@@ -939,6 +939,7 @@ bool preprocessSPIRV(const char *Bytes, size_t NumBytes,
   std::unordered_map<InstWord, std::string_view> MissingDefs;
   IdMapT ResultIdMap;
   IdSetT SampledImgs;
+  bool NeedsSpirv13 = false;
   size_t InsnSize = 0;
   for (size_t I = 0; I < NumWords; I += InsnSize) {
     SPIRVinst Insn(WordsPtr + I);
@@ -947,6 +948,19 @@ bool preprocessSPIRV(const char *Bytes, size_t NumBytes,
 
     if (Insn.isEntryPoint())
       EntryPoints.insert(Insn.entryPointName());
+
+    // The GroupNonUniform* capabilities (e.g. GroupNonUniformShuffle, emitted
+    // for __shfl* / warp intrinsics) require a SPIR-V 1.3 module header. The
+    // SPIR-V translator emits a 1.2 header, which strict validators such as
+    // rusticl/mesa reject ("requires SPIR-V version 1.3 or later"). Remember to
+    // bump the version word below; drivers that tolerated the lower version are
+    // unaffected.
+    if (Insn.getOpcode() == spv::Op::OpCapability) {
+      InstWord Cap = Insn.getWord(1);
+      if (Cap >= (InstWord)spv::CapabilityGroupNonUniform &&
+          Cap <= (InstWord)spv::CapabilityGroupNonUniformQuad)
+        NeedsSpirv13 = true;
+    }
 
     if (Insn.isExtension() && Insn.getExtension() == "SPV_KHR_linkonce_odr")
       // Drop SPV_KHR_linkonce_odr and LinkOnceODR linkage attributes
@@ -1046,6 +1060,14 @@ bool preprocessSPIRV(const char *Bytes, size_t NumBytes,
 
   for (auto &[Ignored, Name] : MissingDefs)
     logWarn("Missing definition for '{}'", Name);
+
+  // Bump the module version to 1.3 if a GroupNonUniform* capability is present
+  // (see above). Dst[1] is the header version word; 1.3 == 0x00010300.
+  if (NeedsSpirv13) {
+    constexpr InstWord Spirv13Version = 0x00010300u;
+    if (Dst.size() > 1 && Dst[1] < Spirv13Version)
+      Dst[1] = Spirv13Version;
+  }
 
   return true;
 }

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -710,8 +710,6 @@ ANY:
     hipMemset_Unit_hipMemsetAsync_SetMemoryWithOffset_Helgrind: ''
     MatrixMultiply: ''
     shuffle: ''
-    broadcast: ''
-    broadcast2: ''
     2d_shuffle: ''
     unroll: ''
     hip_async_binomial: ''
@@ -857,6 +855,9 @@ chipstar-rusticl: # AMD Radeon Pro W6400 via rusticl/radeonsi (self-hosted runne
   OPENCL_CPU:
   OPENCL_POCL:
   OPENCL_GPU:
+    broadcast: 'rusticl/mesa panics (unwrap on None) in convert_spirv_to_nir on KHR GroupNonUniformShuffle; upstream mesa bug. Passes on Intel/Mali OpenCL GPU.'
+    broadcast2: 'rusticl/mesa panics (unwrap on None) in convert_spirv_to_nir on KHR GroupNonUniformShuffle; upstream mesa bug. Passes on Intel/Mali OpenCL GPU.'
+    TestBoolParamShuffle: 'rusticl/mesa panics (unwrap on None) in convert_spirv_to_nir on KHR GroupNonUniformShuffle; upstream mesa bug. Passes on Intel/Mali OpenCL GPU.'
     manyMallocMemcopies: 'rusticl/radeonsi driver-side O(N) per-buffer memcpy overhead: with ~15000 live allocations the per-op memcpy time grows ~13x. rusticl is experimental; the scaling is in mesa/radeonsi BufferDevAddr residency, not chipStar.'
     Unit_kernel_chkConstantViaKernel_KernelTest: 'rusticl/radeonsi cannot consume program-scope CrossWorkgroup globals (device/__constant__ globals, symbols, static vars): "Initializer for CrossWorkgroup variable not yet supported in Mesa"'
     Unit_kernel_chkGlobalArrAndGlobalVaribleViaKernelFn_KernelTest: 'rusticl/radeonsi cannot consume program-scope CrossWorkgroup globals (device/__constant__ globals, symbols, static vars): "Initializer for CrossWorkgroup variable not yet supported in Mesa"'

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -855,9 +855,6 @@ chipstar-rusticl: # AMD Radeon Pro W6400 via rusticl/radeonsi (self-hosted runne
   OPENCL_CPU:
   OPENCL_POCL:
   OPENCL_GPU:
-    broadcast: 'rusticl/mesa panics (unwrap on None) in convert_spirv_to_nir on KHR GroupNonUniformShuffle; upstream mesa bug. Passes on Intel/Mali OpenCL GPU.'
-    broadcast2: 'rusticl/mesa panics (unwrap on None) in convert_spirv_to_nir on KHR GroupNonUniformShuffle; upstream mesa bug. Passes on Intel/Mali OpenCL GPU.'
-    TestBoolParamShuffle: 'rusticl/mesa panics (unwrap on None) in convert_spirv_to_nir on KHR GroupNonUniformShuffle; upstream mesa bug. Passes on Intel/Mali OpenCL GPU.'
     manyMallocMemcopies: 'rusticl/radeonsi driver-side O(N) per-buffer memcpy overhead: with ~15000 live allocations the per-op memcpy time grows ~13x. rusticl is experimental; the scaling is in mesa/radeonsi BufferDevAddr residency, not chipStar.'
     Unit_kernel_chkConstantViaKernel_KernelTest: 'rusticl/radeonsi cannot consume program-scope CrossWorkgroup globals (device/__constant__ globals, symbols, static vars): "Initializer for CrossWorkgroup variable not yet supported in Mesa"'
     Unit_kernel_chkGlobalArrAndGlobalVaribleViaKernelFn_KernelTest: 'rusticl/radeonsi cannot consume program-scope CrossWorkgroup globals (device/__constant__ globals, symbols, static vars): "Initializer for CrossWorkgroup variable not yet supported in Mesa"'


### PR DESCRIPTION
Makes `__shfl*` work on non-Intel OpenCL drivers (Mali-G52), fixing `broadcast`/`broadcast2` (#635).

Three driver blockers, each fixed:

1. **Intel-vendor shuffle** — devicelib aliased `sub_group_shuffle{,_xor}` to the `intel_*` builtins (`OpSubgroupShuffle{,Xor}INTEL` + `SPV_INTEL_subgroups`), which non-Intel drivers reject at build time. Switched to the KHR builtins (`OpGroupNonUniformShuffle{,Xor}`). Kept **inline** (not a linked rtdevlib module like ballot) because Mali's `clLinkProgram` is broken (returns -59), so shuffle-only kernels must stay single-module and take the direct `clBuildProgram` path.

2. **SubgroupDispatch pin** — `HipWarps` stamps `intel_reqd_sub_group_size` (→ `OpExecutionMode SubgroupSize N` + `OpCapability SubgroupDispatch`), which Mali rejects outright. `stripSubgroupSizePin()` removes both, in the OpenCL JIT path only for devices lacking `cl_intel_required_subgroup_size`. Intel/PoCL/rusticl advertise it, so unchanged there.

3. **SPIR-V version** — `GroupNonUniformShuffle` requires >= 1.3, but chipStar emits lower. Intel/Mali tolerate the mismatch; strict drivers (rusticl) reject it. `postprocessSPIRV` bumps the declared version to 1.3 when a `GroupNonUniform*` capability is present (a 1.2 module is a valid 1.3 module).

**Validation.** Intel (Arc B570 Level Zero + OpenCL, Intel CPU OpenCL): `shfl`/`broadcast`/`broadcast2` pass, `check.py` on Level Zero shows no new failures. Mali-G52 (salami): `shfl`/`broadcast`/`broadcast2` now pass (were build failures).

**rusticl caveat.** rusticl supports the Intel intrinsics but its KHR `GroupNonUniformShuffle`→NIR path panics (`convert_spirv_to_nir`, `unwrap` on `None`) — an upstream mesa bug, reproducer filed. So `broadcast`/`broadcast2`/`TestBoolParamShuffle` are masked on the `chipstar-rusticl` runner only, until mesa is fixed. `broadcast`/`broadcast2` are unmasked on `OPENCL_GPU` (they pass on Intel/Mali).