### PR TITLE
cmake: fall back to ldconfig when locating libOpenCL.so.1 (#542)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,16 @@ if(NOT DEFINED OpenCL_LIBRARY)
   else()
     message(STATUS "OpenCL_LIBRARY was not set. Searching for libOpenCL.so in LD_LIBRARY_PATH")
     find_library(OpenCL_LIBRARY NAMES OpenCL libOpenCL.so.1 PATHS ENV LD_LIBRARY_PATH ./ NO_CACHE)
+    if(NOT OpenCL_LIBRARY)
+      # Fall back to ld.so.conf-registered locations (e.g. vendor ICD loaders
+      # not on LD_LIBRARY_PATH nor CMake's default paths). Issue #542.
+      execute_process(COMMAND ldconfig -p OUTPUT_VARIABLE _ldconfig_out ERROR_QUIET)
+      string(REGEX MATCH "libOpenCL\\.so\\.1[^\n]* => ([^\n]+)" _unused "${_ldconfig_out}")
+      if(CMAKE_MATCH_1)
+        string(STRIP "${CMAKE_MATCH_1}" OpenCL_LIBRARY)
+        message(STATUS "Found libOpenCL via ldconfig: ${OpenCL_LIBRARY}")
+      endif()
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
Fixes #542.

When `OpenCL_LIBRARY` is unset, CMake only searched `LD_LIBRARY_PATH` and `./`, so it missed `libOpenCL.so.1` in `ld.so.conf`-registered locations (e.g. `/usr/lib/x86_64-linux-gnu` 

Adds a fallback that parses `ldconfig -p` for `libOpenCL.so.1`. Only runs when the existing search already failed, so it cannot change setups that already resolve OpenCL.

Verified the fallback block against real `ldconfig -p` output: resolves to `/usr/local/lib/libOpenCL.so.1` (existing file). Guarded so a missing entry leaves `OpenCL_LIBRARY` empty rather than erroring.
