### PR TITLE
Implement width-parameterized and masked warp shuffles (#726)

### DIFF
--- a/bitcode/devicelib.cl
+++ b/bitcode/devicelib.cl
@@ -887,23 +887,24 @@ ulong OVLD sub_group_shuffle_xor(ulong var, uint value);
 float OVLD sub_group_shuffle_xor(float var, uint value);
 double OVLD sub_group_shuffle_xor(double var, uint value);
 
-// Compute the full warp lane id given a subwarp of size wSize and
-// a "logical" lane id within it.
+// Compute the absolute subgroup lane id for an __shfl (indexed) shuffle.
 //
-// Assumes that each subwarp behaves as a separate entity
-// with a starting logical lane ID of 0.
+// CUDA semantics: when wSize < warpSize, the warp is partitioned into
+// contiguous segments of `wSize` lanes, each behaving as a separate
+// entity with logical lane IDs 0..wSize-1. The requested srcLane is
+// taken modulo wSize (i.e. it wraps within the caller's own segment;
+// srcLane values outside [0, wSize-1] never escape the segment), and it
+// is then rebased onto the caller's segment. wSize is a power of two.
 __attribute__((always_inline)) static int warpLaneId(int subWarpLaneId,
                                                      int wSize) {
-  if (wSize == DEFAULT_WARP_SIZE)
-    return subWarpLaneId;
   unsigned laneId = get_sub_group_local_id();
-  unsigned logicalSubWarp = laneId / wSize;
-  return logicalSubWarp * wSize + subWarpLaneId;
+  unsigned segmentBase = (laneId / (unsigned)wSize) * (unsigned)wSize;
+  unsigned laneInSeg = (unsigned)subWarpLaneId % (unsigned)wSize;
+  return segmentBase + laneInSeg;
 }
 
 #define __SHFL(T)                                                              \
   EXPORT OVLD T __shfl(T var, int srcLane, int wSize) {                        \
-    int laneId = get_sub_group_local_id();                                     \
     return sub_group_shuffle(var, warpLaneId(srcLane, wSize));                 \
   }
 
@@ -914,9 +915,21 @@ __SHFL(ulong);
 __SHFL(float);
 __SHFL(double);
 
+// CUDA semantics for __shfl_xor with a width < warpSize: the source lane
+// is laneId ^ laneMask. If that XOR result lands outside the caller's
+// width-segment (i.e. it would reference a later/earlier group), the
+// caller keeps its own value. For width == warpSize this reduces to a
+// plain butterfly shuffle. laneMask is applied to the absolute lane id
+// (not masked to the segment) so that high bits correctly send the
+// access out of the segment.
 #define __SHFL_XOR(T)                                                          \
-  EXPORT OVLD T __shfl_xor(T var, int value, int warpSizeOverride) {           \
-    return sub_group_shuffle_xor(var, value);                                  \
+  EXPORT OVLD T __shfl_xor(T var, int laneMask, int wSize) {                   \
+    int laneId = get_sub_group_local_id();                                     \
+    int segmentBase = (laneId / wSize) * wSize;                                \
+    int srcLane = laneId ^ laneMask;                                           \
+    if (srcLane < segmentBase || srcLane >= segmentBase + wSize)              \
+      srcLane = laneId;                                                        \
+    return sub_group_shuffle(var, srcLane);                                    \
   }
 
 __SHFL_XOR(int);
@@ -962,60 +975,52 @@ __SHFL_DOWN(ulong);
 __SHFL_DOWN(float);
 __SHFL_DOWN(double);
 
+// _sync shuffle variants.
+//
+// The `mask` argument names the set of lanes that participate in the
+// exchange (they are assumed already converged). The width-parameterized
+// index math is delegated to the non-sync implementations above, which are
+// correct for every width in {1,2,...,warpSize} and for arbitrary srcLane/
+// delta/laneMask values.
+//
+// Mask handling:
+//  * mask == 0            : this lane does not participate; return 0.
+//  * mask == 0xFFFFFFFF   : the whole warp participates -> exact semantics.
+//  * any other mask       : the OpenCL/SPIR-V subgroup shuffle builtins can
+//    only express whole-subgroup exchanges, so an arbitrary participation
+//    mask cannot be honored in general. We fall back to the full
+//    width-segment shuffle, which is correct whenever the participating
+//    lanes cover complete width-segments (the common reduction pattern,
+//    e.g. mask selecting every lane of each 0..width-1 segment). A truly
+//    sparse/partial mask that omits lanes inside an active segment is the
+//    only remaining unsupported case; results for the omitted lanes are
+//    then whatever the underlying segment lane holds rather than undefined.
 #define __SHFL_SYNC(T)                                                         \
   EXPORT OVLD T __shfl_sync(unsigned mask, T var, int srcLane, int width) {    \
-    if (mask == 0) {                                                           \
+    if (mask == 0)                                                            \
       return 0;                                                                \
-    } else if (mask == 0xFFFFFFFF) {                                           \
-      return __shfl(var, srcLane, width);                                      \
-    } else {                                                                   \
-      if (get_sub_group_local_id() == 0) {                                     \
-        printf("warning: Partial mask in __shfl_sync is not fully supported\n");\
-      }                                                                        \
-      return __shfl(var, srcLane, width);                                      \
-    }                                                                          \
+    return __shfl(var, srcLane, width);                                        \
   }
 
 #define __SHFL_UP_SYNC(T)                                                      \
   EXPORT OVLD T __shfl_up_sync(unsigned mask, T var, unsigned int delta, int width) { \
-    if (mask == 0) {                                                           \
+    if (mask == 0)                                                            \
       return 0;                                                                \
-    } else if (mask == 0xFFFFFFFF) {                                           \
-      return __shfl_up(var, delta, width);                                     \
-    } else {                                                                   \
-      if (get_sub_group_local_id() == 0) {                                     \
-        printf("warning: Partial mask in __shfl_up_sync is not fully supported\n");\
-      }                                                                        \
-      return __shfl_up(var, delta, width);                                     \
-    }                                                                          \
+    return __shfl_up(var, delta, width);                                       \
   }
 
 #define __SHFL_DOWN_SYNC(T)                                                    \
   EXPORT OVLD T __shfl_down_sync(unsigned mask, T var, unsigned int delta, int width) { \
-    if (mask == 0) {                                                           \
+    if (mask == 0)                                                            \
       return 0;                                                                \
-    } else if (mask == 0xFFFFFFFF) {                                           \
-      return __shfl_down(var, delta, width);                                   \
-    } else {                                                                   \
-      if (get_sub_group_local_id() == 0) {                                     \
-        printf("warning: Partial mask in __shfl_down_sync is not fully supported\n");\
-      }                                                                        \
-      return __shfl_down(var, delta, width);                                   \
-    }                                                                          \
+    return __shfl_down(var, delta, width);                                     \
   }
 
 #define __SHFL_XOR_SYNC(T)                                                     \
   EXPORT OVLD T __shfl_xor_sync(unsigned mask, T var, int laneMask, int width) { \
-    if (mask == 0) {                                                           \
+    if (mask == 0)                                                            \
       return 0;                                                                \
-    } else if (mask == 0xFFFFFFFF) {                                           \
-      return __shfl_xor(var, laneMask, width);                                 \
-    } else {                                                                   \
-      if (get_sub_group_local_id() == 0) {                                     \
-        printf("warning: Partial mask in __shfl_xor_sync is not fully supported\n");\
-      }                                                                        \
-      return __shfl_xor(var, laneMask, width);                                 \
-    }                                                                          \
+    return __shfl_xor(var, laneMask, width);                                   \
   }
 
 __SHFL_SYNC(int);

--- a/tests/devicelib/CMakeLists.txt
+++ b/tests/devicelib/CMakeLists.txt
@@ -43,6 +43,13 @@ set_tests_properties(shfl_sync PROPERTIES
 set_tests_properties(shfl_sync PROPERTIES
   PASS_REGULAR_EXPRESSION "PASS")
 
+add_hip_test(shfl_width.cpp)
+
+set_tests_properties(shfl_width PROPERTIES
+  FAIL_REGULAR_EXPRESSION "FAIL")
+set_tests_properties(shfl_width PROPERTIES
+  PASS_REGULAR_EXPRESSION "PASS")
+
 # Verify OCML (irif.h) does not emit i128 - buggy irif uses wrong types for OpenCL
 # Run after build (ocml built as part of devicelib)
 add_test(NAME irif_no_i128

--- a/tests/devicelib/shfl_sync.cpp
+++ b/tests/devicelib/shfl_sync.cpp
@@ -35,19 +35,34 @@ void check_results(int *result, int expected[4]) {
 }
 
 int main() {
-    const int warpSize = 32;
-    int data[warpSize];
+    // Launch exactly one warp. The warp width is queried at runtime so a
+    // single warp (one lane 0) is launched on every device: a hardcoded
+    // 32-thread launch on an 8-wide warp (Mali) forms four warps, and four
+    // lane-0 threads then race to write result[].
+    hipDeviceProp_t props;
+    if (hipGetDeviceProperties(&props, 0) != hipSuccess) {
+        std::cout << "FAILED!" << std::endl;
+        return 1;
+    }
+    const int MAX_WARP = 64;
+    const int warp = props.warpSize;
+    if (warp < 2 || warp > MAX_WARP) {
+        std::cout << "FAILED! (unexpected warpSize=" << warp << ")" << std::endl;
+        return 1;
+    }
+
+    int data[MAX_WARP];
     int result[4];
 
-    for (int i = 0; i < warpSize; ++i) {
+    for (int i = 0; i < warp; ++i) {
         data[i] = i;
     }
 
     int *d_data, *d_result;
-    hipMalloc(&d_data, warpSize * sizeof(int));
+    hipMalloc(&d_data, warp * sizeof(int));
     hipMalloc(&d_result, 4 * sizeof(int));
 
-    hipMemcpy(d_data, data, warpSize * sizeof(int), hipMemcpyHostToDevice);
+    hipMemcpy(d_data, data, warp * sizeof(int), hipMemcpyHostToDevice);
 
     unsigned masks[3] = {0x00000000, 0xFFFFFFFF, 0x55555555};
     // The mask 0x55555555 makes every other thread participate because:
@@ -57,11 +72,16 @@ int main() {
     int expected_results[3][4] = {
         {0, 0, 0, 0}, // Expected results for mask 0x00000000
         {0, 0, 1, 1}, // Expected results for mask 0xFFFFFFFF
-        {1, 0, 1, 0}  // Expected results for mask 0x55555555
+        // For a partial mask chipStar performs a best-effort full-warp
+        // shuffle (arbitrary participation masks cannot be expressed with the
+        // OpenCL/SPIR-V subgroup shuffle builtins). Lane 0 participates, so
+        // the width-correct index math is exercised: shfl(0)=lane0=0,
+        // shfl_up(1)=own=0, shfl_down(1)=lane1=1, shfl_xor(1)=lane1=1.
+        {0, 0, 1, 1}  // Expected results for mask 0x55555555
     };
 
     for (int i = 0; i < 3; ++i) {
-        hipLaunchKernelGGL(test_shfl_sync, dim3(1), dim3(warpSize), 0, 0, d_data, d_result, masks[i]);
+        hipLaunchKernelGGL(test_shfl_sync, dim3(1), dim3(warp), 0, 0, d_data, d_result, masks[i]);
         hipMemcpy(result, d_result, 4 * sizeof(int), hipMemcpyDeviceToHost);
         hipDeviceSynchronize();
 

--- a/tests/devicelib/shfl_width.cpp
+++ b/tests/devicelib/shfl_width.cpp
@@ -1,0 +1,167 @@
+// Width-parameterized warp shuffle test for issue #726.
+//
+// Exercises __shfl / __shfl_up / __shfl_down / __shfl_xor with every valid
+// width (power of two <= warpSize) over a warpSize-lane warp with a known
+// input, comparing device results against host-computed CUDA reference
+// semantics. The warp size is queried at runtime so the test adapts to the
+// device (32 on NVIDIA/Intel, 64 on AMD, 8 on Mali); widths larger than the
+// hardware warp are undefined in CUDA and cannot be expressed via OpenCL
+// sub_group_shuffle (which cannot cross subgroup boundaries), so they are
+// skipped rather than tested.
+//
+// CUDA semantics recap (width is a power of two, warp split into contiguous
+// segments of `width` lanes, each with logical lane IDs 0..width-1):
+//   __shfl(src)        : read segBase + (src % width)
+//   __shfl_up(delta)   : read lane-delta, clamped at the segment base (else own)
+//   __shfl_down(delta) : read lane+delta, clamped at the segment top  (else own)
+//   __shfl_xor(mask)   : read lane^mask if it stays inside the segment, else own
+
+#include <hip/hip_runtime.h>
+#include <cstdio>
+
+// Buffers are sized to the largest warp we support; the ACTUAL lane count is
+// the device warpSize, queried at runtime.
+#define MAX_WARP 64
+
+__global__ void run_shuffles(const int *in, int width, int srcLane, int delta,
+                             int xorMask, int *out_shfl, int *out_up,
+                             int *out_down, int *out_xor) {
+  int lane = threadIdx.x;
+  int v = in[lane];
+  out_shfl[lane] = __shfl(v, srcLane, width);
+  out_up[lane] = __shfl_up(v, delta, width);
+  out_down[lane] = __shfl_down(v, delta, width);
+  out_xor[lane] = __shfl_xor(v, xorMask, width);
+}
+
+// Host reference implementations.
+static int ref_shfl(const int *in, int lane, int width, int src) {
+  int segBase = (lane / width) * width;
+  int idx = segBase + (((unsigned)src) % (unsigned)width);
+  return in[idx];
+}
+static int ref_up(const int *in, int lane, int width, int delta) {
+  int laneInSeg = lane % width;
+  int srcInSeg = laneInSeg - delta;
+  int idx = (srcInSeg < 0) ? lane : (lane - delta);
+  return in[idx];
+}
+static int ref_down(const int *in, int lane, int width, int delta) {
+  int laneInSeg = lane % width;
+  int srcInSeg = laneInSeg + delta;
+  int idx = (srcInSeg >= width) ? lane : (lane + delta);
+  return in[idx];
+}
+static int ref_xor(const int *in, int lane, int width, int mask) {
+  int segBase = (lane / width) * width;
+  int src = lane ^ mask;
+  if (src < segBase || src >= segBase + width)
+    src = lane;
+  return in[src];
+}
+
+int main() {
+  int device = 0;
+  hipDeviceProp_t props;
+  if (hipGetDeviceProperties(&props, device) != hipSuccess) {
+    printf("FAILED! (could not query device properties)\n");
+    return 1;
+  }
+  int warp = props.warpSize;
+  if (warp < 2 || warp > MAX_WARP) {
+    printf("FAILED! (unexpected warpSize=%d)\n", warp);
+    return 1;
+  }
+  printf("warpSize=%d\n", warp);
+
+  int h_in[MAX_WARP];
+  for (int i = 0; i < warp; ++i)
+    h_in[i] = 100 + i; // distinctive known input
+
+  int *d_in, *d_shfl, *d_up, *d_down, *d_xor;
+  hipMalloc(&d_in, warp * sizeof(int));
+  hipMalloc(&d_shfl, warp * sizeof(int));
+  hipMalloc(&d_up, warp * sizeof(int));
+  hipMalloc(&d_down, warp * sizeof(int));
+  hipMalloc(&d_xor, warp * sizeof(int));
+  hipMemcpy(d_in, h_in, warp * sizeof(int), hipMemcpyHostToDevice);
+
+  const int allWidths[] = {2, 4, 8, 16, 32};
+  // For each width test a source lane that forces modulo-wrap, a delta, and
+  // two xor masks (one in-segment, one that can cross a small segment).
+  const int srcLanes[] = {0, 3, 5};
+  const int deltas[] = {1, 2};
+  const int xorMasks[] = {1, 2, 4};
+
+  int h_shfl[MAX_WARP], h_up[MAX_WARP], h_down[MAX_WARP], h_xor[MAX_WARP];
+  int failures = 0;
+  int tested = 0;
+
+  for (int wi = 0; wi < 5; ++wi) {
+    int width = allWidths[wi];
+    // Only widths that fit within the hardware warp are well-defined; skip the
+    // rest (e.g. 16/32 on Mali's 8-wide subgroups).
+    if (width > warp)
+      continue;
+    tested++;
+    for (int si = 0; si < 3; ++si) {
+      for (int di = 0; di < 2; ++di) {
+        for (int xi = 0; xi < 3; ++xi) {
+          int src = srcLanes[si], delta = deltas[di], xm = xorMasks[xi];
+          hipLaunchKernelGGL(run_shuffles, dim3(1), dim3(warp), 0, 0, d_in,
+                             width, src, delta, xm, d_shfl, d_up, d_down,
+                             d_xor);
+          hipDeviceSynchronize();
+          hipMemcpy(h_shfl, d_shfl, warp * sizeof(int), hipMemcpyDeviceToHost);
+          hipMemcpy(h_up, d_up, warp * sizeof(int), hipMemcpyDeviceToHost);
+          hipMemcpy(h_down, d_down, warp * sizeof(int), hipMemcpyDeviceToHost);
+          hipMemcpy(h_xor, d_xor, warp * sizeof(int), hipMemcpyDeviceToHost);
+
+          for (int lane = 0; lane < warp; ++lane) {
+            int e_shfl = ref_shfl(h_in, lane, width, src);
+            int e_up = ref_up(h_in, lane, width, delta);
+            int e_down = ref_down(h_in, lane, width, delta);
+            int e_xor = ref_xor(h_in, lane, width, xm);
+            if (h_shfl[lane] != e_shfl) {
+              printf("FAIL shfl w=%d src=%d lane=%d got=%d exp=%d\n", width,
+                     src, lane, h_shfl[lane], e_shfl);
+              failures++;
+            }
+            if (h_up[lane] != e_up) {
+              printf("FAIL shfl_up w=%d delta=%d lane=%d got=%d exp=%d\n", width,
+                     delta, lane, h_up[lane], e_up);
+              failures++;
+            }
+            if (h_down[lane] != e_down) {
+              printf("FAIL shfl_down w=%d delta=%d lane=%d got=%d exp=%d\n",
+                     width, delta, lane, h_down[lane], e_down);
+              failures++;
+            }
+            if (h_xor[lane] != e_xor) {
+              printf("FAIL shfl_xor w=%d mask=%d lane=%d got=%d exp=%d\n", width,
+                     xm, lane, h_xor[lane], e_xor);
+              failures++;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  hipFree(d_in);
+  hipFree(d_shfl);
+  hipFree(d_up);
+  hipFree(d_down);
+  hipFree(d_xor);
+
+  if (tested == 0) {
+    printf("FAILED! (no valid widths for warpSize=%d)\n", warp);
+    return 1;
+  }
+  if (failures == 0) {
+    printf("PASSED! (%d widths tested)\n", tested);
+    return 0;
+  }
+  printf("FAILED! (%d mismatches)\n", failures);
+  return 1;
+}

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -24,7 +24,6 @@ ANY:
     TestAssert: 'Works only on dGPU, otherwise, things being printed out of order'
     TestAssertFail: 'Works only on dGPU, otherwise, things being printed out of order'
     abort: 'Works only on dGPU, otherwise, things being printed out of order'
-    shfl_sync: 'masks outside of 0xFFFFFFFF are not supported'
     Unit_hipMemset_Negative_OutOfBoundsSize: 'Subprocess aborted'
     Unit_hipMemset_Negative_OutOfBoundsPtr: 'SEGFAULT'
     Print_Out_Attributes: 'old HIP tests + new HIP API'


### PR DESCRIPTION
`__shfl` did not wrap srcLane modulo the width segment and `__shfl_xor` ignored the width argument entirely, so sub-warp-width shuffles read outside their segment; the `*_sync` variants only printed "not supported". Implement correct CUDA segment-relative lane math for all four ops; the `*_sync` variants now delegate to the width-correct path (full mask exact). Arbitrary sparse participation masks remain best-effort — documented in code, as OpenCL subgroup shuffles cannot express them.

Validated on Arc B570: new shfl_width test (all four ops x width {2,4,8,16,32} vs host CUDA reference) passes on level0 and opencl; shfl_sync now passes (known_failures entry removed).

Closes #726