### PR TITLE
fix: remove duplicate hip-targets export that dropped hip-config.cmake (#938)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -956,7 +956,11 @@ install(
   DESTINATION
   ${CONFIG_PACKAGE_INSTALL_DIR}
 )
-install(EXPORT hip-targets FILE hip-targets.cmake NAMESPACE hip:: DESTINATION lib/cmake/hip COMPONENT binary)
+# NOTE: hip-targets is exported once above (see INSTALL(EXPORT hip-targets ...))
+# to ${CONFIG_PACKAGE_INSTALL_DIR} in the default component. Do not add a second
+# install(EXPORT hip-targets ...) with a different component (e.g. COMPONENT
+# binary): a component/partial install (ccmake, cpack, --component) would then
+# ship hip-targets.cmake without hip-config.cmake, breaking find_package(hip).
 
 # Install hip-lang-config.cmake for CMake's native HIP language support
 install(FILES ${CMAKE_SOURCE_DIR}/cmake/hip-lang/hip-lang-config.cmake


### PR DESCRIPTION
Fixes #938.

`hip-targets` was exported twice: once (default component) alongside `hip-config.cmake`, and again with `COMPONENT binary`. A partial/component install (ccmake, cpack, `--component binary`) then ships `hip-targets.cmake` without `hip-config.cmake`, breaking `find_package(hip)`.

Fix removes the redundant second export so targets and config always install together.

Verified by inspecting the generated `cmake_install.cmake`:
- before: `hip-targets.cmake` installed under both `Unspecified` and `COMPONENT "binary"`; `hip-config.cmake` only under `Unspecified`.
- after: `hip-targets.cmake` only under `Unspecified`, together with `hip-config.cmake`; no `binary`-component export remains.
