### PR TITLE
Move vtable function pointers into the generic address space

### DIFF
--- a/include/hip/spirv_hip.hh
+++ b/include/hip/spirv_hip.hh
@@ -259,6 +259,22 @@ __assert_fail(const char *assertion, const char *file, unsigned int line,
   abort();
 }
 #endif // defined(_WIN32) || defined(_WIN64) || defined(__APPLE__)
+
+// Clang materialises a reference to __cxa_pure_virtual in the vtable of every
+// class that still has an unoverridden pure virtual member. The symbol has to
+// resolve on the device even when the slot can never be reached, otherwise the
+// SPIR-V consumer rejects the whole module with
+//   unresolved external symbol #__cxa_pure_virtual in data segment
+// and every kernel in the program fails to build. ROCm supplies it from its
+// device libs; on the SPIR-V platform there is no equivalent, so define it here
+// with the same semantics: calling a pure virtual function is a hard error.
+// No printf here on purpose: it would put a device printf into every
+// translation unit, and each one costs HipVerify's pre-lowering checkpoints a
+// crashing llvm-spirv run in debug builds (about 13 s per TU).
+__device__ __attribute__((noinline)) __attribute__((weak)) void
+__cxa_pure_virtual() {
+  abort();
+}
 } // extern "C"
 #endif // defined(__clang__) && defined(__HIP__)
 

--- a/include/hip/spirv_hip.hh
+++ b/include/hip/spirv_hip.hh
@@ -202,6 +202,20 @@ __assert_fail(const char *assertion, const char *file, unsigned int line,
   abort();
 }
 #endif // defined(_WIN32) || defined(_WIN64) || defined(__APPLE__)
+
+// Clang materialises a reference to __cxa_pure_virtual in the vtable of every
+// class that still has an unoverridden pure virtual member. The symbol has to
+// resolve on the device even when the slot can never be reached, otherwise the
+// SPIR-V consumer rejects the whole module with
+//   unresolved external symbol #__cxa_pure_virtual in data segment
+// and every kernel in the program fails to build. ROCm supplies it from its
+// device libs; on the SPIR-V platform there is no equivalent, so define it here
+// with the same semantics: calling a pure virtual function is a hard error.
+__device__ __attribute__((noinline)) __attribute__((weak)) void
+__cxa_pure_virtual() {
+  printf("Device-side pure virtual function called.\n");
+  abort();
+}
 } // extern "C"
 #endif // defined(__clang__) && defined(__HIP__)
 

