### PR TITLE
Define hrcp(__half) on the SPIR-V platform (#1369)

### DIFF
--- a/include/hip/spirv_hip_fp16.h
+++ b/include/hip/spirv_hip_fp16.h
@@ -1603,7 +1603,6 @@ THE SOFTWARE.
                 return __half_raw{
                     __ocml_log10_f16(static_cast<__half_raw>(x).data)};
             }
-#if !defined(__HIP_PLATFORM_SPIRV__)
             inline
             __device__
             __half hrcp(__half x)
@@ -1611,7 +1610,6 @@ THE SOFTWARE.
                 return __half_raw{
                     static_cast<_Float16>(1.0f) /static_cast<__half_raw>(x).data};
             }
-#endif
             inline
             __device__
             __half hrsqrt(__half x)

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -128,6 +128,8 @@ add_test(NAME "TestHipccHalfOperators"
 
 add_hipcc_test(TestFix1248HalfHostOps.hip HIPCC_OPTIONS -fsyntax-only)
 
+add_hipcc_test(TestHalfDeviceMathFuncs.hip HIPCC_OPTIONS -fsyntax-only)
+
 add_hipcc_test(TestZeroLenArrayTypes.hip TEST_NAME TestZeroLenArrayTypes-O0
   HIPCC_OPTIONS -O0 -c)
 add_hipcc_test(TestZeroLenArrayTypes.hip TEST_NAME TestZeroLenArrayTypes-O1

--- a/tests/compiler/TestHalfDeviceMathFuncs.hip
+++ b/tests/compiler/TestHalfDeviceMathFuncs.hip
@@ -1,0 +1,37 @@
+// Every __half device math function declared by hip_fp16.h must be available
+// on the SPIR-V platform, not just on AMD/NVIDIA.
+//
+// hrcp(__half) used to be wrapped in `#if !defined(__HIP_PLATFORM_SPIRV__)`,
+// so it silently vanished on chipStar while its bfloat16 counterpart stayed.
+// Kokkos' HIP backend binds both in one macro
+// (KOKKOS_HIP_HALF_AND_BHALF_UNARY_FUNCTION_IMPL(rcp, hrcp)), so the __half
+// call resolved to the __hip_bfloat16 overload and failed to compile, which
+// broke every Kokkos-based build (found while porting Trilinos STK).
+//
+// Compile-only on purpose: the regression is a declaration being preprocessed
+// away, which -fsyntax-only catches on every target. Executing these instead
+// probes device fp16 library coverage, which varies: the macOS CI runner's
+// PoCL build resolves none of _Z4ceilDh, _Z4sqrtDh, _Z4log2Dh, ... in its
+// kernel library, while PoCL 6.0/7.1/2025.01.14 on Linux and Arc B570 all
+// evaluate them correctly. That is a device property, not a header property.
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+
+__global__ void callHalfMathFuncs(__half *Out, __half In) {
+  int I = 0;
+  Out[I++] = hceil(In);
+  Out[I++] = hcos(In);
+  Out[I++] = hexp(In);
+  Out[I++] = hexp10(In);
+  Out[I++] = hexp2(In);
+  Out[I++] = hfloor(In);
+  Out[I++] = hlog(In);
+  Out[I++] = hlog10(In);
+  Out[I++] = hlog2(In);
+  Out[I++] = hrcp(In); // The one that regressed.
+  Out[I++] = hrint(In);
+  Out[I++] = hrsqrt(In);
+  Out[I++] = hsin(In);
+  Out[I++] = hsqrt(In);
+  Out[I++] = htrunc(In);
+}


### PR DESCRIPTION
Fixes #1369. Drops the `__HIP_PLATFORM_SPIRV__` guard that compiled hrcp(__half) out on chipStar, and adds a build and run test covering all 15 `__half` device math functions so a future drop fails instead of vanishing silently.