### PR TITLE
cmake: don't register ROCm-Device-Libs constant_folding test (#442)

### DIFF
--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -276,7 +276,6 @@ ANY:
     Unit_hipUserObjectCreate_Negative: 'hipUserObjectCreate is not implemented'
     Unit_hipUserObjectRelease_Negative: 'hipUserObjectCreate is not implemented'
     Unit_hipUserObjectRetain_Negative: 'hipUserObjectCreate is not implemented'
-    constant_fold_lgamma_r: ''
     cuda-simpleCallback: ''
     hipMultiThreadAddCallback: ''
     syncthreadsExitedThreads: 'Exited threads calling __syncthreads'


### PR DESCRIPTION
Fixes #442.

`constant_fold_lgamma_r` (a vendored ROCm-Device-Libs test) registers whenever LLVM's FileCheck is in PATH and always fails: it needs the full amdgcn device-lib set, which chipStar does not build.

Two parts:
- Submodule (CHIP-SPV/ROCm-Device-Libs, 60a4c16, already pushed to the chipstar branch): guard `enable_testing()` + the constant_folding test subdir behind a new `ROCM_DEVICELIB_BUILD_TESTS` option (defaults ON; standalone builds unchanged).
- Here: set `ROCM_DEVICELIB_BUILD_TESTS OFF` before adding the submodule, bump the pointer, and drop the now-obsolete `constant_fold_lgamma_r` known_failures entry.

Verified at configure time (FileCheck in PATH):
- guard ON (pre-fix): `constant_fold_lgamma_r` registered.
- guard OFF (this PR): 0 constant_fold tests registered.