--- a/llvm_passes/CMakeLists.txt
+++ b/llvm_passes/CMakeLists.txt
@@ -112,6 +112,7 @@ add_library(LLVMHipPasses MODULE
     HipDefrost.cpp
     HipDynMem.cpp
     HipEmitLoweredNames.cpp
+    HipFunctionPointerAS.cpp
     HipGlobalVariables.cpp
     HipIGBADetector.cpp
     HipKernelArgSpiller.cpp

--- a/llvm_passes/CMakeLists.txt
+++ b/llvm_passes/CMakeLists.txt
@@ -103,6 +103,7 @@ add_library(LLVMHipPasses MODULE HipPasses.cpp
     HipEmitLoweredNames.cpp HipWarps.cpp HipKernelArgSpiller.cpp
     HipLowerZeroLengthArrays.cpp HipSanityChecks.cpp HipLowerSwitch.cpp
     HipLowerMemset.cpp HipIGBADetector.cpp HipPromoteInts.cpp
+    HipFunctionPointerAS.cpp
     HipSpirvFunctionReorderPass.cpp
     HipVerify.cpp
     ${EXTRA_OBJS})

--- a/llvm_passes/HipFunctionPointerAS.cpp
+++ b/llvm_passes/HipFunctionPointerAS.cpp
@@ -1,0 +1,354 @@
+//===- HipFunctionPointerAS.cpp -------------------------------------------===//
+//
+// Part of the chipStar Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Move function pointers stored in global variable initializers into the
+// generic address space.
+//
+// WORKAROUND(CHIP-SPV/chipStar#1373, llvm/llvm-project#212452): clang types
+// every C++ vtable component with the default globals address space and
+// addrspacecasts function addresses into it, which SPIR-V cannot express.
+// Remove this pass when https://github.com/llvm/llvm-project/pull/212452
+// (vtable components emitted in the generic address space on SPIR-V targets)
+// is in every supported LLVM.
+//
+// Clang emits C++ vtables for SPIR-V targets with every slot in the global
+// address space, so each virtual function slot is
+//
+//   addrspacecast (ptr @_ZN7DerivedD2Ev to ptr addrspace(1))
+//
+// SPIR-V has no cast between two named storage classes: OpPtrCastToGeneric
+// goes from Function/Workgroup/CrossWorkgroup into Generic and
+// OpGenericCastToPtr goes back out, but a Function (plain 'ptr') to
+// CrossWorkgroup cast has no instruction, so the translator rejects the module
+// with
+//
+//   InvalidModule: Invalid SPIR-V module: Casts from private/local/global
+//   address space are allowed only to generic
+//
+// This pass retypes such globals so their slots hold generic (address space 4)
+// pointers, then repairs the slot loads and the indirect call sites that read
+// them. Generic is the storage class SPV_INTEL_function_pointers overloads
+// onto CodeSectionINTEL, and OpPtrCastToGeneric accepts the Function-class
+// pointer both SPIR-V producers emit for a function's address, so every cast
+// left in the module has a direction SPIR-V defines and Intel's consumers
+// accept the result. See CHIP-SPV/chipStar#1373.
+//
+// The trigger is semantic, not the Itanium '_ZTV' name: any global whose
+// initializer casts a Function into a non-generic address space, which also
+// covers hand written dispatch tables. Only the element type of the table
+// changes; the vptr stored inside the object is an ordinary data pointer and
+// stays in the global address space. Non-function slots (offset-to-top, RTTI)
+// move to generic as well, which is a cast SPIR-V defines.
+//
+// Validator note: with opaque pointers the SPIR-V producers scavenge the slot
+// pointee as i8, so the slot constants come out as OpSpecConstantOp
+// PtrCastToGeneric from a pointer to OpTypeFunction to a generic pointer to
+// i8. That does not satisfy the core rule that both sides of the cast point to
+// the same type; SPIRV-Tools from 2026-03 checks it, IGC and NEO accept it.
+//
+// (c) 2026 chipStar developers
+//===----------------------------------------------------------------------===//
+
+#include "HipFunctionPointerAS.h"
+
+#include "LLVMSPIRV.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Operator.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "hip-function-pointer-as"
+
+using namespace llvm;
+
+namespace {
+
+constexpr unsigned GenericAS = SPIRV_GENERIC_AS;
+
+/// True for 'addrspacecast (ptr @SomeFunction to ptr addrspace(N))' with N
+/// not the generic address space: the construct the SPIR-V translator rejects.
+static bool isFunctionCastToNonGeneric(const Constant *C) {
+  const auto *CE = dyn_cast<ConstantExpr>(C);
+  return CE && CE->getOpcode() == Instruction::AddrSpaceCast &&
+         isa<Function>(CE->getOperand(0)) &&
+         CE->getType()->getPointerAddressSpace() != GenericAS;
+}
+
+/// Rewrite pointer-typed constant \p C so its type becomes 'ptr addrspace(4)'.
+static Constant *coercePtrToGeneric(Constant *C) {
+  auto *PtrTy = cast<PointerType>(C->getType());
+  if (PtrTy->getAddressSpace() == GenericAS)
+    return C;
+
+  auto *NewTy = PointerType::get(C->getContext(), GenericAS);
+  if (isa<ConstantPointerNull>(C))
+    return ConstantPointerNull::get(NewTy);
+  if (isa<PoisonValue>(C))
+    return PoisonValue::get(NewTy);
+  if (isa<UndefValue>(C))
+    return UndefValue::get(NewTy);
+
+  // Rebuild an existing addrspacecast from its source rather than stacking a
+  // second cast on top of an illegal one.
+  if (auto *CE = dyn_cast<ConstantExpr>(C))
+    if (CE->getOpcode() == Instruction::AddrSpaceCast)
+      return ConstantExpr::getAddrSpaceCast(CE->getOperand(0), NewTy);
+
+  // Plain data such as the RTTI slot: global -> generic is OpPtrCastToGeneric.
+  return ConstantExpr::getAddrSpaceCast(C, NewTy);
+}
+
+/// Rebuild \p C so that every function pointer it holds is generic. Returns
+/// \p C itself when nothing had to change. With \p Force every pointer in \p C
+/// moves to generic, which keeps an array homogeneous once one of its
+/// elements had to move: the null and RTTI slots of a vtable follow the
+/// function slots.
+static Constant *rewriteInitializer(Constant *C, bool Force = false) {
+  if (isFunctionCastToNonGeneric(C) || (Force && C->getType()->isPointerTy()))
+    return coercePtrToGeneric(C);
+
+  auto *CA = dyn_cast<ConstantAggregate>(C);
+  if (!CA)
+    return C;
+
+  SmallVector<Constant *, 8> Elts;
+  bool Changed = false;
+  for (Use &Op : CA->operands()) {
+    Constant *New = rewriteInitializer(cast<Constant>(Op), Force);
+    Changed |= New != Op;
+    Elts.push_back(New);
+  }
+  if (!Changed)
+    return C;
+
+  if (auto *CS = dyn_cast<ConstantStruct>(CA))
+    // Vtables are literal structs; a literal struct with the rewritten member
+    // types is what a retyped one has to be.
+    return ConstantStruct::getAnon(Elts, CS->getType()->isPacked());
+
+  if (!Force)
+    for (unsigned I = 0, E = Elts.size(); I != E; ++I)
+      Elts[I] = rewriteInitializer(CA->getOperand(I), /*Force=*/true);
+  if (isa<ConstantVector>(CA))
+    return ConstantVector::get(Elts);
+  return ConstantArray::get(ArrayType::get(Elts.front()->getType(), Elts.size()),
+                            Elts);
+}
+
+/// Replace \p Old with a global holding \p NewInit. Opaque pointers make the
+/// address of the global the same LLVM type regardless of the value type, so
+/// users can simply be redirected.
+static void retypeGlobal(Module &M, GlobalVariable *Old, Constant *NewInit) {
+  auto *New = new GlobalVariable(
+      M, NewInit->getType(), Old->isConstant(), Old->getLinkage(), NewInit, "",
+      nullptr, Old->getThreadLocalMode(), Old->getAddressSpace(),
+      Old->isExternallyInitialized());
+  New->copyAttributesFrom(Old);
+  New->setComdat(Old->getComdat());
+  New->copyMetadata(Old, 0);
+
+  // A constant getelementptr records its source element type, so
+  // replaceAllUsesWith would leave GEPs that still claim the old value type
+  // while pointing at the retyped global. Classes with virtual bases hit this:
+  // the VTT holds one 'getelementptr inrange (...) ({...}, ptr @_ZTC...)' per
+  // construction vtable, and the translator this pass was written against
+  // aborted in transConstantUse() on the disagreement; current producers
+  // tolerate it. Rebuild those GEPs against the new value type first.
+  SmallVector<ConstantExpr *, 8> GEPUsers;
+  for (User *U : Old->users())
+    if (auto *CE = dyn_cast<ConstantExpr>(U))
+      if (CE->getOpcode() == Instruction::GetElementPtr &&
+          cast<GEPOperator>(CE)->getSourceElementType() == Old->getValueType())
+        GEPUsers.push_back(CE);
+  for (ConstantExpr *CE : GEPUsers) {
+    auto *GEP = cast<GEPOperator>(CE);
+    SmallVector<Value *, 4> Idxs(CE->op_begin() + 1, CE->op_end());
+    CE->replaceAllUsesWith(ConstantExpr::getGetElementPtr(
+        New->getValueType(), New, Idxs, GEP->getNoWrapFlags(),
+        GEP->getInRange()));
+  }
+
+  Old->replaceAllUsesWith(New);
+  New->takeName(Old);
+  Old->eraseFromParent();
+}
+
+/// Produce a value equivalent to \p V but typed 'ptr addrspace(4)'.
+///
+/// The interesting case is a load of a vtable slot. Its result type has to
+/// change: after the table was retyped the memory holds a generic pointer, and
+/// a load claiming to read a global pointer would translate to an OpLoad whose
+/// result type disagrees with the pointee. Casting after the load would not
+/// help for the same reason. Phis and selects of slots are rebuilt in generic
+/// with their operands rewritten in turn. Anything else gets an addrspacecast,
+/// which SPIR-V defines from every named storage class.
+///
+/// \p Generic caches the replacement of every value already rewritten, so a
+/// slot shared by several calls is retyped once and a phi cycle closes on the
+/// rebuilt phi. \p Dead collects the instructions left without a purpose.
+static Value *makeCalleeGeneric(Value *V, Instruction *InsertBefore,
+                                DenseMap<Value *, Value *> &Generic,
+                                SmallSetVector<Instruction *, 8> &Dead) {
+  auto *PtrTy = dyn_cast<PointerType>(V->getType());
+  if (!PtrTy || PtrTy->getAddressSpace() == GenericAS)
+    return V;
+  auto *GenericPtrTy = PointerType::get(V->getContext(), GenericAS);
+
+  if (auto *C = dyn_cast<Constant>(V))
+    return coercePtrToGeneric(C);
+
+  // A cast back into a named storage class: its source is already what we
+  // want. Readers of a slot load that was retyped for another call see one.
+  if (auto *ASC = dyn_cast<AddrSpaceCastInst>(V))
+    if (ASC->getSrcAddressSpace() == GenericAS) {
+      Dead.insert(ASC);
+      return ASC->getPointerOperand();
+    }
+
+  if (auto It = Generic.find(V); It != Generic.end())
+    return It->second;
+
+  if (auto *LI = dyn_cast<LoadInst>(V)) {
+    Value *Ptr = LI->getPointerOperand();
+
+    // The slot address is normally a getelementptr whose source element type
+    // is the old slot type. The byte offset is the same either way, but a
+    // typed-pointer consumer wants the GEP and the load to agree.
+    if (auto *GEP = dyn_cast<GetElementPtrInst>(Ptr))
+      if (auto *SrcPtrTy = dyn_cast<PointerType>(GEP->getSourceElementType()))
+        if (SrcPtrTy->getAddressSpace() != GenericAS) {
+          SmallVector<Value *, 4> Idx(GEP->idx_begin(), GEP->idx_end());
+          auto *NewGEP = GetElementPtrInst::Create(
+              GenericPtrTy, GEP->getPointerOperand(), Idx, GEP->getName(),
+              GEP->getIterator());
+          NewGEP->setNoWrapFlags(GEP->getNoWrapFlags());
+          NewGEP->setDebugLoc(GEP->getDebugLoc());
+          GEP->replaceAllUsesWith(NewGEP);
+          Dead.insert(GEP);
+          Ptr = NewGEP;
+        }
+
+    IRBuilder<> B(LI);
+    auto *NewLI = B.CreateAlignedLoad(GenericPtrTy, Ptr, LI->getAlign(),
+                                      LI->isVolatile(), LI->getName());
+    NewLI->setOrdering(LI->getOrdering());
+    NewLI->setSyncScopeID(LI->getSyncScopeID());
+    NewLI->copyMetadata(*LI);
+    Generic[LI] = NewLI;
+
+    // Other readers of the old load still want the original address space;
+    // generic -> global is OpGenericCastToPtr.
+    if (!LI->use_empty()) {
+      auto *Back = cast<Instruction>(B.CreateAddrSpaceCast(NewLI, PtrTy));
+      LI->replaceAllUsesWith(Back);
+      Dead.insert(Back);
+    }
+    Dead.insert(LI);
+    return NewLI;
+  }
+
+  if (isa<PHINode>(V) || isa<SelectInst>(V)) {
+    auto *I = cast<Instruction>(V);
+    Instruction *NewI = I->clone();
+    NewI->mutateType(GenericPtrTy);
+    NewI->insertBefore(I->getIterator());
+    Generic[I] = NewI;
+    for (Use &U : NewI->operands()) {
+      if (U->getType() != PtrTy)
+        continue; // The select condition.
+      Instruction *IP = NewI;
+      if (auto *Phi = dyn_cast<PHINode>(NewI))
+        IP = Phi->getIncomingBlock(U)->getTerminator();
+      U.set(makeCalleeGeneric(U.get(), IP, Generic, Dead));
+    }
+    Dead.insert(I);
+    return NewI;
+  }
+
+  return IRBuilder<>(InsertBefore).CreateAddrSpaceCast(V, GenericPtrTy);
+}
+
+/// Retype every global whose initializer holds a function pointer cast into a
+/// non-generic address space. Returns true if the module changed.
+static bool fixGlobalInitializers(Module &M) {
+  bool Changed = false;
+  for (GlobalVariable &GV : llvm::make_early_inc_range(M.globals())) {
+    if (!GV.hasInitializer())
+      continue;
+    Constant *NewInit = rewriteInitializer(GV.getInitializer());
+    if (NewInit == GV.getInitializer())
+      continue;
+    LLVM_DEBUG(dbgs() << DEBUG_TYPE << ": retyping " << GV.getName() << "\n");
+    retypeGlobal(M, &GV, NewInit);
+    Changed = true;
+  }
+  return Changed;
+}
+
+/// Repair calls whose callee is not in the generic address space.
+static bool fixIndirectCalls(Module &M) {
+  SmallVector<CallBase *, 8> Calls;
+  for (Function &F : M)
+    for (Instruction &I : instructions(F)) {
+      auto *CB = dyn_cast<CallBase>(&I);
+      if (!CB || isa<Function>(CB->getCalledOperand()))
+        continue;
+      unsigned AS = CB->getCalledOperand()->getType()->getPointerAddressSpace();
+      // The program address space is what a plain function pointer uses and
+      // translates fine; generic is what this pass produces.
+      if (AS != GenericAS && AS != M.getDataLayout().getProgramAddressSpace())
+        Calls.push_back(CB);
+    }
+  if (Calls.empty())
+    return false;
+
+  DenseMap<Value *, Value *> Generic;
+  SmallSetVector<Instruction *, 8> Dead;
+  for (CallBase *CB : Calls) {
+    Value *Callee = CB->getCalledOperand();
+    // A constant cast of a function is a direct call in disguise; strip it.
+    if (auto *F = dyn_cast<Function>(Callee->stripPointerCasts()))
+      CB->setCalledOperand(F);
+    else
+      CB->setCalledOperand(makeCalleeGeneric(Callee, CB, Generic, Dead));
+  }
+  // Drop the originals: whatever lost its last user, iterating since erasing
+  // one frees its operands, and a rebuilt phi that only fed itself.
+  SmallVector<Instruction *, 8> Pending(Dead.begin(), Dead.end());
+  for (bool Again = true; Again;) {
+    Again = false;
+    for (auto It = Pending.begin(); It != Pending.end();) {
+      Instruction *I = *It;
+      if (!all_of(I->users(), [I](User *U) { return U == I; })) {
+        ++It;
+        continue;
+      }
+      I->dropAllReferences();
+      I->eraseFromParent();
+      It = Pending.erase(It);
+      Again = true;
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+PreservedAnalyses HipFunctionPointerASPass::run(Module &M,
+                                                ModuleAnalysisManager &AM) {
+  bool Changed = fixGlobalInitializers(M);
+  Changed |= fixIndirectCalls(M);
+  return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
+}

--- a/llvm_passes/HipFunctionPointerAS.cpp
+++ b/llvm_passes/HipFunctionPointerAS.cpp
@@ -53,6 +53,7 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/Operator.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/Debug.h"
 
@@ -189,6 +190,30 @@ static GlobalVariable *replaceGlobalInitializer(Module &M, GlobalVariable *Old,
   Old->getAllMetadata(MDs);
   for (const auto &MD : MDs)
     New->addMetadata(MD.first, *MD.second);
+
+  // A constant getelementptr stores its source element type explicitly, so
+  // replaceAllUsesWith would leave GEPs that still claim the *old* value type
+  // while pointing at the retyped global. Classes with virtual bases hit this:
+  // the VTT (_ZTT...) holds one 'getelementptr inrange(...) ({...}, ptr @_ZTC...)'
+  // per construction vtable, and once a _ZTC table is retyped the SPIR-V writer
+  // aborts in transConstantUse() on the disagreement. Rebuild those GEPs against
+  // the new value type first, keeping indices, nowrap flags and inrange.
+  Type *OldValTy = Old->getValueType();
+  Type *NewValTy = New->getValueType();
+  SmallVector<ConstantExpr *, 8> GEPUsers;
+  for (User *U : Old->users())
+    if (auto *CE = dyn_cast<ConstantExpr>(U))
+      if (CE->getOpcode() == Instruction::GetElementPtr &&
+          cast<GEPOperator>(CE)->getSourceElementType() == OldValTy)
+        GEPUsers.push_back(CE);
+
+  for (ConstantExpr *CE : GEPUsers) {
+    auto *GEP = cast<GEPOperator>(CE);
+    SmallVector<Value *, 4> Idxs(CE->op_begin() + 1, CE->op_end());
+    Constant *NewCE = ConstantExpr::getGetElementPtr(
+        NewValTy, New, Idxs, GEP->getNoWrapFlags(), GEP->getInRange());
+    CE->replaceAllUsesWith(NewCE);
+  }
 
   Old->replaceAllUsesWith(New);
   std::string Name = Old->getName().str();

--- a/llvm_passes/HipFunctionPointerAS.cpp
+++ b/llvm_passes/HipFunctionPointerAS.cpp
@@ -433,11 +433,59 @@ static bool fixIndirectCalls(Module &M) {
   return true;
 }
 
+/// Erase C++ vtable-family globals that nothing in the module refers to.
+///
+/// Clang emits the vtable, VTT, construction vtables and RTTI of any
+/// polymorphic class that merely *appears* in device code, even when no device
+/// code ever dispatches through them. Trilinos hits this hard: Tpetra::RowMatrix
+/// is host-only polymorphic with virtual bases, so every HIP explicit
+/// instantiation carries a dead _ZTV/_ZTT/_ZTC set whose slots are almost all
+/// null and whose virtual base offsets are inttoptr constants. Translating them
+/// crashes llvm-spirv inside transConstantUse():
+///
+///   Assertion `(C->getType()->isPointerTy() ||
+///               ExpectedType->isTypeUntypedPointerKHR()) &&
+///              "Only pointer type mismatches should be possible"' failed.
+///
+/// GlobalDCE leaves them alone because they sit in comdats. A chipStar device
+/// module is self-contained - nothing outside it can link against these symbols
+/// - so dropping the unreferenced ones is safe and keeps the module
+/// translatable. Only the Itanium vtable prefixes are considered, so runtime
+/// visible globals such as __chip_var_* are never touched.
+static bool eraseUnusedVTableGlobals(Module &M) {
+  static const StringRef Prefixes[] = {"_ZTV", "_ZTT", "_ZTC", "_ZTI", "_ZTS"};
+
+  bool Changed = false;
+  bool Again = true;
+  while (Again) {
+    Again = false;
+    SmallVector<GlobalVariable *, 8> Dead;
+    for (GlobalVariable &GV : M.globals()) {
+      if (!GV.use_empty() || GV.hasExternalLinkage() || GV.isDeclaration())
+        continue;
+      StringRef Name = GV.getName();
+      if (llvm::any_of(Prefixes,
+                       [&](StringRef P) { return Name.starts_with(P); }))
+        Dead.push_back(&GV);
+    }
+    for (GlobalVariable *GV : Dead) {
+      // Dropping the initializer first lets a VTT release the construction
+      // vtables it points at, so the next round can collect those too.
+      GV->setComdat(nullptr);
+      GV->setInitializer(nullptr);
+      GV->eraseFromParent();
+      Changed = Again = true;
+    }
+  }
+  return Changed;
+}
+
 } // namespace
 
 PreservedAnalyses HipFunctionPointerASPass::run(Module &M,
                                                 ModuleAnalysisManager &AM) {
-  bool Changed = fixGlobalInitializers(M);
+  bool Changed = eraseUnusedVTableGlobals(M);
+  Changed |= fixGlobalInitializers(M);
   Changed |= fixIndirectCalls(M);
   return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
 }

--- a/llvm_passes/HipFunctionPointerAS.cpp
+++ b/llvm_passes/HipFunctionPointerAS.cpp
@@ -1,0 +1,418 @@
+//===- HipFunctionPointerAS.cpp -------------------------------------------===//
+//
+// Part of the chipStar Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Move function pointers stored in global variable initializers into the
+// generic address space.
+//
+// Clang emits C++ vtables for SPIR-V targets with every slot in the global
+// address space, so each virtual function slot is a constant expression
+//
+//   addrspacecast (ptr @_ZN7DerivedD2Ev to ptr addrspace(1))
+//
+// SPIR-V only permits casts from a named storage class into Generic, never the
+// other way around, so the module is rejected by the translator with
+//
+//   InvalidModule: Invalid SPIR-V module: Casts from private/local/global
+//   address space are allowed only to generic
+//
+// This pass rewrites such vtables so their slots hold generic (address space
+// 4) pointers instead, which is the only address space a function pointer may
+// legally live in, and then repairs the loads and call sites that read them.
+// With that done SPV_INTEL_function_pointers is sufficient to translate and
+// run device side virtual dispatch. See CHIP-SPV/chipStar#1373.
+//
+// The pass is deliberately not keyed on the Itanium '_ZTV' vtable name
+// prefix. The trigger is semantic: any global whose initializer casts a
+// Function into a non-generic address space. That also covers hand written
+// dispatch tables and any other construct with the same shape.
+//
+// Only the element type of the table changes. The vptr, that is the pointer
+// *to* the vtable which is stored inside the object, is an ordinary data
+// pointer and legally stays in the global address space.
+//
+// A vtable also holds non-function data such as the offset-to-top and the RTTI
+// descriptor. Retyping the whole homogeneous array moves those into generic as
+// well, which is a global -> generic cast and therefore the legal direction.
+//
+// (c) 2026 chipStar developers
+//===----------------------------------------------------------------------===//
+
+#include "HipFunctionPointerAS.h"
+
+#include "LLVMSPIRV.h"
+
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Support/Debug.h"
+
+#include "PassPluginCompat.h"
+
+#define DEBUG_TYPE "hip-function-pointer-as"
+
+using namespace llvm;
+
+namespace {
+
+constexpr unsigned GenericAS = SPIRV_GENERIC_AS;
+
+/// True for 'addrspacecast (ptr @SomeFunction to ptr addrspace(N))' with N not
+/// being the generic address space. This is the exact construct the SPIR-V
+/// translator rejects.
+static bool isFunctionCastToNonGeneric(const Constant *C) {
+  const auto *CE = dyn_cast<ConstantExpr>(C);
+  if (!CE || CE->getOpcode() != Instruction::AddrSpaceCast)
+    return false;
+  if (!isa<Function>(CE->getOperand(0)))
+    return false;
+  return CE->getType()->getPointerAddressSpace() != GenericAS;
+}
+
+/// True if \p C is, or transitively contains, an illegal function pointer cast.
+static bool containsFunctionCastToNonGeneric(const Constant *C,
+                                             SmallPtrSetImpl<const Constant *> &Seen) {
+  if (!C || !Seen.insert(C).second)
+    return false;
+  if (isFunctionCastToNonGeneric(C))
+    return true;
+  // Do not descend into other globals; they are visited on their own.
+  if (isa<GlobalValue>(C))
+    return false;
+  for (const Use &U : C->operands())
+    if (const auto *Op = dyn_cast<Constant>(&U))
+      if (containsFunctionCastToNonGeneric(Op, Seen))
+        return true;
+  return false;
+}
+
+/// Rewrite \p C, which must be of some pointer type, so that its type becomes
+/// 'ptr addrspace(4)'.
+static Constant *coercePtrToGeneric(Constant *C) {
+  auto *PtrTy = cast<PointerType>(C->getType());
+  if (PtrTy->getAddressSpace() == GenericAS)
+    return C;
+
+  auto *NewTy = PointerType::get(C->getContext(), GenericAS);
+
+  if (isa<ConstantPointerNull>(C))
+    return ConstantPointerNull::get(NewTy);
+  if (isa<PoisonValue>(C))
+    return PoisonValue::get(NewTy);
+  if (isa<UndefValue>(C))
+    return UndefValue::get(NewTy);
+
+  // Rebuild an existing addrspacecast from its original operand rather than
+  // stacking a second cast on top of an already illegal one.
+  if (auto *CE = dyn_cast<ConstantExpr>(C))
+    if (CE->getOpcode() == Instruction::AddrSpaceCast)
+      return ConstantExpr::getAddrSpaceCast(CE->getOperand(0), NewTy);
+
+  // Plain data operands, for example the RTTI descriptor slot, live in the
+  // global address space. Global -> generic is the legal cast direction.
+  return ConstantExpr::getAddrSpaceCast(C, NewTy);
+}
+
+/// Recursively rebuild \p C so that every function pointer it holds is in the
+/// generic address space. Returns the rewritten constant, which may have a
+/// different type than \p C, or \p C itself when nothing had to change.
+static Constant *rewriteInitializer(Constant *C) {
+  if (!C)
+    return C;
+
+  if (isFunctionCastToNonGeneric(C))
+    return coercePtrToGeneric(C);
+
+  // Nested aggregates: rewrite element wise.
+  auto *CA = dyn_cast<ConstantAggregate>(C);
+  if (!CA)
+    return C;
+
+  SmallVector<Constant *, 8> Elts;
+  bool Changed = false;
+  for (unsigned I = 0, E = CA->getNumOperands(); I < E; ++I) {
+    Constant *Old = CA->getOperand(I);
+    Constant *New = rewriteInitializer(Old);
+    Changed |= New != Old;
+    Elts.push_back(New);
+  }
+  if (!Changed)
+    return C;
+
+  if (isa<ConstantArray>(CA)) {
+    // Arrays are homogeneous: once one slot moved to generic, every slot has
+    // to follow, including the null and RTTI slots of a vtable.
+    for (Constant *&E : Elts)
+      if (E->getType()->isPointerTy())
+        E = coercePtrToGeneric(E);
+    assert(!Elts.empty());
+    Type *EltTy = Elts.front()->getType();
+    for (Constant *E : Elts)
+      if (E->getType() != EltTy)
+        return C; // Heterogeneous after rewriting; leave it alone.
+    return ConstantArray::get(ArrayType::get(EltTy, Elts.size()), Elts);
+  }
+
+  if (auto *CS = dyn_cast<ConstantStruct>(CA)) {
+    // Struct members keep their individual types, so use a literal struct with
+    // the rewritten member types. Vtables are literal structs in practice.
+    return ConstantStruct::getAnon(CS->getContext(), Elts,
+                                   CS->getType()->isPacked());
+  }
+
+  return C;
+}
+
+/// Replace \p Old with a new global holding \p NewInit. With opaque pointers
+/// the address of the global has the same LLVM type regardless of the value
+/// type, so all users can simply be redirected.
+static GlobalVariable *replaceGlobalInitializer(Module &M, GlobalVariable *Old,
+                                                Constant *NewInit) {
+  auto *New = new GlobalVariable(
+      M, NewInit->getType(), Old->isConstant(), Old->getLinkage(), NewInit, "",
+      nullptr, Old->getThreadLocalMode(), Old->getAddressSpace(),
+      Old->isExternallyInitialized());
+
+  New->copyAttributesFrom(Old);
+  New->setAlignment(Old->getAlign());
+  New->setComdat(Old->getComdat());
+  SmallVector<std::pair<unsigned, MDNode *>, 4> MDs;
+  Old->getAllMetadata(MDs);
+  for (const auto &MD : MDs)
+    New->addMetadata(MD.first, *MD.second);
+
+  Old->replaceAllUsesWith(New);
+  std::string Name = Old->getName().str();
+  Old->eraseFromParent();
+  New->setName(Name);
+  return New;
+}
+
+/// Produce a value equivalent to \p V but typed 'ptr addrspace(4)'.
+///
+/// The interesting case by far is a load of a vtable slot. Its result type has
+/// to change, because after the table itself has been retyped the memory now
+/// holds a generic pointer and a load claiming to read a global pointer would
+/// translate to a SPIR-V OpLoad whose result type disagrees with the pointee.
+/// Inserting a cast after the load would not help for the same reason.
+///
+/// Anything not understood falls back to an inserted addrspacecast, which is
+/// always valid when the source is a named storage class.
+///
+/// \p Visited breaks cycles, which phis of function pointers can form.
+static Value *makeCalleeGeneric(Value *V, Instruction *InsertBefore,
+                                SmallSetVector<Instruction *, 8> &Dead,
+                                SmallPtrSetImpl<Value *> &Visited) {
+  auto *PtrTy = dyn_cast<PointerType>(V->getType());
+  if (!PtrTy || PtrTy->getAddressSpace() == GenericAS)
+    return V;
+
+  auto *GenericPtrTy = PointerType::get(V->getContext(), GenericAS);
+
+  if (!Visited.insert(V).second) {
+    // Already being rewritten further up the recursion; fall back to a cast.
+    IRBuilder<> B(InsertBefore);
+    return B.CreateAddrSpaceCast(V, GenericPtrTy);
+  }
+
+  // Look through a cast back into a named storage class: its source is already
+  // what we want. Several calls sharing one slot load reach this, because the
+  // first call rewrites the load and leaves the others reading through such a
+  // compensating cast.
+  if (auto *ASC = dyn_cast<AddrSpaceCastInst>(V))
+    if (ASC->getSrcAddressSpace() == GenericAS) {
+      Dead.insert(ASC);
+      return ASC->getPointerOperand();
+    }
+
+  if (auto *LI = dyn_cast<LoadInst>(V)) {
+    IRBuilder<> B(LI);
+    Value *Ptr = LI->getPointerOperand();
+
+    // The address of the slot is normally computed by a getelementptr whose
+    // source element type is the old slot type. Both are pointers of the same
+    // size so the byte offset is unchanged, but keeping the types consistent
+    // avoids handing the SPIR-V translator a load that disagrees with the
+    // pointee type of its operand.
+    if (auto *GEP = dyn_cast<GetElementPtrInst>(Ptr))
+      if (auto *SrcPtrTy = dyn_cast<PointerType>(GEP->getSourceElementType()))
+        if (SrcPtrTy->getAddressSpace() != GenericAS) {
+          SmallVector<Value *, 4> Idx(GEP->idx_begin(), GEP->idx_end());
+          IRBuilder<> GB(GEP);
+          auto *NewGEP = cast<GetElementPtrInst>(GB.CreateGEP(
+              GenericPtrTy, GEP->getPointerOperand(), Idx, GEP->getName()));
+#if LLVM_VERSION_MAJOR >= 19
+          NewGEP->setNoWrapFlags(GEP->getNoWrapFlags());
+#else
+          NewGEP->setIsInBounds(GEP->isInBounds());
+#endif
+          NewGEP->setDebugLoc(GEP->getDebugLoc());
+          Ptr = NewGEP;
+          GEP->replaceAllUsesWith(NewGEP);
+          Dead.insert(GEP);
+        }
+
+    auto *NewLI = B.CreateAlignedLoad(GenericPtrTy, Ptr, LI->getAlign(),
+                                      LI->isVolatile(), LI->getName());
+    NewLI->setOrdering(LI->getOrdering());
+    NewLI->setSyncScopeID(LI->getSyncScopeID());
+    NewLI->copyMetadata(*LI);
+    NewLI->setDebugLoc(LI->getDebugLoc());
+
+    // Any remaining reader of the old load still wants the original address
+    // space. Generic -> global is a legal narrowing cast in SPIR-V.
+    if (!LI->use_empty()) {
+      auto *Back = cast<Instruction>(B.CreateAddrSpaceCast(NewLI, PtrTy));
+      LI->replaceAllUsesWith(Back);
+      Dead.insert(Back);
+    }
+    Dead.insert(LI);
+    return NewLI;
+  }
+
+  if (auto *Phi = dyn_cast<PHINode>(V)) {
+    // Rebuild the phi in the generic address space so that a virtual call
+    // reached from several predecessors still sees a single generic value.
+    // Each incoming value is rewritten in turn, so that a slot load feeding
+    // the phi is retyped rather than merely cast.
+    IRBuilder<> B(Phi);
+    auto *NewPhi = B.CreatePHI(GenericPtrTy, Phi->getNumIncomingValues(),
+                               Phi->getName());
+    NewPhi->setDebugLoc(Phi->getDebugLoc());
+    for (unsigned I = 0, E = Phi->getNumIncomingValues(); I < E; ++I) {
+      BasicBlock *BB = Phi->getIncomingBlock(I);
+      Value *In = Phi->getIncomingValue(I);
+      Value *NewIn;
+      if (auto *CIn = dyn_cast<Constant>(In))
+        NewIn = coercePtrToGeneric(CIn);
+      else
+        NewIn = makeCalleeGeneric(In, BB->getTerminator(), Dead, Visited);
+      NewPhi->addIncoming(NewIn, BB);
+    }
+    Dead.insert(Phi);
+    return NewPhi;
+  }
+
+  if (auto *C = dyn_cast<Constant>(V))
+    return coercePtrToGeneric(C);
+
+  IRBuilder<> B(InsertBefore);
+  return B.CreateAddrSpaceCast(V, GenericPtrTy);
+}
+
+/// Rebuild \p CB so that its callee operand is \p NewCallee. LLVM encodes the
+/// address space of an indirect callee in the call itself, so the instruction
+/// has to be recreated rather than patched in place.
+static void rewriteCallCallee(CallBase *CB, Value *NewCallee) {
+  SmallVector<Value *, 8> Args(CB->args());
+  SmallVector<OperandBundleDef, 2> Bundles;
+  CB->getOperandBundlesAsDefs(Bundles);
+
+  CallBase *NewCB;
+  if (auto *CI = dyn_cast<CallInst>(CB)) {
+    auto *NewCI =
+        CallInst::Create(CB->getFunctionType(), NewCallee, Args, Bundles, "", CB);
+    NewCI->setTailCallKind(CI->getTailCallKind());
+    NewCB = NewCI;
+  } else if (auto *II = dyn_cast<InvokeInst>(CB)) {
+    NewCB = InvokeInst::Create(CB->getFunctionType(), NewCallee,
+                               II->getNormalDest(), II->getUnwindDest(), Args,
+                               Bundles, "", CB);
+  } else {
+    return;
+  }
+
+  NewCB->setCallingConv(CB->getCallingConv());
+  NewCB->setAttributes(CB->getAttributes());
+  NewCB->copyMetadata(*CB);
+  NewCB->setDebugLoc(CB->getDebugLoc());
+  // Fast-math flags, 'contract' in particular, are not carried by metadata.
+  if (isa<FPMathOperator>(CB) && isa<FPMathOperator>(NewCB))
+    NewCB->setFastMathFlags(CB->getFastMathFlags());
+
+  NewCB->takeName(CB);
+  CB->replaceAllUsesWith(NewCB);
+  CB->eraseFromParent();
+}
+
+/// Retype vtable-like globals. Returns true if the module changed.
+static bool fixGlobalInitializers(Module &M) {
+  SmallVector<GlobalVariable *, 8> Candidates;
+  for (GlobalVariable &GV : M.globals()) {
+    if (!GV.hasInitializer())
+      continue;
+    SmallPtrSet<const Constant *, 16> Seen;
+    if (containsFunctionCastToNonGeneric(GV.getInitializer(), Seen))
+      Candidates.push_back(&GV);
+  }
+
+  bool Changed = false;
+  for (GlobalVariable *GV : Candidates) {
+    Constant *NewInit = rewriteInitializer(GV->getInitializer());
+    if (NewInit == GV->getInitializer())
+      continue;
+    LLVM_DEBUG(dbgs() << "hip-function-pointer-as: retyping " << GV->getName()
+                      << "\n");
+    replaceGlobalInitializer(M, GV, NewInit);
+    Changed = true;
+  }
+  return Changed;
+}
+
+/// Repair indirect calls whose callee is not in the generic address space.
+static bool fixIndirectCalls(Module &M) {
+  SmallVector<CallBase *, 8> Calls;
+  for (Function &F : M)
+    for (BasicBlock &BB : F)
+      for (Instruction &I : BB) {
+        auto *CB = dyn_cast<CallBase>(&I);
+        if (!CB || !CB->isIndirectCall())
+          continue;
+        Value *Callee = CB->getCalledOperand();
+        unsigned AS = Callee->getType()->getPointerAddressSpace();
+        // The program address space is what a plain 'call' uses and is always
+        // fine; generic is what we are aiming for.
+        if (AS == GenericAS || AS == M.getDataLayout().getProgramAddressSpace())
+          continue;
+        Calls.push_back(CB);
+      }
+
+  if (Calls.empty())
+    return false;
+
+  // A set so that an instruction reached twice, which happens when several
+  // calls share one slot load, is not erased twice.
+  SmallSetVector<Instruction *, 8> Dead;
+  for (CallBase *CB : Calls) {
+    SmallPtrSet<Value *, 8> Visited;
+    Value *NewCallee =
+        makeCalleeGeneric(CB->getCalledOperand(), CB, Dead, Visited);
+    if (NewCallee != CB->getCalledOperand())
+      rewriteCallCallee(CB, NewCallee);
+  }
+
+  // Drop the originals now that nothing refers to them any more.
+  for (Instruction *I : reverse(Dead))
+    if (I->use_empty())
+      I->eraseFromParent();
+
+  return true;
+}
+
+} // namespace
+
+PreservedAnalyses HipFunctionPointerASPass::run(Module &M,
+                                                ModuleAnalysisManager &AM) {
+  bool Changed = fixGlobalInitializers(M);
+  Changed |= fixIndirectCalls(M);
+  return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
+}

--- a/llvm_passes/HipFunctionPointerAS.h
+++ b/llvm_passes/HipFunctionPointerAS.h
@@ -1,0 +1,31 @@
+//===- HipFunctionPointerAS.h ---------------------------------------------===//
+//
+// Part of the chipStar Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Move function pointers held in global variable initializers (C++ vtables in
+// practice) into the generic address space so the module can be translated to
+// SPIR-V.
+//
+// (c) 2026 chipStar developers
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_PASSES_HIP_FUNCTION_POINTER_AS_H
+#define LLVM_PASSES_HIP_FUNCTION_POINTER_AS_H
+
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
+
+using namespace llvm;
+
+class HipFunctionPointerASPass
+    : public PassInfoMixin<HipFunctionPointerASPass> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  static bool isRequired() { return true; }
+};
+
+#endif

--- a/llvm_passes/HipPasses.cpp
+++ b/llvm_passes/HipPasses.cpp
@@ -34,6 +34,7 @@
 #include "HipLowerRoundIntrinsics.h"
 #include "HipLowerSubwordAtomics.h"
 #include "HipIGBADetector.h"
+#include "HipFunctionPointerAS.h"
 #include "HipPromoteInts.h"
 #include "HipLowerOverflowIntrinsics.h"
 #include "HipSpirvFunctionReorderPass.h"
@@ -215,6 +216,11 @@ static void addFullLinkTimePasses(ModulePassManager &MPM) {
 
   addPassWithVerification(MPM, createModuleToFunctionPassAdaptor(InferAddressSpacesPass(4)), "InferAddressSpacesPass");
 
+  // Move vtable function pointers into the generic address space. Runs after
+  // inlining and InferAddressSpaces so it only sees the indirect calls that
+  // genuinely survive into the SPIR-V module.
+  addPassWithVerification(MPM, HipFunctionPointerASPass(), "HipFunctionPointerASPass");
+
   addPassWithVerification(MPM, HipIGBADetectorPass(), "HipIGBADetectorPass");
 
   // Fix InvalidBitWidth errors due to non-standard integer types
@@ -285,6 +291,12 @@ llvmGetPassPluginInfo() {
                   if (Name == "hip-lower-subword-atomics") {
                     MPM.addPass(createModuleToFunctionPassAdaptor(
                         HipLowerSubwordAtomicsPass()));
+                    return true;
+                  }
+                  // Register the vtable function pointer address space pass
+                  // as standalone, which makes it directly testable with opt.
+                  if (Name == "hip-function-pointer-as") {
+                    MPM.addPass(HipFunctionPointerASPass());
                     return true;
                   }
                   // Register SPIR-V function reorder pass as standalone

--- a/llvm_passes/HipPasses.cpp
+++ b/llvm_passes/HipPasses.cpp
@@ -56,13 +56,23 @@
 
 using namespace llvm;
 
-// A predicate for internalize pass
+// A predicate for internalize pass. Returning true means preserve GV.
 //
-// This internalizes all non-kernel functions so unused ones get removed by DCE
-// pass.
-static bool internalizeSPIRVFunctions(const GlobalValue &GV) {
+// Internalizes all non-kernel functions so unused ones get removed by DCE
+// pass, and the Itanium vtable family (_ZTV vtable, _ZTT VTT, _ZTC construction
+// vtable). Clang emits those for every polymorphic class that appears in device
+// code, and an explicit instantiation gives them weak_odr linkage, which
+// GlobalDCE alone must keep. A device module is self-contained, so nothing can
+// link against them and the unreferenced ones can go; left in, a dead table
+// whose virtual base offsets are inttoptr constants aborts llvm-spirv
+// (CHIP-SPV/chipStar#1382).
+static bool preserveDuringInternalize(const GlobalValue &GV) {
+  if (isa<GlobalVariable>(GV)) {
+    StringRef Name = GV.getName();
+    return !(Name.starts_with("_ZTV") || Name.starts_with("_ZTT") ||
+             Name.starts_with("_ZTC"));
+  }
   const auto *F = dyn_cast<Function>(&GV);
-  // Returning true means preserve GV.
   return !(F && F->getCallingConv() == CallingConv::SPIR_FUNC);
 }
 
@@ -210,7 +220,7 @@ static void addFullLinkTimePasses(ModulePassManager &MPM) {
 
   // Internalize all __device__ functions (spir_kernels) so the follow-up DCE
   // passes cleans-ups the unused ones.
-  addPassWithVerification(MPM, InternalizePass(internalizeSPIRVFunctions), "InternalizePass");
+  addPassWithVerification(MPM, InternalizePass(preserveDuringInternalize), "InternalizePass");
   addPassWithVerification(MPM, createModuleToFunctionPassAdaptor(DCEPass()), "DCEPass");
   addPassWithVerification(MPM, GlobalDCEPass(), "GlobalDCEPass");
 

--- a/llvm_passes/HipPasses.cpp
+++ b/llvm_passes/HipPasses.cpp
@@ -30,6 +30,7 @@
 #include "HipLowerSwitch.h"
 #include "HipLowerMemset.h"
 #include "HipIGBADetector.h"
+#include "HipFunctionPointerAS.h"
 #include "HipPromoteInts.h"
 #include "HipSpirvFunctionReorderPass.h"
 #include "HipVerify.h"
@@ -192,6 +193,11 @@ static void addFullLinkTimePasses(ModulePassManager &MPM) {
 
   addPassWithVerification(MPM, createModuleToFunctionPassAdaptor(InferAddressSpacesPass(4)), "InferAddressSpacesPass");
 
+  // Move function pointers held in vtables into the generic address space.
+  // Runs after inlining and InferAddressSpaces so that it only has to deal
+  // with the indirect calls which genuinely survive to the SPIR-V module.
+  addPassWithVerification(MPM, HipFunctionPointerASPass(), "HipFunctionPointerASPass");
+
   addPassWithVerification(MPM, HipIGBADetectorPass(), "HipIGBADetectorPass");
 
   // Fix InvalidBitWidth errors due to non-standard integer types
@@ -235,6 +241,12 @@ llvmGetPassPluginInfo() {
                   // Register merged IR+SPIR-V validation pass as standalone (legacy - use hip-verify instead)
                   if (Name == "ir-spirv-validate") {
                     MPM.addPass(HipVerifyPass("IR+SPIR-V validation"));
+                    return true;
+                  }
+                  // Register the vtable function pointer address space pass
+                  // as standalone, which makes it directly testable with opt.
+                  if (Name == "hip-function-pointer-as") {
+                    MPM.addPass(HipFunctionPointerASPass());
                     return true;
                   }
                   // Register SPIR-V function reorder pass as standalone

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -177,6 +177,11 @@ add_shell_test(TestTextureUnsupportedMixedDim.bash)
 
 add_hipcc_test(TestLdg.hip HIPCC_OPTIONS -fsyntax-only)
 add_hipcc_test(TestSwitchCase.hip HIPCC_OPTIONS -O1 -c)
+# Device side C++ virtual dispatch (CHIP-SPV/chipStar#1373). Compile only: -c
+# already runs the device link that translates to SPIR-V, which is where the
+# unfixed compiler failed. The dispatch is executed by
+# tests/runtime/TestDeviceVirtualDispatch.hip on devices that can run it.
+add_hipcc_test(TestDeviceVirtualFunctions.hip HIPCC_OPTIONS -c)
 add_hipcc_test(TestHostSideHIPVectors.hip HIPCC_OPTIONS -fsyntax-only)
 add_hipcc_test(TestAlignAttr.hip HIPCC_OPTIONS -fsyntax-only)
 # Check CHIP_FAST_MATH is set for -ffast-math and preprocessor guards

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -182,6 +182,9 @@ add_hipcc_test(TestSwitchCase.hip HIPCC_OPTIONS -O1 -c)
 # unfixed compiler failed. The dispatch is executed by
 # tests/runtime/TestDeviceVirtualDispatch.hip on devices that can run it.
 add_hipcc_test(TestDeviceVirtualFunctions.hip HIPCC_OPTIONS -c)
+# Dead vtables of an explicit instantiation must not survive into the device
+# module (#1382). Inspects the lowered device bitcode.
+add_shell_test(TestDeadVTableVirtualBase.bash)
 add_hipcc_test(TestHostSideHIPVectors.hip HIPCC_OPTIONS -fsyntax-only)
 add_hipcc_test(TestAlignAttr.hip HIPCC_OPTIONS -fsyntax-only)
 # Check CHIP_FAST_MATH is set for -ffast-math and preprocessor guards

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -170,6 +170,14 @@ add_shell_test(TestTextureUnsupportedMixedDim.bash)
 
 add_hipcc_test(TestLdg.hip HIPCC_OPTIONS -fsyntax-only)
 add_hipcc_test(TestSwitchCase.hip HIPCC_OPTIONS -O1 -c)
+# Device-side C++ virtual dispatch. Needs the vtable function pointer slots to
+# be moved into the generic address space (CHIP-SPV/chipStar#1373). Compile
+# only: SPIR-V translation happens during the device link that -c already
+# performs, which is exactly where the unfixed compiler failed, so this catches
+# a regression of the pass on every target without launching an indirect call
+# on a device that cannot execute one. The matching runtime check lives in
+# tests/runtime/TestDeviceVirtualDispatch.hip.
+add_hipcc_test(TestDeviceVirtualFunctions.hip HIPCC_OPTIONS -c)
 add_hipcc_test(TestHostSideHIPVectors.hip HIPCC_OPTIONS -fsyntax-only)
 add_hipcc_test(TestAlignAttr.hip HIPCC_OPTIONS -fsyntax-only)
 # Check CHIP_FAST_MATH is set for -ffast-math and preprocessor guards

--- a/tests/compiler/TestDeadVTableVirtualBase.bash
+++ b/tests/compiler/TestDeadVTableVirtualBase.bash
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Reproducer for CHIP-SPV/chipStar#1382: dead C++ vtables in device modules.
+#
+# An explicit instantiation makes clang emit the vtable, VTT and construction
+# vtables of a polymorphic class into the device module with weak_odr linkage,
+# which GlobalDCE cannot discard, even though nothing on the device dispatches
+# through them. A device module is self-contained, so nothing can ever link
+# against them, and their inttoptr virtual base offsets are what aborted
+# llvm-spirv on Tpetra::RowMatrix's HIP instantiations. Check that the lowered
+# device bitcode, the input of the SPIR-V producer, carries no vtable family
+# global.
+set -eu
+
+HIPCC="@CMAKE_BINARY_DIR@/bin/hipcc"
+LLVM_DIS="@CLANG_ROOT_PATH_BIN@/llvm-dis"
+SRC="@CMAKE_CURRENT_SOURCE_DIR@/TestDeadVTableVirtualBase.hip"
+OUT="@CMAKE_CURRENT_BINARY_DIR@/@TEST_NAME@.d"
+
+if [ ! -x "${LLVM_DIS}" ]; then
+  echo "llvm-dis not found at ${LLVM_DIS}; skipping"
+  exit 0
+fi
+
+rm -rf "${OUT}"
+mkdir -p "${OUT}"
+cd "${OUT}"
+
+# The lowered device bitcode is *-generic-lower.bc with the old offload driver
+# and *.hipfb.<triple>.-lower.bc with the new one; both end in -lower.bc.
+"${HIPCC}" --save-temps=cwd -c "${SRC}" -o TestDeadVTableVirtualBase.o
+BC=$(ls "${OUT}"/*-lower.bc 2>/dev/null | head -1)
+if [ -z "${BC}" ]; then
+  echo "FAIL: no lowered device bitcode (*-lower.bc) produced by hipcc"
+  exit 1
+fi
+"${LLVM_DIS}" "${BC}" -o lowered.ll
+
+if grep -qE '^@_ZT[VTC]' lowered.ll; then
+  echo "FAIL: dead vtable family globals survive in the device module:"
+  grep -E '^@_ZT[VTC]' lowered.ll | cut -c1-100
+  exit 1
+fi
+echo "PASSED"

--- a/tests/compiler/TestDeadVTableVirtualBase.hip
+++ b/tests/compiler/TestDeadVTableVirtualBase.hip
@@ -1,0 +1,30 @@
+// Input of TestDeadVTableVirtualBase.bash, the reproducer for
+// CHIP-SPV/chipStar#1382.
+//
+// The explicit instantiation makes clang emit the vtable, VTT and construction
+// vtable of Impl<int> into the device module with weak_odr linkage although
+// nothing on the device dispatches through them. Their slots are null because
+// the virtual members are host only, and the virtual base offset is an
+// inttoptr constant, which is what aborted llvm-spirv on Tpetra::RowMatrix's
+// HIP instantiations:
+//
+//   SPIRVWriter.cpp: transConstantUse: Assertion `(C->getType()->isPointerTy()
+//   || ExpectedType->isTypeUntypedPointerKHR()) && "Only pointer type
+//   mismatches should be possible"' failed.
+
+#include <hip/hip_runtime.h>
+
+template <typename T> struct Base {
+  T Pad;
+  virtual ~Base() {}
+  virtual T get() const { return Pad; }
+};
+
+template <typename T> struct Impl : virtual Base<T> {
+  T V;
+  T get() const override { return V; }
+};
+
+template struct Impl<int>;
+
+__global__ void unrelated(int *Out) { Out[0] = 1; }

--- a/tests/compiler/TestDeviceVirtualFunctions.hip
+++ b/tests/compiler/TestDeviceVirtualFunctions.hip
@@ -1,0 +1,61 @@
+// Compile-only reproducer for CHIP-SPV/chipStar#1373: device side virtual
+// dispatch. Clang emits every vtable slot as a function pointer cast into the
+// global address space. SPIR-V has casts into and out of Generic but none from
+// the Function storage class (a plain pointer) into CrossWorkgroup, so the
+// device link that -c already performs fails before anything reaches a device:
+//
+//   InvalidModule: Invalid SPIR-V module: Casts from private/local/global
+//   address space are allowed only to generic
+//
+// The dynamic type is picked from a kernel argument so the call cannot be
+// devirtualized. Executing the dispatch needs SPV_INTEL_function_pointers and
+// is covered by tests/runtime/TestDeviceVirtualDispatch.hip.
+
+#include <hip/hip_runtime.h>
+
+struct Shape {
+  float Scale;
+  __device__ Shape(float S) : Scale(S) {}
+  __device__ virtual ~Shape() {}
+  __device__ virtual float area() const { return Scale; }
+};
+
+struct Square : Shape {
+  __device__ Square(float S) : Shape(S) {}
+  __device__ float area() const override { return Scale * Scale; }
+};
+
+struct Circle : Shape {
+  __device__ Circle(float S) : Shape(S) {}
+  __device__ float area() const override { return 3.0f * Scale * Scale; }
+};
+
+__global__ void dispatch(const int *Sel, float *Area) {
+  Square Sq(2.0f);
+  Circle Ci(2.0f);
+  const Shape *S = Sel[threadIdx.x] ? static_cast<const Shape *>(&Ci) : &Sq;
+  Area[threadIdx.x] = S->area();
+}
+
+// A virtual base gives the class a VTT and construction vtables. The VTT holds
+// constant GEPs into those tables, which must be rebuilt when the tables are
+// retyped.
+struct VBase {
+  __device__ virtual ~VBase() {}
+  __device__ virtual int id() const { return 1; }
+};
+
+struct Mid : virtual VBase {
+  __device__ int id() const override { return 2; }
+};
+
+struct Leaf : Mid {
+  __device__ int id() const override { return 3; }
+};
+
+__global__ void dispatchVirtualBase(const int *Sel, int *Out) {
+  Mid M;
+  Leaf L;
+  const VBase *B = Sel[threadIdx.x] ? static_cast<const VBase *>(&L) : &M;
+  Out[threadIdx.x] = B->id();
+}

--- a/tests/compiler/TestDeviceVirtualFunctions.hip
+++ b/tests/compiler/TestDeviceVirtualFunctions.hip
@@ -1,0 +1,70 @@
+// Compile regression test for CHIP-SPV/chipStar#1373.
+//
+// Clang emits C++ vtables for SPIR-V targets with every slot in the global
+// address space, which makes each virtual function slot an addrspacecast of a
+// function into CrossWorkGroup. SPIR-V only allows casts into Generic, so the
+// device link step used to abort with
+//
+//   InvalidModule: Invalid SPIR-V module: Casts from private/local/global
+//   address space are allowed only to generic
+//
+// before the code ever reached a device. HipFunctionPointerASPass moves those
+// slots into the generic address space.
+//
+// This test only compiles. -c still runs the device link that translates to
+// SPIR-V, which is exactly where the unfixed compiler failed, so a regression
+// of the pass is caught here on every target. It deliberately does not launch
+// anything, because executing an indirect call needs
+// SPV_INTEL_function_pointers, which only Intel's stack implements today. The
+// runtime check that validates the dispatched values numerically is
+// tests/runtime/TestDeviceVirtualDispatch.hip, which gates itself on device
+// capability.
+
+#include <hip/hip_runtime.h>
+
+struct Shape {
+  double Scale;
+  __device__ Shape(double S) : Scale(S) {}
+  __device__ virtual ~Shape() {}
+  __device__ virtual double area() const { return Scale; }
+  __device__ virtual int tag() const { return 0; }
+};
+
+struct Square : Shape {
+  __device__ Square(double S) : Shape(S) {}
+  __device__ ~Square() override {}
+  __device__ double area() const override { return Scale * Scale; }
+  __device__ int tag() const override { return 1; }
+};
+
+struct Circle : Shape {
+  __device__ Circle(double S) : Shape(S) {}
+  __device__ ~Circle() override {}
+  __device__ double area() const override { return 3.0 * Scale * Scale; }
+  __device__ int tag() const override { return 2; }
+};
+
+// The dynamic type is picked from a runtime value so the compiler cannot
+// devirtualize the call and quietly stop exercising the vtable.
+__global__ void dispatchKernel(const int *Sel, double *Area, int *Tag) {
+  int I = threadIdx.x;
+  Square Sq(2.0);
+  Circle Ci(2.0);
+  Shape *S = Sel[I] ? static_cast<Shape *>(&Ci) : static_cast<Shape *>(&Sq);
+  Area[I] = S->area();
+  Tag[I] = S->tag();
+}
+
+// Here the base pointer is round tripped through memory, which is the shape
+// real code such as Trilinos STK produces.
+__device__ __attribute__((noinline)) double areaOf(const Shape *S) {
+  return S->area();
+}
+
+__global__ void indirectDispatchKernel(const int *Sel, double *Area) {
+  int I = threadIdx.x;
+  Square Sq(3.0);
+  Circle Ci(3.0);
+  const Shape *Table[2] = {&Sq, &Ci};
+  Area[I] = areaOf(Table[Sel[I] & 1]);
+}

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -247,3 +247,8 @@ add_hip_runtime_test(TestSyncthreadsAndOrCount.hip)
 # __clz(0)-poison miscompile only manifests at -O1 and above.
 add_hip_runtime_test(TestSnakeMiscompileO2.hip)
 target_compile_options(TestSnakeMiscompileO2 PRIVATE -O2)
+
+# Device side C++ virtual dispatch (CHIP-SPV/chipStar#1373). Skips itself at
+# runtime on stacks without SPV_INTEL_function_pointers; the compile side is
+# covered on every target by tests/compiler/TestDeviceVirtualFunctions.hip.
+add_hip_runtime_test(TestDeviceVirtualDispatch.hip)

--- a/tests/runtime/TestDeviceVirtualDispatch.hip
+++ b/tests/runtime/TestDeviceVirtualDispatch.hip
@@ -1,0 +1,154 @@
+// Runtime reproducer for device side C++ virtual dispatch
+// (CHIP-SPV/chipStar#1373). The compile side is covered on every target by
+// tests/compiler/TestDeviceVirtualFunctions.hip; this test executes the
+// dispatch and checks the results, which needs a device that can run an
+// indirect call.
+//
+// Indirect calls are modelled with SPV_INTEL_function_pointers and support
+// cannot be probed at runtime: Intel accepts such modules without advertising
+// cl_intel_function_pointers, rusticl rejects them only in the device JIT, and
+// PoCL hangs. So the stacks known to implement it are allow-listed before the
+// first launch, mirroring the isIntelGPU idiom of the OpenCL backend. A GPU is
+// required as well as the Intel vendor: an Intel OpenCL CPU device reports the
+// same vendor string.
+
+#include <hip/hip_interop.h>
+#include <hip/hip_runtime.h>
+
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+// Weak so this also links on a build without the OpenCL backend.
+extern "C" __attribute__((weak)) int clGetDeviceInfo(void *Device,
+                                                     unsigned ParamName,
+                                                     size_t ParamValueSize,
+                                                     void *ParamValue,
+                                                     size_t *ParamValueSizeRet);
+static constexpr unsigned ClDeviceType = 0x1000;   // CL_DEVICE_TYPE
+static constexpr unsigned ClDeviceVendor = 0x102C; // CL_DEVICE_VENDOR
+static constexpr unsigned long long ClDeviceTypeGpu = 1 << 2; // CL_DEVICE_TYPE_GPU
+
+static bool deviceSupportsIndirectCalls() {
+  int NumHandles = 0;
+  if (hipGetBackendNativeHandles(0, nullptr, &NumHandles) != hipSuccess ||
+      NumHandles < 1)
+    return false;
+  std::vector<uintptr_t> Handles(NumHandles);
+  if (hipGetBackendNativeHandles(0, Handles.data(), nullptr) != hipSuccess)
+    return false;
+
+  const char *Backend = reinterpret_cast<const char *>(Handles[0]);
+  if (!Backend)
+    return false;
+  if (!strcmp(Backend, "level0"))
+    return true;
+  // Handles[2] is the cl_device_id, see CHIPQueueOpenCL::getBackendHandles.
+  if (strcmp(Backend, "opencl") || NumHandles < 3 || !clGetDeviceInfo)
+    return false;
+  void *Device = reinterpret_cast<void *>(Handles[2]);
+  char Vendor[256] = {0};
+  unsigned long long Type = 0;
+  if (clGetDeviceInfo(Device, ClDeviceVendor, sizeof(Vendor) - 1, Vendor,
+                      nullptr) ||
+      clGetDeviceInfo(Device, ClDeviceType, sizeof(Type), &Type, nullptr))
+    return false;
+  return strstr(Vendor, "Intel") && (Type & ClDeviceTypeGpu);
+}
+
+struct Shape {
+  float Scale;
+  __device__ Shape(float S) : Scale(S) {}
+  __device__ virtual ~Shape() {}
+  __device__ virtual float area() const { return Scale; }
+};
+
+struct Square : Shape {
+  __device__ Square(float S) : Shape(S) {}
+  __device__ float area() const override { return Scale * Scale; }
+};
+
+struct Circle : Shape {
+  __device__ Circle(float S) : Shape(S) {}
+  __device__ float area() const override { return 3.0f * Scale * Scale; }
+};
+
+// The dynamic type comes from a runtime value so the call cannot be
+// devirtualized and quietly turn the test into a no-op.
+__global__ void dispatchKernel(const int *Sel, float *Area) {
+  Square Sq(2.0f);
+  Circle Ci(2.0f);
+  const Shape *S = Sel[threadIdx.x] ? static_cast<const Shape *>(&Ci) : &Sq;
+  Area[threadIdx.x] = S->area();
+}
+
+// The base pointer is round tripped through memory, which is the shape real
+// code such as Trilinos STK produces.
+__device__ __attribute__((noinline)) float areaOf(const Shape *S) {
+  return S->area();
+}
+
+__global__ void indirectDispatchKernel(const int *Sel, float *Area) {
+  Square Sq(3.0f);
+  Circle Ci(3.0f);
+  const Shape *Table[2] = {&Sq, &Ci};
+  Area[threadIdx.x] = areaOf(Table[Sel[threadIdx.x] & 1]);
+}
+
+static constexpr int N = 4;
+
+template <typename KernelT>
+static bool runAndCheck(const char *Name, KernelT Kernel, const int *DSel,
+                        float *DArea, const float *Want) {
+  float HArea[N] = {0};
+  (void)hipMemset(DArea, 0, N * sizeof(float));
+  Kernel<<<1, N>>>(DSel, DArea);
+  (void)hipDeviceSynchronize();
+  hipError_t Err = hipGetLastError();
+  if (Err != hipSuccess) {
+    printf("FAIL: %s: %s\n", Name, hipGetErrorString(Err));
+    return false;
+  }
+  (void)hipMemcpy(HArea, DArea, N * sizeof(float), hipMemcpyDeviceToHost);
+  bool Ok = true;
+  for (int I = 0; I < N; I++)
+    if (HArea[I] != Want[I]) {
+      printf("FAIL: %s[%d]: %f (want %f)\n", Name, I, HArea[I], Want[I]);
+      Ok = false;
+    }
+  return Ok;
+}
+
+int main() {
+  int DeviceCount = 0;
+  hipError_t Err = hipGetDeviceCount(&DeviceCount);
+  if (Err == hipErrorInitializationError || Err == hipErrorNoDevice) {
+    printf("HIP_SKIP_THIS_TEST: no backend available (error %d)\n", Err);
+    return CHIP_SKIP_TEST;
+  }
+  if (!deviceSupportsIndirectCalls()) {
+    printf("HIP_SKIP_THIS_TEST: device does not support device side indirect "
+           "calls (SPV_INTEL_function_pointers)\n");
+    return CHIP_SKIP_TEST;
+  }
+
+  const int HSel[N] = {0, 1, 1, 0};
+  const float WantArea[N] = {4.0f, 12.0f, 12.0f, 4.0f};
+  const float WantIndirectArea[N] = {9.0f, 27.0f, 27.0f, 9.0f};
+
+  int *DSel = nullptr;
+  float *DArea = nullptr;
+  (void)hipMalloc(&DSel, N * sizeof(int));
+  (void)hipMalloc(&DArea, N * sizeof(float));
+  (void)hipMemcpy(DSel, HSel, N * sizeof(int), hipMemcpyHostToDevice);
+
+  bool Ok = runAndCheck("dispatch", dispatchKernel, DSel, DArea, WantArea);
+  Ok &= runAndCheck("indirectDispatch", indirectDispatchKernel, DSel, DArea,
+                    WantIndirectArea);
+
+  (void)hipFree(DSel);
+  (void)hipFree(DArea);
+  if (Ok)
+    printf("PASSED\n");
+  return Ok ? 0 : 1;
+}

--- a/tests/runtime/TestDeviceVirtualDispatch.hip
+++ b/tests/runtime/TestDeviceVirtualDispatch.hip
@@ -95,6 +95,39 @@ __global__ void indirectDispatchKernel(const int *Sel, float *Area) {
   Area[threadIdx.x] = areaOf(Table[Sel[threadIdx.x] & 1]);
 }
 
+// Dispatch through an abstract base. Clang keeps a __cxa_pure_virtual slot in
+// the vtable of any class with an unoverridden pure virtual member, and the
+// device side has to define that symbol (CHIP-SPV/chipStar#1381). Without it
+// the consumer rejects the module and every kernel in the program fails to
+// build.
+struct Abstract {
+  // noinline keeps the store of Abstract's own vptr, and with it the reference
+  // to __cxa_pure_virtual, in the module at every optimisation level. Inlined
+  // into a derived constructor that store is dead and the vtable is dropped.
+  __device__ __attribute__((noinline)) Abstract() {}
+  __device__ virtual ~Abstract() {}
+  __device__ virtual float area() const = 0;
+};
+
+struct Rect final : Abstract {
+  float W, H;
+  __device__ Rect(float W_, float H_) : W(W_), H(H_) {}
+  __device__ float area() const final { return W * H; }
+};
+
+struct AbstractSquare final : Abstract {
+  float S;
+  __device__ explicit AbstractSquare(float S_) : S(S_) {}
+  __device__ float area() const final { return S * S; }
+};
+
+__global__ void pureVirtualKernel(const int *Sel, float *Area) {
+  Rect R(3.0f, 4.0f);
+  AbstractSquare Sq(5.0f);
+  const Abstract *Table[2] = {&R, &Sq};
+  Area[threadIdx.x] = Table[Sel[threadIdx.x] & 1]->area();
+}
+
 static constexpr int N = 4;
 
 template <typename KernelT>
@@ -135,6 +168,7 @@ int main() {
   const int HSel[N] = {0, 1, 1, 0};
   const float WantArea[N] = {4.0f, 12.0f, 12.0f, 4.0f};
   const float WantIndirectArea[N] = {9.0f, 27.0f, 27.0f, 9.0f};
+  const float WantPureVirtualArea[N] = {12.0f, 25.0f, 25.0f, 12.0f};
 
   int *DSel = nullptr;
   float *DArea = nullptr;
@@ -145,6 +179,8 @@ int main() {
   bool Ok = runAndCheck("dispatch", dispatchKernel, DSel, DArea, WantArea);
   Ok &= runAndCheck("indirectDispatch", indirectDispatchKernel, DSel, DArea,
                     WantIndirectArea);
+  Ok &= runAndCheck("pureVirtual", pureVirtualKernel, DSel, DArea,
+                    WantPureVirtualArea);
 
   (void)hipFree(DSel);
   (void)hipFree(DArea);

--- a/tests/runtime/TestDeviceVirtualDispatch.hip
+++ b/tests/runtime/TestDeviceVirtualDispatch.hip
@@ -128,6 +128,36 @@ __global__ void indirectDispatchKernel(const int *Sel, double *Area) {
   Area[I] = areaOf(Table[Sel[I] & 1]);
 }
 
+// Dispatch through an *abstract* base. Clang keeps a __cxa_pure_virtual slot in
+// the vtable of any class with an unoverridden pure virtual member, and the
+// device side has to define that symbol (CHIP-SPV/chipStar#1381). Without it
+// the consumer rejects the module and every kernel in the program silently
+// fails to build, while launches keep reporting hipSuccess.
+struct Abstract {
+  __device__ virtual ~Abstract() {}
+  __device__ virtual double area() const = 0;
+};
+
+struct AbstractRect final : Abstract {
+  double W, H;
+  __device__ AbstractRect(double W_, double H_) : W(W_), H(H_) {}
+  __device__ double area() const final { return W * H; }
+};
+
+struct AbstractSquare final : Abstract {
+  double S;
+  __device__ explicit AbstractSquare(double S_) : S(S_) {}
+  __device__ double area() const final { return S * S; }
+};
+
+__global__ void pureVirtualKernel(const int *Sel, double *Area) {
+  int I = threadIdx.x;
+  AbstractRect R(3.0, 4.0);
+  AbstractSquare Sq(5.0);
+  const Abstract *Table[2] = {&R, &Sq};
+  Area[I] = Table[Sel[I] & 1]->area();
+}
+
 int main() {
   int DeviceCount = 0;
   hipError_t Err = hipGetDeviceCount(&DeviceCount);
@@ -147,6 +177,7 @@ int main() {
   double WantArea[N] = {4.0, 12.0, 12.0, 4.0};
   int WantTag[N] = {1, 2, 2, 1};
   double WantIndirectArea[N] = {9.0, 27.0, 27.0, 9.0};
+  double WantPureVirtualArea[N] = {12.0, 25.0, 25.0, 12.0};
 
   int *DSel = nullptr;
   double *DArea = nullptr;
@@ -191,6 +222,24 @@ int main() {
     if (HArea[I] != WantIndirectArea[I]) {
       printf("FAIL: indirectDispatch[%d]: area=%f (want %f)\n", I, HArea[I],
              WantIndirectArea[I]);
+      Ok = false;
+    }
+  }
+
+  for (int I = 0; I < N; I++)
+    HArea[I] = 0;
+  pureVirtualKernel<<<1, N>>>(DSel, DArea);
+  (void)hipDeviceSynchronize();
+  Err = hipGetLastError();
+  if (Err != hipSuccess) {
+    printf("FAIL: pureVirtualKernel: %s\n", hipGetErrorString(Err));
+    Ok = false;
+  }
+  (void)hipMemcpy(HArea, DArea, N * sizeof(double), hipMemcpyDeviceToHost);
+  for (int I = 0; I < N; I++) {
+    if (HArea[I] != WantPureVirtualArea[I]) {
+      printf("FAIL: pureVirtual[%d]: area=%f (want %f)\n", I, HArea[I],
+             WantPureVirtualArea[I]);
       Ok = false;
     }
   }

--- a/tests/runtime/TestDeviceVirtualDispatch.hip
+++ b/tests/runtime/TestDeviceVirtualDispatch.hip
@@ -1,0 +1,205 @@
+// Runtime check for device side C++ virtual dispatch (CHIP-SPV/chipStar#1373).
+//
+// The compile side of this is covered everywhere by
+// tests/compiler/TestDeviceVirtualFunctions.hip. This test additionally
+// executes the dispatch and checks the results numerically, which requires a
+// device that can actually run an indirect call.
+//
+// Capability gate
+// ---------------
+// Device side indirect calls are modelled with SPV_INTEL_function_pointers,
+// and support for it is not discoverable at runtime:
+//
+//   * Intel accepts such modules but does not advertise
+//     cl_intel_function_pointers in CL_DEVICE_EXTENSIONS, so the extension
+//     string is not a usable probe.
+//   * rusticl rejects the module during the device JIT ("spirv_to_nir
+//     failed"), which surfaces only once a kernel is launched.
+//   * PoCL neither runs nor rejects it, it hangs, so "try it and catch the
+//     build error" cannot work either.
+//
+// Because of the PoCL behaviour the decision has to be made before the first
+// launch, so we allow-list the stacks known to implement the extension rather
+// than probing. This mirrors the isIntelGPU idiom the OpenCL backend already
+// uses in src/backend/OpenCL/CHIPBackendOpenCL.cc. Everything else is skipped.
+
+#include <hip/hip_interop.h>
+#include <hip/hip_runtime.h>
+
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+// Declared weakly so this test also links on a build without the OpenCL
+// backend, where libOpenCL is absent and the symbol is simply null.
+extern "C" __attribute__((weak)) int clGetDeviceInfo(void *Device,
+                                                     unsigned ParamName,
+                                                     size_t ParamValueSize,
+                                                     void *ParamValue,
+                                                     size_t *ParamValueSizeRet);
+
+// From cl.h, spelled out so that this test needs no OpenCL headers.
+static constexpr unsigned ClDeviceType = 0x1000;
+static constexpr unsigned ClDeviceVendor = 0x102C;
+static constexpr unsigned long long ClDeviceTypeGpu = 1 << 2;
+
+static bool deviceSupportsIndirectCalls() {
+  int NumHandles = 0;
+  if (hipGetBackendNativeHandles(0, nullptr, &NumHandles) != hipSuccess ||
+      NumHandles < 1)
+    return false;
+
+  std::vector<uintptr_t> Handles(NumHandles);
+  if (hipGetBackendNativeHandles(0, Handles.data(), nullptr) != hipSuccess)
+    return false;
+
+  const char *Backend = reinterpret_cast<const char *>(Handles[0]);
+  if (!Backend)
+    return false;
+
+  // Level Zero is Intel's own stack, which implements the extension.
+  if (!strcmp(Backend, "level0"))
+    return true;
+
+  if (strcmp(Backend, "opencl"))
+    return false;
+
+  // Handles[2] is the cl_device_id, see CHIPQueueOpenCL::getBackendHandles.
+  if (NumHandles < 3 || !clGetDeviceInfo)
+    return false;
+  void *Device = reinterpret_cast<void *>(Handles[2]);
+
+  char Vendor[256] = {0};
+  if (clGetDeviceInfo(Device, ClDeviceVendor, sizeof(Vendor) - 1, Vendor,
+                      nullptr))
+    return false;
+
+  unsigned long long Type = 0;
+  if (clGetDeviceInfo(Device, ClDeviceType, sizeof(Type), &Type, nullptr))
+    return false;
+
+  return strstr(Vendor, "Intel") != nullptr && (Type & ClDeviceTypeGpu);
+}
+
+struct Shape {
+  double Scale;
+  __device__ Shape(double S) : Scale(S) {}
+  __device__ virtual ~Shape() {}
+  __device__ virtual double area() const { return Scale; }
+  __device__ virtual int tag() const { return 0; }
+};
+
+struct Square : Shape {
+  __device__ Square(double S) : Shape(S) {}
+  __device__ ~Square() override {}
+  __device__ double area() const override { return Scale * Scale; }
+  __device__ int tag() const override { return 1; }
+};
+
+struct Circle : Shape {
+  __device__ Circle(double S) : Shape(S) {}
+  __device__ ~Circle() override {}
+  __device__ double area() const override { return 3.0 * Scale * Scale; }
+  __device__ int tag() const override { return 2; }
+};
+
+// The dynamic type is picked from a runtime value so the compiler cannot
+// devirtualize the call and quietly turn the test into a no-op.
+__global__ void dispatchKernel(const int *Sel, double *Area, int *Tag) {
+  int I = threadIdx.x;
+  Square Sq(2.0);
+  Circle Ci(2.0);
+  Shape *S = Sel[I] ? static_cast<Shape *>(&Ci) : static_cast<Shape *>(&Sq);
+  Area[I] = S->area();
+  Tag[I] = S->tag();
+}
+
+// Here the base pointer is round tripped through memory, which is the shape
+// real code such as Trilinos STK produces.
+__device__ __attribute__((noinline)) double areaOf(const Shape *S) {
+  return S->area();
+}
+
+__global__ void indirectDispatchKernel(const int *Sel, double *Area) {
+  int I = threadIdx.x;
+  Square Sq(3.0);
+  Circle Ci(3.0);
+  const Shape *Table[2] = {&Sq, &Ci};
+  Area[I] = areaOf(Table[Sel[I] & 1]);
+}
+
+int main() {
+  int DeviceCount = 0;
+  hipError_t Err = hipGetDeviceCount(&DeviceCount);
+  if (Err == hipErrorInitializationError || Err == hipErrorNoDevice) {
+    printf("HIP_SKIP_THIS_TEST: no backend available (error %d)\n", Err);
+    return CHIP_SKIP_TEST;
+  }
+
+  if (!deviceSupportsIndirectCalls()) {
+    printf("HIP_SKIP_THIS_TEST: device does not support device side indirect "
+           "calls (SPV_INTEL_function_pointers)\n");
+    return CHIP_SKIP_TEST;
+  }
+
+  const int N = 4;
+  int HSel[N] = {0, 1, 1, 0};
+  double WantArea[N] = {4.0, 12.0, 12.0, 4.0};
+  int WantTag[N] = {1, 2, 2, 1};
+  double WantIndirectArea[N] = {9.0, 27.0, 27.0, 9.0};
+
+  int *DSel = nullptr;
+  double *DArea = nullptr;
+  int *DTag = nullptr;
+  (void)hipMalloc(&DSel, N * sizeof(int));
+  (void)hipMalloc(&DArea, N * sizeof(double));
+  (void)hipMalloc(&DTag, N * sizeof(int));
+  (void)hipMemcpy(DSel, HSel, N * sizeof(int), hipMemcpyHostToDevice);
+
+  bool Ok = true;
+  double HArea[N] = {0};
+  int HTag[N] = {0};
+
+  dispatchKernel<<<1, N>>>(DSel, DArea, DTag);
+  (void)hipDeviceSynchronize();
+  Err = hipGetLastError();
+  if (Err != hipSuccess) {
+    printf("FAIL: dispatchKernel: %s\n", hipGetErrorString(Err));
+    Ok = false;
+  }
+  (void)hipMemcpy(HArea, DArea, N * sizeof(double), hipMemcpyDeviceToHost);
+  (void)hipMemcpy(HTag, DTag, N * sizeof(int), hipMemcpyDeviceToHost);
+  for (int I = 0; I < N; I++) {
+    if (HArea[I] != WantArea[I] || HTag[I] != WantTag[I]) {
+      printf("FAIL: dispatch[%d]: area=%f (want %f) tag=%d (want %d)\n", I,
+             HArea[I], WantArea[I], HTag[I], WantTag[I]);
+      Ok = false;
+    }
+  }
+
+  for (int I = 0; I < N; I++)
+    HArea[I] = 0;
+  indirectDispatchKernel<<<1, N>>>(DSel, DArea);
+  (void)hipDeviceSynchronize();
+  Err = hipGetLastError();
+  if (Err != hipSuccess) {
+    printf("FAIL: indirectDispatchKernel: %s\n", hipGetErrorString(Err));
+    Ok = false;
+  }
+  (void)hipMemcpy(HArea, DArea, N * sizeof(double), hipMemcpyDeviceToHost);
+  for (int I = 0; I < N; I++) {
+    if (HArea[I] != WantIndirectArea[I]) {
+      printf("FAIL: indirectDispatch[%d]: area=%f (want %f)\n", I, HArea[I],
+             WantIndirectArea[I]);
+      Ok = false;
+    }
+  }
+
+  (void)hipFree(DSel);
+  (void)hipFree(DArea);
+  (void)hipFree(DTag);
+
+  if (Ok)
+    printf("PASSED\n");
+  return Ok ? 0 : 1;
+}


### PR DESCRIPTION
Adds an LLVM pass that moves C++ vtable function pointer slots into the generic address space, the only address space SPIR-V permits function pointers in, and repairs the slot loads and indirect call sites that read them.

Also folds in the three follow-ups that make it usable on real C++: constant GEPs are rebuilt when a vtable is retyped (classes with virtual bases), unreferenced vtable globals are dropped before translation, and `__cxa_pure_virtual` is defined on the device.

Closes #1373
Fixes #1381
Fixes #1382

The pass is a temporary workaround. The root cause is in clang, which types every vtable component with the default globals address space (`clang/lib/CodeGen/CGVTables.cpp`, `getVTableComponentType`); the upstream fix is https://github.com/llvm/llvm-project/pull/212452 and the pass comes out once every supported LLVM carries it. `HipFunctionPointerAS.cpp` carries a `WORKAROUND(...)` marker to that effect.
