### PR TITLE
props: query warpSize from the device instead of hard-coding it

### DIFF
--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -2797,17 +2797,24 @@ void CHIPDeviceLevel0::populateDevicePropertiesImpl() {
   // as per gen architecture doc
   HipDeviceProps_.regsPerBlock = 4096;
 
-  HipDeviceProps_.warpSize = CHIP_DEFAULT_WARP_SIZE;
-  if (std::find(DeviceComputeProps.subGroupSizes,
-                DeviceComputeProps.subGroupSizes +
-                    DeviceComputeProps.numSubGroupSizes,
-                CHIP_DEFAULT_WARP_SIZE) !=
-      DeviceComputeProps.subGroupSizes + DeviceComputeProps.numSubGroupSizes) {
+  // Report the subgroup size that warp-sensitive kernels actually execute at
+  // (queried from the device) rather than hard-coding CHIP_DEFAULT_WARP_SIZE,
+  // so props.warpSize agrees with the device-side `warpSize` variable
+  // (get_sub_group_size()). chipStar pins kernels to CHIP_DEFAULT_WARP_SIZE
+  // where the device supports it; otherwise it reports the device's native
+  // width.
+  const uint32_t *SgBegin = DeviceComputeProps.subGroupSizes;
+  const uint32_t *SgEnd = SgBegin + DeviceComputeProps.numSubGroupSizes;
+  if (DeviceComputeProps.numSubGroupSizes == 0) {
+    HipDeviceProps_.warpSize = CHIP_DEFAULT_WARP_SIZE;
+  } else if (std::find(SgBegin, SgEnd, CHIP_DEFAULT_WARP_SIZE) != SgEnd) {
+    HipDeviceProps_.warpSize = CHIP_DEFAULT_WARP_SIZE; // pinned to the default
   } else {
-    logWarn(
-        "The device might not support subgroup size {}, warp-size sensitive "
-        "kernels might not work correctly.",
-        CHIP_DEFAULT_WARP_SIZE);
+    HipDeviceProps_.warpSize = *std::max_element(SgBegin, SgEnd);
+    logWarn("Device does not support subgroup size {}; reporting warpSize {} "
+            "instead. Warp-size-sensitive kernels assuming {} may misbehave.",
+            CHIP_DEFAULT_WARP_SIZE, HipDeviceProps_.warpSize,
+            CHIP_DEFAULT_WARP_SIZE);
   }
 
   // Replicate from OpenCL implementation

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -534,14 +534,26 @@ void CHIPDeviceOpenCL::populateDevicePropertiesImpl() {
   // totally made up
   HipDeviceProps_.regsPerBlock = 64;
 
-  HipDeviceProps_.warpSize = CHIP_DEFAULT_WARP_SIZE;
-  // Try to check that we support the default warp size.
+  // Report the subgroup size that warp-sensitive kernels actually execute at.
+  // chipStar pins them to CHIP_DEFAULT_WARP_SIZE via reqd_sub_group_size where
+  // the device supports it; where it does not (e.g. Mali) the pin is dropped
+  // and kernels run at the device's native width. Query the device rather than
+  // hard-coding the constant so props.warpSize agrees with the device-side
+  // `warpSize` variable (get_sub_group_size()).
   std::vector<uint> Sg = ClDevice->getInfo<CL_DEVICE_SUB_GROUP_SIZES_INTEL>();
-  if (std::find(Sg.begin(), Sg.end(), CHIP_DEFAULT_WARP_SIZE) == Sg.end()) {
-    logWarn(
-        "The device might not support subgroup size {}, warp-size sensitive "
-        "kernels might not work correctly.",
-        CHIP_DEFAULT_WARP_SIZE);
+  if (Sg.empty()) {
+    // Driver does not report supported subgroup sizes (e.g. Mali); fall back to
+    // the build-time default.
+    HipDeviceProps_.warpSize = CHIP_DEFAULT_WARP_SIZE;
+  } else if (std::find(Sg.begin(), Sg.end(), CHIP_DEFAULT_WARP_SIZE) !=
+             Sg.end()) {
+    HipDeviceProps_.warpSize = CHIP_DEFAULT_WARP_SIZE; // pinned to the default
+  } else {
+    HipDeviceProps_.warpSize = *std::max_element(Sg.begin(), Sg.end());
+    logWarn("Device does not support subgroup size {}; reporting warpSize {} "
+            "instead. Warp-size-sensitive kernels assuming {} may misbehave.",
+            CHIP_DEFAULT_WARP_SIZE, HipDeviceProps_.warpSize,
+            CHIP_DEFAULT_WARP_SIZE);
   }
 
   HipDeviceProps_.maxGridSize[0] = HipDeviceProps_.maxGridSize[1] =


### PR DESCRIPTION
Both backends set \`props.warpSize\` to the build-time \`CHIP_DEFAULT_WARP_SIZE\` and only warned when the device did not support it, so on a device whose subgroup width differs (e.g. Mali) the reported \`warpSize\` was wrong and disagreed with the device-side \`warpSize\` variable (\`get_sub_group_size()\`).

Set it from the device query (\`CL_DEVICE_SUB_GROUP_SIZES_INTEL\` / Level Zero \`subGroupSizes\`): prefer \`CHIP_DEFAULT_WARP_SIZE\` when supported (chipStar pins warp-sensitive kernels to it), otherwise the device native size. Drivers that do not enumerate subgroup sizes at the device level (Mali OpenCL) keep the build-time default as a fallback; querying those needs a per-kernel probe (`clGetKernelSubGroupInfo`), left as a follow-up.

Pairs with the device-side runtime `warpSize` change. Verified: Intel Level Zero + OpenCL and rusticl (W6400, supports {32,64}) all report warpSize 32.