### PR TITLE
Fix segfault during exception unwind after hipCreateTextureObject error (#1256)

### DIFF
--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -6177,6 +6177,13 @@ hipCreateTextureObject(hipTextureObject_t *TexObject,
   if (!TexObject)
     RETURN(hipErrorInvalidValue);
 
+  // Initialize the output handle so that any error return below leaves the
+  // caller with a safe, destroyable value. Otherwise a RAII wrapper that
+  // calls hipDestroyTextureObject during exception unwind would operate on an
+  // uninitialized handle and crash. See #1256. Value-initialize so this
+  // compiles whether hipTextureObject_t is a pointer or an integral handle.
+  *TexObject = hipTextureObject_t{};
+
   if (!ResDesc)
     RETURN(hipErrorInvalidValue);
 

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -722,31 +722,24 @@ public:
                     ze_sampler_handle_t TheSampler)
       : chipstar::Texture(ResDesc), Image(TheImage), Sampler(TheSampler) {}
 
+  // Destructors are implicitly noexcept: an escaping exception during stack
+  // unwinding would call std::terminate. Skip null handles and never let a
+  // failure propagate out of the destructor (log instead of throw). See #1256.
   virtual ~CHIPTextureLevel0() {
-    destroyImage(Image);
-    destroySampler(Sampler);
+    if (Image) {
+      zeStatus = zeImageDestroy(Image);
+      if (zeStatus != ZE_RESULT_SUCCESS)
+        logError("zeImageDestroy failed in ~CHIPTextureLevel0: {}", zeStatus);
+    }
+    if (Sampler) {
+      zeStatus = zeSamplerDestroy(Sampler);
+      if (zeStatus != ZE_RESULT_SUCCESS)
+        logError("zeSamplerDestroy failed in ~CHIPTextureLevel0: {}", zeStatus);
+    }
   }
 
   ze_image_handle_t getImage() const { return Image; }
   ze_sampler_handle_t getSampler() const { return Sampler; }
-
-  // Destroy the LZ image object
-  static void destroyImage(ze_image_handle_t Handle) {
-    // The application must not call this function from
-    // simultaneous threads with the same image handle.
-    // Done via destructor should not be called from multiple threads
-    zeStatus = zeImageDestroy(Handle);
-    CHIPERR_CHECK_LOG_AND_THROW(hipErrorTbd);
-  }
-
-  // Destroy the LZ sampler object
-  static void destroySampler(ze_sampler_handle_t Handle) {
-    // The application must not call this function
-    // from simultaneous threads with the same sampler handle.
-    // Done via destructor should not be called from multiple threads
-    zeStatus = zeSamplerDestroy(Handle);
-    CHIPERR_CHECK_LOG_AND_THROW(hipErrorTbd);
-  }
 };
 
 class CHIPDeviceLevel0 : public chipstar::Device {

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -635,11 +635,17 @@ public:
                     cl_sampler TheSampler)
       : chipstar::Texture(ResDesc), Image(TheImage), Sampler(TheSampler) {}
 
+  // Destructors are implicitly noexcept; guard against null handles so a
+  // partially-constructed texture unwinds cleanly. See #1256.
   virtual ~CHIPTextureOpenCL() {
-    clStatus = clReleaseMemObject(Image);
-    assert(clStatus == CL_SUCCESS && "Invalid image handler?");
-    clStatus = clReleaseSampler(Sampler);
-    assert(clStatus == CL_SUCCESS && "Invalid sampler handler?");
+    if (Image) {
+      clStatus = clReleaseMemObject(Image);
+      assert(clStatus == CL_SUCCESS && "Invalid image handler?");
+    }
+    if (Sampler) {
+      clStatus = clReleaseSampler(Sampler);
+      assert(clStatus == CL_SUCCESS && "Invalid sampler handler?");
+    }
     (void)clStatus;
   }
 


### PR DESCRIPTION
hipCreateTextureObject left `*TexObject` uninitialized on error returns, and the Level Zero texture destructor threw (via CHIPERR_CHECK_LOG_AND_THROW) inside an implicitly-noexcept destructor. A RAII handle destroyed during exception unwind then either dereferenced garbage or triggered std::terminate. Now value-initialize `*TexObject` at entry and make the L0/OpenCL texture destructors null-guarded and non-throwing.

Validated on Arc B570: reproduced the SIGSEGV without the fix, clean with it, on both level0 and opencl; texture ctests pass (34/34 L0, 13/13 OCL).

Closes #1256