### PR TITLE
Preserve device debug info for gdb-oneapi (#1004)

### DIFF
--- a/llvm-patches/llvm/0007-preserve-device-debug-info.patch
+++ b/llvm-patches/llvm/0007-preserve-device-debug-info.patch
@@ -1,0 +1,70 @@
+From db7c9f28fff802bd9f4165a344c3b5ef5f6973a2 Mon Sep 17 00:00:00 2001
+From: chipStar <chipstar@chip.spv>
+Date: Sat, 18 Jul 2026 14:18:22 +0300
+Subject: [PATCH] Preserve device debug info for gdb-oneapi
+
+HIPSPVToolChain::adjustDebugInfoKind() unconditionally forced NoDebugInfo,
+so -g/-O0 produced device SPIR-V with no debug metadata at all. The stated
+reason (SPIRV-LLVM-Translator aborting on DW_OP_LLVM_convert) no longer
+applies: the translator now lowers it to SPIRVDebug::Convert.
+
+Stop clobbering the requested debug level, and when -g is given emit the
+NonSemantic.Shader.DebugInfo form (--spirv-debug-info-version=
+nonsemantic-shader-200 + SPV_KHR_non_semantic_info) that Intel's IGC and
+gdb-oneapi consume to resolve source lines and locals in device code.
+
+Refs: CHIP-SPV/chipStar#1004
+---
+ clang/lib/Driver/ToolChains/HIPSPV.cpp | 34 +++++++++++++++++++++-----
+ 1 file changed, 28 insertions(+), 6 deletions(-)
+
+diff --git a/clang/lib/Driver/ToolChains/HIPSPV.cpp b/clang/lib/Driver/ToolChains/HIPSPV.cpp
+index 4cde8f9..58892d6 100644
+--- a/clang/lib/Driver/ToolChains/HIPSPV.cpp
++++ b/clang/lib/Driver/ToolChains/HIPSPV.cpp
+@@ -93,8 +93,23 @@ void HIPSPV::Linker::constructLinkAndEmitSpirvCommand(
+   // We need 1.2 when using warp-level primitivies via sub group extensions.
+   // Strictly put we'd need 1.3 for the standard non-extension shuffle
+   // operations, but it's not supported by any target yet.
+-  llvm::opt::ArgStringList TrArgs{"--spirv-max-version=1.2",
+-                                  "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups,+SPV_EXT_shader_atomic_float_add"};
++  std::string SpirvExts =
++      "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups,"
++      "+SPV_EXT_shader_atomic_float_add";
++  llvm::opt::ArgStringList TrArgs{"--spirv-max-version=1.2"};
++  // When the user requests debug info (-g, but not -g0), preserve it into the
++  // SPIR-V in the NonSemantic.Shader.DebugInfo form. Intel's IGC and gdb-oneapi
++  // consume this to map device code back to source lines and local variables;
++  // the translator's default OpenCL.DebugInfo.100 form is not sufficient for
++  // that. Emitting the NonSemantic debug instructions requires the
++  // SPV_KHR_non_semantic_info extension, so it is only enabled here on demand
++  // to keep the default (non-debug) SPIR-V output unchanged.
++  if (const Arg *A = Args.getLastArg(options::OPT_g_Group);
++      A && !A->getOption().matches(options::OPT_g0)) {
++    SpirvExts += ",+SPV_KHR_non_semantic_info";
++    TrArgs.push_back("--spirv-debug-info-version=nonsemantic-shader-200");
++  }
++  TrArgs.push_back(Args.MakeArgString(SpirvExts));
+   InputInfo TrInput = InputInfo(types::TY_LLVM_BC, TempFile, "");
+   SPIRV::constructTranslateCommand(C, *this, JA, Output, TrInput, TrArgs);
+ }
+@@ -283,8 +298,15 @@ VersionTuple HIPSPVToolChain::computeMSVCVersion(const Driver *D,
+ void HIPSPVToolChain::adjustDebugInfoKind(
+     llvm::codegenoptions::DebugInfoKind &DebugInfoKind,
+     const llvm::opt::ArgList &Args) const {
+-  // Debug info generation is disabled for SPIRV-LLVM-Translator
+-  // which currently aborts on the presence of DW_OP_LLVM_convert.
+-  // TODO: Enable debug info when the SPIR-V backend arrives.
+-  DebugInfoKind = llvm::codegenoptions::NoDebugInfo;
++  // Historically device debug info was force-disabled here because the
++  // SPIRV-LLVM-Translator aborted on DW_OP_LLVM_convert debug expressions.
++  // The translator now lowers that operation (SPIRVDebug::Convert), so honor
++  // the debug level the user requested (e.g. via -g) and let it flow into the
++  // emitted SPIR-V. constructLinkAndEmitSpirvCommand() additionally enables the
++  // NonSemantic.Shader.DebugInfo form at translation time so that Intel's IGC
++  // and gdb-oneapi can consume it. Leaving DebugInfoKind untouched keeps the
++  // default (no -g) behavior unchanged, since the driver defaults it to
++  // NoDebugInfo.
++  (void)DebugInfoKind;
++  (void)Args;
+ }


### PR DESCRIPTION
Adds llvm-patches/llvm/0007 for the configure_llvm.sh build path. The HIPSPV toolchain force-disabled device debug info (adjustDebugInfoKind -> NoDebugInfo), so -g/-O0 produced SPIR-V with no debug metadata and gdb-oneapi could not resolve locals in kernels. The historical blocker (translator aborting on DW_OP_LLVM_convert) is gone. The patch honors -g and, when set, emits the NonSemantic.Shader.DebugInfo form that Intel IGC/gdb-oneapi consume.

The same change is upstreamed in llvm/llvm-project#210504 and applied to the fork branch in CHIP-SPV/llvm-project#6.

Refs #1004

## Hardware validation on Aurora (PVC, i915, oneAPI 2025.3, LLVM 22)

Full in-kernel debugging works, including reading arguments and locals per SIMD lane:

    addKernel (a=0xff00fffffffe0000, b=0xff00fffffffd0000, c=0xff00fffffffc0000, n=256)
        at dbgtest.hip:9
    n = 256   idx = 64   lhs = 64   rhs = 128
    print a[idx]  ->  $4 = 64
    thread :3     ->  idx = 70, lhs = 70

Getting there needs three changes. This PR is one of them; the other two are chipStar-side and are not yet written.

1. This patch: honor -g and request nonsemantic-shader-200 + SPV_KHR_non_semantic_info.
2. Add +SPV_INTEL_optnone to the same extension list. At -O0 clang marks kernels optnone; without the extension the translator silently drops it, so IGC optimizes the kernel and every variable reads <optimized out>. Needed only on the Triple::ChipStar branch upstream, whose allowlist excludes it; the generic branch already uses --spirv-ext=+all.
3. chipStar must stop discarding optnone and must pass -cl-opt-disable to zeModuleCreate:
   - llvm_passes/HipPasses.cpp RemoveNoInlineOptNoneAttrsPass strips optnone from every function unconditionally, before the translator runs. It should skip that when the module carries debug info (llvm.dbg.cu).
   - CHIPBackendLevel0::getDefaultJitFlags() returns "". It should yield -cl-opt-disable when the module has debug info.

Measured combinations, all with -g -O0 on PVC:

| optnone in IR | SPV_INTEL_optnone | L0 build flags | locals |
|---|---|---|---|
| stripped | no | -cl-opt-disable -g | optimized out |
| stripped | yes | -cl-opt-disable -g | optimized out |
| preserved | yes | (empty, current default) | optimized out |
| preserved | yes | -g | optimized out |
| preserved | yes | -cl-opt-disable | readable |

So -cl-opt-disable alone is not enough, and preserving optnone alone is not enough; both are required. -g in the L0 build flags is not needed.

Also confirmed: nonsemantic-shader-200 is the right choice. Testing nonsemantic-shader-100 changed nothing, and icpx -fsycl -g passes -spirv-debug-info-version=nonsemantic-shader-200 itself.

The -g binary runs correctly on PVC and there is no change when -g is absent.

## Using gdb-oneapi with chipStar

Two prerequisites live outside the compiler entirely.

1. Enable EU debug on the node. It is off by default but writable by a normal user inside a job; no root needed:

       for f in /sys/class/drm/card*/prelim_enable_eu_debug; do echo 1 > "$f"; done

   Without this, Level Zero enumerates zero devices under ZET_ENABLE_PROGRAM_DEBUGGING=1 and chipStar fails with hipErrorNotInitialized.

2. Redirect gdb-oneapi's auto-attach hook. Its intelgt_auto_attach.py plants the trigger breakpoint on zeContextCreate, but chipStar calls zeContextCreateEx (src/backend/Level0/CHIPBackendLevel0.cc:2368). Different address, so the hook never fires, gdbserver-ze never starts, and device breakpoints stay pending while the program runs to completion. The extension provides an official override:

       export INTELGT_AUTO_ATTACH_HOOK="-qualified zeContextCreateEx"

Full session:

    for f in /sys/class/drm/card*/prelim_enable_eu_debug; do echo 1 > "$f"; done
    export ZET_ENABLE_PROGRAM_DEBUGGING=1
    export INTELGT_AUTO_ATTACH_HOOK="-qualified zeContextCreateEx"
    export CHIP_BE=level0
    export CHIP_JIT_FLAGS_OVERRIDE="-cl-opt-disable"   # until item 3 above lands
    hipcc -g -O0 test.hip -o test
    gdb-oneapi -ex "set breakpoint pending on" -ex "break test.hip:42" -ex run ./test

Add INTELGT_AUTO_ATTACH_VERBOSE_LOG=1 to trace auto-attach; a successful run logs "gdbserver-ze started for process N".

Item 2 deserves its own fix: chipStar could call zeContextCreate when it is not subsetting devices, and Intel should hook both entry points, since any Level Zero application using the Ex form is invisible to auto-attach today.
