### PR TITLE
Define __chip_group_all/any/ballot work-group collectives (#1359)

### DIFF
--- a/bitcode/devicelib.cl
+++ b/bitcode/devicelib.cl
@@ -532,6 +532,19 @@ EXPORT void __chip_syncthreads() {
   barrier(CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE);
 }
 
+// Work-group collectives backing __syncthreads_and/_or/_count. The barrier
+// semantics are provided by __chip_syncthreads() in the callers
+// (sync_and_util.hh); work_group_* are themselves convergent collectives.
+EXPORT int __chip_group_all(int predicate) { return work_group_all(predicate); }
+
+EXPORT int __chip_group_any(int predicate) { return work_group_any(predicate); }
+
+// __syncthreads_count: returns the number of threads with a true predicate,
+// not a ballot bitmask (blocks can exceed 64 threads).
+EXPORT ulong __chip_group_ballot(int predicate) {
+  return work_group_reduce_add(predicate ? 1 : 0);
+}
+
 // local_fence
 EXPORT void __chip_threadfence_block() { mem_fence(CLK_LOCAL_MEM_FENCE); }
 

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -239,3 +239,6 @@ set_tests_properties(TestEventResetWarnFlood PROPERTIES
   ENVIRONMENT "CHIP_LOGLEVEL=warn"
   FAIL_REGULAR_EXPRESSION "FAIL;reset\\(\\) called while event is recording")
 add_hip_runtime_test(TestFixHostNativeAtomicSupported.hip)
+# Reproducer for issue #1359: __syncthreads_and/or/count unresolved
+# (__chip_group_all/any/ballot missing from the device library).
+add_hip_runtime_test(TestSyncthreadsAndOrCount.hip)

--- a/tests/runtime/TestSyncthreadsAndOrCount.hip
+++ b/tests/runtime/TestSyncthreadsAndOrCount.hip
@@ -1,0 +1,69 @@
+// Reproducer for chipStar issue #1359.
+//
+// __syncthreads_and/__syncthreads_or/__syncthreads_count lower to
+// __chip_group_all/__chip_group_any/__chip_group_ballot, which are declared
+// in include/hip/devicelib/sync_and_util.hh but have no definition in the
+// device library. On the OpenCL backend the kernel fails to JIT with
+// "error: unresolved external symbol __chip_group_all" and the kernel never
+// runs.
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+
+#include <hip/hip_runtime.h>
+
+#include <cstdio>
+
+#define HIPCHECK(Expr)                                                         \
+  do {                                                                         \
+    hipError_t Err = (Expr);                                                   \
+    if (Err != hipSuccess) {                                                   \
+      printf("FAIL: %s returned %s\n", #Expr, hipGetErrorString(Err));         \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+__global__ void syncthreadsCollectives(int *Out) {
+  int Tid = threadIdx.x;
+  // All threads pass a true predicate -> nonzero.
+  int AllTrue = __syncthreads_and(1);
+  // Thread 0 passes false -> zero.
+  int AllButOne = __syncthreads_and(Tid != 0);
+  // Only thread 3 passes true -> nonzero.
+  int AnyOne = __syncthreads_or(Tid == 3);
+  // All threads pass false -> zero.
+  int AnyNone = __syncthreads_or(0);
+  // Exactly 10 threads pass true.
+  int CountTen = __syncthreads_count(Tid < 10);
+  if (Tid == 0) {
+    Out[0] = AllTrue;
+    Out[1] = AllButOne;
+    Out[2] = AnyOne;
+    Out[3] = AnyNone;
+    Out[4] = CountTen;
+  }
+}
+
+int main() {
+  constexpr int NumResults = 5;
+  int *OutD;
+  int OutH[NumResults] = {-1, -1, -1, -1, -1};
+  HIPCHECK(hipMalloc(&OutD, sizeof(OutH)));
+  HIPCHECK(hipMemcpy(OutD, OutH, sizeof(OutH), hipMemcpyHostToDevice));
+  syncthreadsCollectives<<<1, 64>>>(OutD);
+  HIPCHECK(hipGetLastError());
+  HIPCHECK(hipDeviceSynchronize());
+  HIPCHECK(hipMemcpy(OutH, OutD, sizeof(OutH), hipMemcpyDeviceToHost));
+  HIPCHECK(hipFree(OutD));
+
+  assert(OutH[0] != 0 && "__syncthreads_and(1) must be true");
+  assert(OutH[1] == 0 && "__syncthreads_and(tid != 0) must be false");
+  assert(OutH[2] != 0 && "__syncthreads_or(tid == 3) must be true");
+  assert(OutH[3] == 0 && "__syncthreads_or(0) must be false");
+  assert(OutH[4] == 10 && "__syncthreads_count(tid < 10) must be 10");
+
+  printf("PASSED\n");
+  return 0;
+}


### PR DESCRIPTION
Fixes #1359: __syncthreads_and/or/count referenced __chip_group_all/any/ballot which had declarations but no definitions; adds work_group_* backed definitions to devicelib.cl, with a reproducer test.