### PR TITLE
cmake: resolve gcc symlink before deriving --gcc-toolchain base (#937)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,11 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+# Resolve symlinks first: on distros where `gcc` is a ccache shim
+# (e.g. Fedora's /usr/lib64/ccache/gcc -> /usr/bin/ccache), the unresolved
+# path yields a wrong --gcc-toolchain base (issue #937).
+get_filename_component(GCC_PATH "${GCC_PATH}" REALPATH)
+
 # Extract the base path (removing /bin/gcc from the end)
 get_filename_component(GCC_BASE_PATH ${GCC_PATH} DIRECTORY)
 get_filename_component(GCC_BASE_PATH ${GCC_BASE_PATH} DIRECTORY)


### PR DESCRIPTION
Fixes #937.

On distros where `which gcc` returns a ccache shim (Fedora's `/usr/lib64/ccache/gcc` -> `/usr/bin/ccache`), stripping `/bin/gcc` from the unresolved path gives `--gcc-toolchain=/usr/lib64`, so clang can't find `crtbegin.o` / `libstdc++` and the compiler check fails.

Fix: resolve symlinks (`REALPATH`) before deriving the toolchain base.

Simulating the Fedora ccache shim, the derived `--gcc-toolchain` base:
- before: `.../lib64` (matches the reported broken `/usr/lib64`)
- after: `.../usr` (correct)

No-op for standard installs: where `gcc` resolves within the same `bin` dir (e.g. `/usr/bin/gcc` -> `/usr/bin/x86_64-linux-gnu-gcc-13`), the base stays `/usr`.
