### PR TITLE
Consolidate program-scope variable init into one kernel (#582)

### DIFF
--- a/llvm_passes/HipGlobalVariables.cpp
+++ b/llvm_passes/HipGlobalVariables.cpp
@@ -255,41 +255,31 @@ static bool hasNoRuntimeConstants(Constant *C, const GVarMapT &GVarMap) {
   return false; // Default answer if we can't fully analyze the constant.
 }
 
-// Emit a shadow kernel for initialing the global variable.
-static void emitGlobalVarInitShadowKernel(Module &M, GlobalVariable *GVar,
-                                          GlobalVariable *OriginalGVar,
-                                          GVarMapT GVarMap) {
+// Emit the initialization IR for a single global variable at the Builder's
+// current insertion point (inside a shadow kernel body). See #582: this body
+// is shared by the per-variable init shadow kernel and the single combined
+// init kernel.
+static void emitGlobalVarInitBody(Module &M, IRBuilder<> &Builder,
+                                  GlobalVariable *GVar,
+                                  GlobalVariable *OriginalGVar,
+                                  GVarMapT &GVarMap) {
   // For original global variable in pseudo code:
   //
   //   SomeType Foo = SomeInit;
   //
-  // A) Emit the following shadow kernel in pseudo code:
-  //
-  //   SomeType* <ChipVarPrefix>Foo; // *1
-  //   void <ChipVarInitPrefix>Foo() {
+  // A) Emit:
   //     memcpy(<ChipVarPrefix>Foo, &Foo, sizeof(SomeType));
-  //   }
   //
-  // B) Emit the following shadow kernel in pseudo code:
-  //
-  //   SomeType* <ChipVarPrefix>Foo; // *1
-  //   void <ChipVarInitPrefix>Foo() {
+  // B) Emit (fallback for initializers referencing other lowered variables
+  //    whose addresses are resolved at runtime):
   //     *<ChipVarPrefix>Foo = SomeInit;
-  //   }
+  //    This alternative should be avoided as it may lead to bad native
+  //    code-gen.
   //
-  // This alternative should be avoided as it may lead to bad native code-gen.
-  // This is used as fallback for variables with references to other variables
-  // whose addresses are resolved at runtime (aka. the variables being lowered
-  // in this pass).
-  //
-  // *1: Emitted by emitIndirectGlobalVariable().
-  //
+  // <ChipVarPrefix>Foo (i.e. GVar) is emitted by emitIndirectGlobalVariable().
 
   assert(GVar->getValueType()->isIntegerTy(64));
   assert(OriginalGVar->hasInitializer());
-
-  auto Name = std::string(ChipVarInitPrefix) + OriginalGVar->getName().str();
-  IRBuilder<> Builder(createKernelStub(M, Name, {}));
 
   // GVar is i64; load and convert to pointer.
   auto *PtrAS = PointerType::get(M.getContext(), SpirvCrossWorkGroupAS);
@@ -324,6 +314,35 @@ static void emitGlobalVarInitShadowKernel(Module &M, GlobalVariable *GVar,
 
   // *<ChipVarPrefix>Foo = SomeInit;
   Builder.CreateStore(Init, Ptr);
+}
+
+// Emit a per-variable shadow kernel for initializing the global variable.
+// Emitted in the globals-as-kernel-args (rusticl) lowering, where each init
+// kernel is later reworked to take the storage address as an argument.
+static void emitGlobalVarInitShadowKernel(Module &M, GlobalVariable *GVar,
+                                          GlobalVariable *OriginalGVar,
+                                          GVarMapT GVarMap) {
+  auto Name = std::string(ChipVarInitPrefix) + OriginalGVar->getName().str();
+  IRBuilder<> Builder(createKernelStub(M, Name, {}));
+  emitGlobalVarInitBody(M, Builder, GVar, OriginalGVar, GVarMap);
+}
+
+// Emit a single combined shadow kernel that initializes ALL host-accessible
+// program-scope variables in one kernel launch. This avoids the O(N) launch
+// overhead of launching one single-work-item init kernel per variable (#582).
+// The InitVars are (lowered-i64-GVar, original-GVar) pairs; the caller has
+// already filtered out variables without initializers and the special
+// device-heap-null case. Returns true if a kernel was emitted.
+static bool emitCombinedGlobalVarInitKernel(
+    Module &M,
+    ArrayRef<std::pair<GlobalVariable *, GlobalVariable *>> InitVars,
+    GVarMapT &GVarMap) {
+  if (InitVars.empty())
+    return false;
+  IRBuilder<> Builder(createKernelStub(M, ChipVarInitAllName, {}));
+  for (auto &Pair : InitVars)
+    emitGlobalVarInitBody(M, Builder, Pair.first, Pair.second, GVarMap);
+  return true;
 }
 
 static bool shouldLower(const GlobalVariable &GVar) {
@@ -745,19 +764,34 @@ static bool lowerGlobalVariables(Module &M) {
   // Lower host accessible global device variables.
   GVarMapT GVarMap = emitIndirectGlobalVariables(M);
   if (!GVarMap.empty()) {
+    // Collect (lowered-i64-GVar, original-GVar) pairs that need initialization,
+    // in a deterministic order, for the combined init kernel (#582).
+    std::vector<std::pair<GlobalVariable *, GlobalVariable *>> InitVars;
     for (auto Kv : GVarMap) {
       emitGlobalVarInfoShadowKernel(M, Kv.first);
       emitGlobalVarBindShadowKernel(M, Kv.second, Kv.first);
       if (Kv.first->hasInitializer()) {
-        // Skip init kernel only for __chipspv_device_heap which has a
-        // pointer-typed null initializer that clspv cannot handle.
+        // Skip init only for __chipspv_device_heap which has a pointer-typed
+        // null initializer that clspv cannot handle.
         bool IsDeviceHeapNull =
             Kv.first->getName() == ChipDeviceHeapName &&
             Kv.first->getInitializer()->isNullValue();
         if (!IsDeviceHeapNull)
-          emitGlobalVarInitShadowKernel(M, Kv.second, Kv.first, GVarMap);
+          InitVars.push_back(std::make_pair(Kv.second, Kv.first));
       }
     }
+#ifdef CHIP_ENABLE_DEVICE_PROGRAM_SCOPE_GLOBALS
+    // Program-scope-globals path (default): initialize all variables from a
+    // single combined shadow kernel launched once, instead of one
+    // single-work-item init kernel launch per variable (#582).
+    emitCombinedGlobalVarInitKernel(M, InitVars, GVarMap);
+#else
+    // Globals-as-kernel-args (rusticl) path: keep per-variable init kernels;
+    // lowerGlobalsToKernelArgs() reworks each to take the storage address as
+    // an argument.
+    for (auto &Pair : InitVars)
+      emitGlobalVarInitShadowKernel(M, Pair.first, Pair.second, GVarMap);
+#endif
     replaceGlobalVariableUses(GVarMap);
     eraseMappedGlobalVariables(GVarMap);
     Changed |= true;

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -507,14 +507,25 @@ void chipstar::Module::prepareDeviceVariablesNoLock(chipstar::Device *Device,
   logTrace("Initialize device variables in module: {}", (void *)this);
 
   bool QueuedKernels = false;
-  for (auto *Var : ChipVars_) {
-    logTrace("Checking variable '{}' for initialization: hasInitializer={}", 
-             Var->getName(), Var->hasInitializer());
-    if (!Var->hasInitializer())
-      continue;
-    logTrace("Initializing variable '{}'", Var->getName());
-    queueVariableInitShadowKernel(Queue, this, Var);
+  // Fast path (#582): the program-scope-globals lowering emits a single
+  // combined init kernel that initializes ALL variables in one launch, instead
+  // of one single-work-item init kernel per variable. Launch it once when
+  // present; otherwise fall back to the per-variable init kernels (used by the
+  // globals-as-kernel-args/rusticl lowering).
+  if (auto *CombinedInitKernel = findKernel(ChipVarInitAllName)) {
+    logTrace("Initializing all device variables via combined init kernel");
+    queueKernel(Queue, CombinedInitKernel);
     QueuedKernels = true;
+  } else {
+    for (auto *Var : ChipVars_) {
+      logTrace("Checking variable '{}' for initialization: hasInitializer={}",
+               Var->getName(), Var->hasInitializer());
+      if (!Var->hasInitializer())
+        continue;
+      logTrace("Initializing variable '{}'", Var->getName());
+      queueVariableInitShadowKernel(Queue, this, Var);
+      QueuedKernels = true;
+    }
   }
 
   // Launch kernel for resetting host-inaccessible global device variables.

--- a/src/common.hh
+++ b/src/common.hh
@@ -69,6 +69,11 @@ constexpr char ChipVarBindPrefix[] = "__chip_var_bind_";
 /// A prefix used for a shadow kernel used for initializing device
 /// variables.
 constexpr char ChipVarInitPrefix[] = "__chip_var_init_";
+/// The name of a single combined shadow kernel that initializes ALL
+/// host-accessible program-scope variables in one launch. Emitted (in the
+/// program-scope-globals lowering) instead of per-variable init kernels to
+/// avoid O(N) single-work-item kernel launches. See issue #582.
+constexpr char ChipVarInitAllName[] = "__chip_var_init_all";
 /// A structure to where properties of a device variable are written.
 /// CHIPVarInfo[0]: Size in bytes.
 /// CHIPVarInfo[1]: Requested alignment.


### PR DESCRIPTION
Program-scope (`__device__`/`__constant__`) variable init launched one single-work-item shadow kernel per variable, costing O(N) launches at first module use. Consolidate them into a single `__chip_var_init_all` kernel (reusing the existing runtime-constant-initializer pattern). Backend-agnostic; the rusticl globals-as-kernel-args path keeps per-variable kernels and the runtime auto-detects which to use.

Performance on Intel Arc B570 (Level Zero), 256 initialized globals: first-use init drops from ~42ms to ~26ms, about 37 percent faster.

Scope: this reduces launch count only. #582 also asks for parallel copies, memset for zero-initialized objects, and replacing the shadow kernels with CL/LZ copy/fill commands so DMA engines can be used. None of that is addressed here, so #582 stays open pending a follow-up.

Validated on Arc B570: values correct across symbol/constant-memory tests; check.py 100% pass on level0 (1043) and opencl (1009).

Refs #582
