### PR TITLE
Fix promoteInt ctest timeout by disabling redundant HipVerify

### DIFF
--- a/tests/compiler/promoteInt/run_promote_int_pass.bash
+++ b/tests/compiler/promoteInt/run_promote_int_pass.bash
@@ -13,8 +13,13 @@ OUTPUT_LL="${BASE_NAME}.out.ll"
 OUTPUT_SPV="${BASE_NAME}.spv"
 SPIRV_OPTS="--spirv-max-version=1.2 --spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups"
 
-# Run the promote int pass
-${LLVM_OPT} -load-pass-plugin "${HIP_SPV_PASSES_LIB}" \
+# Run the promote int pass.
+# Disable HipVerify's in-pass IR->SPIR-V re-verification (CHIP_VERIFY_MODE=off):
+# it defaults on in Debug builds and re-converts the whole module after every
+# pass (CHIP-SPV/chipStar#1047), which balloons large inputs like
+# benchmark_block_sort to ~70s and trips the ctest timeout under load. This
+# script validates the SPIR-V itself below, so that verification is redundant.
+CHIP_VERIFY_MODE=off ${LLVM_OPT} -load-pass-plugin "${HIP_SPV_PASSES_LIB}" \
     -passes=hip-post-link-passes \
     "${INPUT_FILE}" -o "${OUTPUT_BC}" || exit 1
 


### PR DESCRIPTION
The promoteInt compile-only tests time out intermittently in Debug CI builds (e.g. Test LLVM Patches). HipVerify defaults on in Debug and re-converts the whole module to SPIR-V after every pass (#1047), taking ~70s on large inputs like benchmark_block_sort — under a 200s ctest cap on a contended runner it tips over. The test script already validates the SPIR-V itself, so CHIP_VERIFY_MODE=off drops the pass to ~3s with no loss of coverage.