### PR TITLE
[L0] Give each graph kernel node a private kernel handle (#782)

### DIFF
--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1283,6 +1283,18 @@ public:
   virtual chipstar::Kernel *getKernel() = 0;
 
   /**
+   * @brief Give this exec item a private, independent kernel handle.
+   *
+   * Used by persistent HIP graph kernel nodes so that two nodes launching the
+   * same kernel function bind their arguments to independent kernel handles
+   * instead of clobbering one shared handle (issue #782). Must be called after
+   * setKernel() and before setupAllArgs(). The default is a no-op: backends
+   * whose exec items already own a private handle (e.g. OpenCL borrows a unique
+   * cl_kernel in setKernel()) need no isolation.
+   */
+  virtual void useIndependentKernelHandle() {}
+
+  /**
    * @brief Get the Queue object
    *
    * @return Queue*

--- a/src/CHIPGraph.cc
+++ b/src/CHIPGraph.cc
@@ -145,6 +145,10 @@ CHIPGraphNodeKernel::CHIPGraphNodeKernel(const hipKernelNodeParams *TheParams)
   ExecItem_ = Backend->createExecItem(Params_.gridDim, Params_.blockDim,
                                       Params_.sharedMemBytes, nullptr);
   ExecItem_->setKernel(ChipKernel);
+  // Give this graph node a private kernel handle so that another node
+  // launching the same kernel does not clobber this node's argument
+  // bindings when both are queued before execution (issue #782).
+  ExecItem_->useIndependentKernelHandle();
   ExecItem_->setArgs(TheParams->kernelParams);
   // setupAllArgs() binds implicit device-global address arguments, so the
   // module's device variables must be allocated first. The normal launch path
@@ -175,6 +179,10 @@ CHIPGraphNodeKernel::CHIPGraphNodeKernel(const void *HostFunction, dim3 GridDim,
 
   ExecItem_ = Backend->createExecItem(GridDim, BlockDim, SharedMem, nullptr);
   ExecItem_->setKernel(ChipKernel);
+  // Give this graph node a private kernel handle so that another node
+  // launching the same kernel does not clobber this node's argument
+  // bindings when both are queued before execution (issue #782).
+  ExecItem_->useIndependentKernelHandle();
   ExecItem_->setArgs(Params_.kernelParams);
   // setupAllArgs() binds implicit device-global address arguments, so the
   // module's device variables must be allocated first (see the

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -941,6 +941,33 @@ CHIPKernelLevel0::CHIPKernelLevel0(ze_kernel_handle_t ZeKernel,
       StaticLocalSize_;
   MaxWorkGroupSize_ = Device->getAttr(hipDeviceAttributeMaxThreadsPerBlock);
 }
+
+CHIPKernelLevel0 *CHIPKernelLevel0::clone() {
+  // Create an independent ze_kernel_handle_t for the same function so the
+  // copy has its own argument bindings (issue #782). Level Zero has no
+  // zeKernelClone, so we create a fresh handle from the parent module using
+  // the same kernel name and residency flag as the original creation path.
+  // The original handle is left untouched.
+  ze_kernel_handle_t ClonedHandle = nullptr;
+  // Keep the name in a local so pKernelName does not dangle: getName() returns
+  // a temporary std::string whose buffer would be freed before zeKernelCreate.
+  std::string KernelName = getName();
+  ze_kernel_desc_t KernelDesc = {ZE_STRUCTURE_TYPE_KERNEL_DESC, nullptr,
+                                 0, // flags
+                                 KernelName.c_str()};
+  if (!Device->hasOnDemandPaging())
+    KernelDesc.flags |= ZE_KERNEL_FLAG_FORCE_RESIDENCY;
+  zeStatus = zeKernelCreate(Module->get(), &KernelDesc, &ClonedHandle);
+  CHIPERR_CHECK_LOG_AND_THROW_TABLE(zeKernelCreate);
+  auto *Cloned = new CHIPKernelLevel0(ClonedHandle, Device, getName(),
+                                      getFuncInfo(), Module);
+  // Preserve the host/device function pointer associations so that the clone
+  // still resolves to the same HIP kernel (needed by graph-node execution,
+  // e.g. prepareDeviceVariables()).
+  Cloned->setHostPtr(getHostPtr());
+  Cloned->setDevPtr(getDevPtr());
+  return Cloned;
+}
 // End CHIPKernelLevelZero
 
 hipError_t CHIPKernelLevel0::getAttributes(hipFuncAttributes *Attr) {
@@ -3693,3 +3720,23 @@ void CHIPExecItemLevel0::setKernel(chipstar::Kernel *Kernel) {
 }
 
 chipstar::Kernel *CHIPExecItemLevel0::getKernel() { return ChipKernel_; }
+
+void CHIPExecItemLevel0::takeOwnedKernelClone() {
+  // Replace the (shared) kernel with an independent clone that this exec item
+  // owns and destroys, so argument bindings are private to this exec item
+  // (issue #782). The original shared kernel is left untouched.
+  ChipKernel_ = ChipKernel_->clone();
+  OwnsKernel_ = true;
+}
+
+chipstar::ExecItem *CHIPExecItemLevel0::clone() const {
+  auto *NewExecItem = new CHIPExecItemLevel0(*this);
+  // Give the clone its own ze_kernel_handle_t so that a duplicated graph (e.g.
+  // hipGraphClone) does not share argument state with the original (#782).
+  NewExecItem->takeOwnedKernelClone();
+  // Force argument (re)binding onto the freshly cloned handle at launch time;
+  // the copy constructor inherited ArgsSetup from the source which may have
+  // already bound arguments to the original handle.
+  NewExecItem->ArgsSetup = false;
+  return NewExecItem;
+}

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -53,6 +53,17 @@ class CHIPKernelLevel0;
 
 class CHIPExecItemLevel0 : public chipstar::ExecItem {
   CHIPKernelLevel0 *ChipKernel_ = nullptr;
+  // When true, ChipKernel_ is a per-exec-item clone (its own
+  // ze_kernel_handle_t) owned by this exec item and destroyed on teardown.
+  // HIP graph kernel nodes use this so that two nodes launching the same
+  // kernel bind their arguments to independent handles instead of clobbering
+  // one shared handle (issue #782).
+  bool OwnsKernel_ = false;
+
+  // Replace ChipKernel_ with an owned, independent clone (its own
+  // ze_kernel_handle_t) so this exec item binds arguments to a private handle
+  // (issue #782). Defined out-of-line because it uses CHIPKernelLevel0::clone.
+  void takeOwnedKernelClone();
 
 public:
   CHIPExecItemLevel0(const CHIPExecItemLevel0 &Other)
@@ -67,13 +78,14 @@ public:
                      hipStream_t ChipQueue)
       : ExecItem(GirdDim, BlockDim, SharedMem, ChipQueue) {}
 
-  virtual ~CHIPExecItemLevel0() override {}
+  virtual ~CHIPExecItemLevel0() override {
+    if (OwnsKernel_)
+      delete ChipKernel_;
+  }
 
   virtual void setupAllArgs() override;
-  virtual chipstar::ExecItem *clone() const override {
-    auto NewExecItem = new CHIPExecItemLevel0(*this);
-    return NewExecItem;
-  }
+  virtual chipstar::ExecItem *clone() const override;
+  virtual void useIndependentKernelHandle() override { takeOwnedKernelClone(); }
 
   void setKernel(chipstar::Kernel *Kernel) override;
   chipstar::Kernel *getKernel() override;
@@ -706,6 +718,13 @@ public:
                    std::string FuncName, SPVFuncInfo *FuncInfo,
                    CHIPModuleLevel0 *Parent);
   ze_kernel_handle_t &get();
+
+  /// Create an independent copy of this kernel with its own
+  /// ze_kernel_handle_t (a fresh handle from the parent module, as Level Zero
+  /// has no zeKernelClone) so that argument bindings on the clone do not affect
+  /// this kernel's handle. The caller owns the returned object and must delete
+  /// it. Used by HIP graph kernel nodes (issue #782).
+  CHIPKernelLevel0 *clone();
 
   CHIPModuleLevel0 *getModule() override { return Module; }
   const CHIPModuleLevel0 *getModule() const override { return Module; }


### PR DESCRIPTION
Two HIP graph kernel nodes launching the same kernel function shared one ze_kernel_handle_t; since args are bound per-handle and graph execution queues both launches before running, the second node's arguments overwrote the first. Each graph kernel node now gets an independent handle (created via zeKernelCreate from the parent module — Level Zero has no zeKernelClone), owned and freed by its exec item. OpenCL already borrows a unique cl_kernel per exec item and is unchanged.

Validated on Arc B570: repro (two nodes, same kernel, different outputs) fails on base and passes with the fix on both backends; full graph suite shows zero regressions.

Closes #782