### PR TITLE
Pass host-only ocml_host_math_funcs via -Wl, to silence RDC data layout warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -755,12 +755,17 @@ set(HIP_OFFLOAD_COMPILE_OPTIONS_BUILD_
 # -no-hip-rt: Prevents linking amdhip64 library implicitly when doing
 #             combined compile and link or when the --hip-link is
 #             present at the link step.
+#
+# ocml_host_math_funcs is a host-only static library; pass it via -Wl, so
+# clang's static-device-library handling does not unbundle it into empty
+# device bitcode during -fgpu-rdc links (spurious "different data layouts"
+# warnings from llvm-link, see issue #525).
 list(APPEND HIP_OFFLOAD_LINK_OPTIONS_INSTALL_
   ${HIP_SYSROOT_LINK_OPTIONS}
-  "-L${LIB_INSTALL_DIR}" "-lCHIP" "-no-hip-rt -locml_host_math_funcs")
+  "-L${LIB_INSTALL_DIR}" "-lCHIP" "-no-hip-rt -Wl,-locml_host_math_funcs")
 list(APPEND HIP_OFFLOAD_LINK_OPTIONS_BUILD_
   ${HIP_SYSROOT_LINK_OPTIONS}
-  "-L${CMAKE_BINARY_DIR}" "-lCHIP" "-no-hip-rt -locml_host_math_funcs")
+  "-L${CMAKE_BINARY_DIR}" "-lCHIP" "-no-hip-rt -Wl,-locml_host_math_funcs")
 
 if(OpenCL_LIBRARY)
   target_link_options(CHIP PUBLIC -Wl,-rpath,${OpenCL_DIR})

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -149,10 +149,11 @@ add_shell_test(TestHipcc692Regression.bash)
 add_shell_test(TestHipccFileOrderPreservation.bash)
 add_shell_test(TestHipcc945MacroSpace.bash)
 add_shell_test(TestHipccArgOrder.bash)
-# Separate compilation uses clang-offload-bundler which calls llvm-objcopy
-# with options not supported on MachO (macOS).
+# Separate compilation and -fgpu-rdc use clang-offload-bundler which calls
+# llvm-objcopy with options not supported on MachO (macOS).
 if(NOT APPLE)
   add_shell_test(TestSeparateCompilation.bash)
+  add_shell_test(TestRDCNoDataLayoutWarning.bash)
 endif()
 add_subdirectory(rdcLink)
 add_test(NAME "TestHipccMultiSource" COMMAND 

--- a/tests/compiler/TestRDCNoDataLayoutWarning.bash
+++ b/tests/compiler/TestRDCNoDataLayoutWarning.bash
@@ -1,0 +1,28 @@
+#!/bin/bash
+# RDC linking must not emit "Linking two modules of different data layouts".
+#
+# libocml_host_math_funcs.a is a host-only static library. When it is passed
+# to the link line as -locml_host_math_funcs, clang's static-device-library
+# handling unbundles every member into an (empty) device bitcode archive and
+# llvm-link then warns about each empty module's missing data layout.
+# See CHIP-SPV/chipStar#525.
+set -eu
+
+SRC_DIR=@CMAKE_CURRENT_SOURCE_DIR@
+OUT_DIR=@CMAKE_CURRENT_BINARY_DIR@/@TEST_NAME@.d
+HIPCC=@CMAKE_BINARY_DIR@/bin/hipcc
+
+mkdir -p ${OUT_DIR}
+${HIPCC} -fgpu-rdc ${SRC_DIR}/inputs/a.hip -c -o ${OUT_DIR}/a.o
+${HIPCC} -fgpu-rdc ${SRC_DIR}/inputs/b.hip -c -o ${OUT_DIR}/b.o
+
+LINK_LOG=${OUT_DIR}/link.log
+${HIPCC} -fgpu-rdc ${OUT_DIR}/{a,b}.o -o ${OUT_DIR}/ab 2>${LINK_LOG} \
+  || { cat ${LINK_LOG}; exit 1; }
+cat ${LINK_LOG}
+
+if grep -q "different data layouts" ${LINK_LOG}; then
+  echo "FAIL: spurious data layout warning at RDC link"
+  exit 1
+fi
+echo PASSED


### PR DESCRIPTION
In -fgpu-rdc links clang's static device library handling unbundles the host-only libocml_host_math_funcs.a into empty device bitcode modules, so every RDC link printed "Linking two modules of different data layouts: 'ArchiveModule' is ''". Passing the library with -Wl, keeps the host link identical while the offload machinery ignores it. Adds TestRDCNoDataLayoutWarning reproducer.

Fixes #525