### PR TITLE
cmake: scope MKL library path to SYCL interop samples (#656)

### DIFF
--- a/cmake/mkl_and_icpx.cmake
+++ b/cmake/mkl_and_icpx.cmake
@@ -16,12 +16,16 @@ find_package(MKL CONFIG
 	PATHS /opt/intel/oneapi/mkl/latest/lib/cmake/mkl)
 
 # Manually include MKL dirs so that they get cached
-if(MKL_FOUND) 
+if(MKL_FOUND)
   include_directories(${MKL_INCLUDE})
-  add_link_options(-L${MKL_ROOT}/lib/${MKL_ARCH})
+  # Do NOT use add_link_options() here: it is directory-scoped and would brutally
+  # inject the MKL library search path into the link line of *every* target in the
+  # samples tree, not just the SYCL interop samples (issue #656). Fold it into
+  # INTEL_LIBS instead so it is applied per-target via target_link_options().
+  set(MKL_LINK_DIR -L${MKL_ROOT}/lib/${MKL_ARCH})
 endif()
 
-set(INTEL_LIBS -L${ICPX_CORE_LIBDIR} -lsvml -lintlc -lirng -limf -lsycl)
+set(INTEL_LIBS ${MKL_LINK_DIR} -L${ICPX_CORE_LIBDIR} -lsvml -lintlc -lirng -limf -lsycl)
 
 if(ICPX_EXECUTABLE AND MKL_FOUND)
   message(STATUS "Found both MLK and ICPX")


### PR DESCRIPTION
Addresses #656.

`cmake/mkl_and_icpx.cmake` used `add_link_options(-L${MKL_ROOT}/lib/${MKL_ARCH})`. That is directory-scoped, and the file is `include()`d in samples/CMakeLists.txt before the `add_subdirectory` loop, so the MKL library search path was injected into the link line of every sample (including CUDA samples) rather than just the SYCL interop samples that use MKL.

Fix: fold the path into `INTEL_LIBS`, which is only consumed by the interop samples' `target_link_options(... PRIVATE ...)`, so it applies per-target.

Verified by inspecting the generated build.ninja (MKL found, icpx available):
- before: 90/180 sample link rules carried `-L.../lib/intel64` (e.g. the non-SYCL `abort` sample).
- after: 4/180 — exactly the SYCL/hip interop targets; `abort` and the rest carry none.

Note: this removes the over-broad injection the issue is about; I could not reproduce the reporter's exact icpx-2023.2.1 / Ubuntu cross-libstdc++ link failure to confirm that specific symptom.
