### PR TITLE
Level0: clean error instead of segfault on deferred module build failure

### DIFF
--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -3152,19 +3152,24 @@ std::string resultToString(ze_result_t zeStatus) {
 // CHIPModuleLevel0
 // ***********************************************************************
 
-/// Dumps build/link log into the error log stream. The 'Log' value must be
-/// valid handle. This function will destroy the log handle.
-static void dumpBuildLog(ze_module_build_log_handle_t &&Log) {
+/// Dumps build/link log into the error log stream and returns its contents.
+/// The 'Log' value must be a valid handle. This function will destroy the log
+/// handle.
+static std::string dumpBuildLog(ze_module_build_log_handle_t &&Log) {
+  std::string LogStr;
   size_t LogSize;
   zeStatus = zeModuleBuildLogGetString(Log, &LogSize, nullptr);
   if (zeStatus == ZE_RESULT_SUCCESS) {
     std::vector<char> LogVec(LogSize);
     zeStatus = zeModuleBuildLogGetString(Log, &LogSize, LogVec.data());
-    if (zeStatus == ZE_RESULT_SUCCESS)
-      logInfo("ZE Build Log:\n{}", std::string_view(LogVec.data(), LogSize));
+    if (zeStatus == ZE_RESULT_SUCCESS) {
+      LogStr.assign(LogVec.data(), LogSize);
+      logInfo("ZE Build Log:\n{}", LogStr);
+    }
   }
 
   CHIPERR_CHECK_LOG_AND_THROW_TABLE(zeModuleBuildLogDestroy);
+  return LogStr;
 }
 
 void save(const ze_module_desc_t &desc, const ze_module_handle_t &module,
@@ -3356,9 +3361,20 @@ static ze_module_handle_t compileIL(ze_context_handle_t ZeCtx,
              elapsed.count());
   else
     logTrace("zeModulerCeate took {} seconds", elapsed.count());
-  dumpBuildLog(std::move(Log));
+  std::string BuildLog = dumpBuildLog(std::move(Log));
 
   CHIPERR_CHECK_LOG_AND_THROW_TABLE(zeModuleCreate);
+
+  // Some Level Zero drivers compile lazily: zeModuleCreate returns SUCCESS but
+  // the build log reports a fatal error (e.g. "backend compiler failed build"
+  // for a kernel using double on a GPU without native FP64 when DP emulation is
+  // off). A subsequent zeModuleGetKernelNames on such a half-built module
+  // segfaults inside the driver, so surface the failure as a clean error here
+  // instead of proceeding.
+  if (BuildLog.find("backend compiler failed build") != std::string::npos)
+    CHIPERR_LOG_AND_THROW("Level Zero module build failed:\n" + BuildLog,
+                          hipErrorInvalidImage);
+
   logTrace("LZ CREATE MODULE via calling zeModuleCreate {} ",
            resultToString(zeStatus));
 


### PR DESCRIPTION
Surfaced while investigating #1234 (HeCBench flip on Arc A380).

Some Level Zero drivers compile lazily: zeModuleCreate returns SUCCESS but the build log reports a fatal error - e.g. a kernel using double on a GPU without native FP64 when DP emulation is off ("Double type is not supported on this platform. backend compiler failed build."). A subsequent zeModuleGetKernelNames on that half-built module segfaults inside libze_intel_gpu, so the whole process dies with SIGSEGV and no explanation.

Fix: dumpBuildLog now returns the log contents; compileIL checks it after zeModuleCreate and throws hipErrorInvalidImage with the log when it contains "backend compiler failed build", instead of proceeding into the crash.

Verified on Intel Arc A380 (Alchemist, no native FP64), Level Zero:
- Before: flip-hip without DP emulation -> SIGSEGV (rc 139) inside the driver at zeModuleGetKernelNames.
- After: clean "hipErrorInvalidImage (Level Zero module build failed: ... Double type is not supported on this platform)", process exits without crashing.
- With DP emulation on (IGC_EnableDPEmulation=1 OverrideDefaultFP64Settings=1): builds and runs normally - no false positive.