### PR TITLE
bf16: make the hip_bf16.h free functions inline, and reinterpret bits in the as-casts (#1383, #1385)

### DIFF
--- a/include/hip/spirv_hip_bf16.h
+++ b/include/hip/spirv_hip_bf16.h
@@ -319,7 +319,12 @@ __device__ inline __hip_bfloat162 __lows2bfloat162(const __hip_bfloat162 a, cons
  * \brief Reinterprets short int into a bfloat16
  */
 __device__ inline __hip_bfloat16 __short_as_bfloat16(const short int a) {
-  return __hip_bfloat16{(unsigned short)a};
+  // Not __hip_bfloat16{a}: the type is not an aggregate here, so that would
+  // select the converting constructor from float and turn a bit pattern into
+  // a numeric conversion.
+  __hip_bfloat16 r;
+  r.data = (unsigned short)a;
+  return r;
 }
 
 /**
@@ -327,7 +332,9 @@ __device__ inline __hip_bfloat16 __short_as_bfloat16(const short int a) {
  * \brief Reinterprets unsigned short int into a bfloat16
  */
 __device__ inline __hip_bfloat16 __ushort_as_bfloat16(const unsigned short int a) {
-  return __hip_bfloat16{a};
+  __hip_bfloat16 r;
+  r.data = a;
+  return r;
 }
 
 

--- a/include/hip/spirv_hip_bf16.h
+++ b/include/hip/spirv_hip_bf16.h
@@ -210,7 +210,7 @@ __HOST_DEVICE__ inline float2 __bfloat1622float2(const __hip_bfloat162 a) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_CONV
  * \brief Moves bfloat16 value to bfloat162
  */
-__device__ __hip_bfloat162 __bfloat162bfloat162(const __hip_bfloat16 a) {
+__device__ inline __hip_bfloat162 __bfloat162bfloat162(const __hip_bfloat16 a) {
   return __hip_bfloat162{a, a};
 }
 
@@ -218,13 +218,13 @@ __device__ __hip_bfloat162 __bfloat162bfloat162(const __hip_bfloat16 a) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_CONV
  * \brief Reinterprets bits in a __hip_bfloat16 as a signed short integer
  */
-__device__ short int __bfloat16_as_short(const __hip_bfloat16 h) { return (short)h.data; }
+__device__ inline short int __bfloat16_as_short(const __hip_bfloat16 h) { return (short)h.data; }
 
 /**
  * \ingroup HIP_INTRINSIC_BFLOAT162_CONV
  * \brief Reinterprets bits in a __hip_bfloat16 as an unsigned signed short integer
  */
-__device__ unsigned short int __bfloat16_as_ushort(const __hip_bfloat16 h) { return h.data; }
+__device__ inline unsigned short int __bfloat16_as_ushort(const __hip_bfloat16 h) { return h.data; }
 
 /**
  * \ingroup HIP_INTRINSIC_BFLOAT162_CONV
@@ -246,7 +246,7 @@ __HOST_DEVICE__ inline __hip_bfloat162 __float22bfloat162_rn(const float2 a) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_CONV
  * \brief Combine two __hip_bfloat16 to __hip_bfloat162
  */
-__device__ __hip_bfloat162 __halves2bfloat162(const __hip_bfloat16 a, const __hip_bfloat16 b) {
+__device__ inline __hip_bfloat162 __halves2bfloat162(const __hip_bfloat16 a, const __hip_bfloat16 b) {
   return __hip_bfloat162{a, b};
 }
 
@@ -254,13 +254,13 @@ __device__ __hip_bfloat162 __halves2bfloat162(const __hip_bfloat16 a, const __hi
  * \ingroup HIP_INTRINSIC_BFLOAT162_CONV
  * \brief Returns high 16 bits of __hip_bfloat162
  */
-__device__ __hip_bfloat16 __high2bfloat16(const __hip_bfloat162 a) { return a.y; }
+__device__ inline __hip_bfloat16 __high2bfloat16(const __hip_bfloat162 a) { return a.y; }
 
 /**
  * \ingroup HIP_INTRINSIC_BFLOAT162_CONV
  * \brief Returns high 16 bits of __hip_bfloat162
  */
-__device__ __hip_bfloat162 __high2bfloat162(const __hip_bfloat162 a) {
+__device__ inline __hip_bfloat162 __high2bfloat162(const __hip_bfloat162 a) {
   return __hip_bfloat162{a.y, a.y};
 }
 
@@ -274,7 +274,7 @@ __HOST_DEVICE__ inline float __high2float(const __hip_bfloat162 a) { return __bf
  * \ingroup HIP_INTRINSIC_BFLOAT162_CONV
  * \brief Extracts high 16 bits from each and combines them
  */
-__device__ __hip_bfloat162 __highs2bfloat162(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline __hip_bfloat162 __highs2bfloat162(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hip_bfloat162{a.y, b.y};
 }
 
@@ -282,13 +282,13 @@ __device__ __hip_bfloat162 __highs2bfloat162(const __hip_bfloat162 a, const __hi
  * \ingroup HIP_INTRINSIC_BFLOAT162_CONV
  * \brief Returns low 16 bits of __hip_bfloat162
  */
-__device__ __hip_bfloat16 __low2bfloat16(const __hip_bfloat162 a) { return a.x; }
+__device__ inline __hip_bfloat16 __low2bfloat16(const __hip_bfloat162 a) { return a.x; }
 
 /**
  * \ingroup HIP_INTRINSIC_BFLOAT162_CONV
  * \brief Returns low 16 bits of __hip_bfloat162
  */
-__device__ __hip_bfloat162 __low2bfloat162(const __hip_bfloat162 a) {
+__device__ inline __hip_bfloat162 __low2bfloat162(const __hip_bfloat162 a) {
   return __hip_bfloat162{a.x, a.x};
 }
 
@@ -302,7 +302,7 @@ __HOST_DEVICE__ inline float __low2float(const __hip_bfloat162 a) { return __bfl
  * \ingroup HIP_INTRINSIC_BFLOAT162_CONV
  * \brief Swaps both halves
  */
-__device__ __hip_bfloat162 __lowhigh2highlow(const __hip_bfloat162 a) {
+__device__ inline __hip_bfloat162 __lowhigh2highlow(const __hip_bfloat162 a) {
   return __hip_bfloat162{a.y, a.x};
 }
 
@@ -310,7 +310,7 @@ __device__ __hip_bfloat162 __lowhigh2highlow(const __hip_bfloat162 a) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_CONV
  * \brief Extracts low 16 bits from each and combines them
  */
-__device__ __hip_bfloat162 __lows2bfloat162(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline __hip_bfloat162 __lows2bfloat162(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hip_bfloat162{a.x, b.x};
 }
 
@@ -318,7 +318,7 @@ __device__ __hip_bfloat162 __lows2bfloat162(const __hip_bfloat162 a, const __hip
  * \ingroup HIP_INTRINSIC_BFLOAT162_CONV
  * \brief Reinterprets short int into a bfloat16
  */
-__device__ __hip_bfloat16 __short_as_bfloat16(const short int a) {
+__device__ inline __hip_bfloat16 __short_as_bfloat16(const short int a) {
   return __hip_bfloat16{(unsigned short)a};
 }
 
@@ -326,7 +326,7 @@ __device__ __hip_bfloat16 __short_as_bfloat16(const short int a) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_CONV
  * \brief Reinterprets unsigned short int into a bfloat16
  */
-__device__ __hip_bfloat16 __ushort_as_bfloat16(const unsigned short int a) {
+__device__ inline __hip_bfloat16 __ushort_as_bfloat16(const unsigned short int a) {
   return __hip_bfloat16{a};
 }
 
@@ -335,7 +335,7 @@ __device__ __hip_bfloat16 __ushort_as_bfloat16(const unsigned short int a) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_ARITH
  * \brief Adds two bfloat16 values
  */
-__device__ __hip_bfloat16 __hadd(const __hip_bfloat16 a, const __hip_bfloat16 b) {
+__device__ inline __hip_bfloat16 __hadd(const __hip_bfloat16 a, const __hip_bfloat16 b) {
   return __float2bfloat16(__bfloat162float(a) + __bfloat162float(b));
 }
 
@@ -343,7 +343,7 @@ __device__ __hip_bfloat16 __hadd(const __hip_bfloat16 a, const __hip_bfloat16 b)
  * \ingroup HIP_INTRINSIC_BFLOAT16_ARITH
  * \brief Subtracts two bfloat16 values
  */
-__device__ __hip_bfloat16 __hsub(const __hip_bfloat16 a, const __hip_bfloat16 b) {
+__device__ inline __hip_bfloat16 __hsub(const __hip_bfloat16 a, const __hip_bfloat16 b) {
   return __float2bfloat16(__bfloat162float(a) - __bfloat162float(b));
 }
 
@@ -351,7 +351,7 @@ __device__ __hip_bfloat16 __hsub(const __hip_bfloat16 a, const __hip_bfloat16 b)
  * \ingroup HIP_INTRINSIC_BFLOAT16_ARITH
  * \brief Divides two bfloat16 values
  */
-__device__ __hip_bfloat16 __hdiv(const __hip_bfloat16 a, const __hip_bfloat16 b) {
+__device__ inline __hip_bfloat16 __hdiv(const __hip_bfloat16 a, const __hip_bfloat16 b) {
   return __float2bfloat16(__bfloat162float(a) / __bfloat162float(b));
 }
 
@@ -359,7 +359,7 @@ __device__ __hip_bfloat16 __hdiv(const __hip_bfloat16 a, const __hip_bfloat16 b)
  * \ingroup HIP_INTRINSIC_BFLOAT16_ARITH
  * \brief Performs FMA of given bfloat16 values
  */
-__device__ __hip_bfloat16 __hfma(const __hip_bfloat16 a, const __hip_bfloat16 b,
+__device__ inline __hip_bfloat16 __hfma(const __hip_bfloat16 a, const __hip_bfloat16 b,
                                  const __hip_bfloat16 c) {
   return __float2bfloat16(
       fmaf(__bfloat162float(a), __bfloat162float(b), __bfloat162float(c)));
@@ -369,7 +369,7 @@ __device__ __hip_bfloat16 __hfma(const __hip_bfloat16 a, const __hip_bfloat16 b,
  * \ingroup HIP_INTRINSIC_BFLOAT16_ARITH
  * \brief Multiplies two bfloat16 values
  */
-__device__ __hip_bfloat16 __hmul(const __hip_bfloat16 a, const __hip_bfloat16 b) {
+__device__ inline __hip_bfloat16 __hmul(const __hip_bfloat16 a, const __hip_bfloat16 b) {
   return __float2bfloat16(__bfloat162float(a) * __bfloat162float(b));
 }
 
@@ -377,7 +377,7 @@ __device__ __hip_bfloat16 __hmul(const __hip_bfloat16 a, const __hip_bfloat16 b)
  * \ingroup HIP_INTRINSIC_BFLOAT16_ARITH
  * \brief Negate a bfloat16 value
  */
-__device__ __hip_bfloat16 __hneg(const __hip_bfloat16 a) {
+__device__ inline __hip_bfloat16 __hneg(const __hip_bfloat16 a) {
   auto ret = a;
   ret.data ^= 0x8000;
   return ret;
@@ -387,7 +387,7 @@ __device__ __hip_bfloat16 __hneg(const __hip_bfloat16 a) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_ARITH
  * \brief Returns absolute of a bfloat16
  */
-__device__ __hip_bfloat16 __habs(const __hip_bfloat16 a) {
+__device__ inline __hip_bfloat16 __habs(const __hip_bfloat16 a) {
   auto ret = a;
   ret.data &= 0x7FFF;
   return ret;
@@ -397,7 +397,7 @@ __device__ __hip_bfloat16 __habs(const __hip_bfloat16 a) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_ARITH
  * \brief Divides bfloat162 values
  */
-__device__ __hip_bfloat162 __h2div(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline __hip_bfloat162 __h2div(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hip_bfloat162{__float2bfloat16(__bfloat162float(a.x) / __bfloat162float(b.x)),
                          __float2bfloat16(__bfloat162float(a.y) / __bfloat162float(b.y))};
 }
@@ -406,7 +406,7 @@ __device__ __hip_bfloat162 __h2div(const __hip_bfloat162 a, const __hip_bfloat16
  * \ingroup HIP_INTRINSIC_BFLOAT162_ARITH
  * \brief Returns absolute of a bfloat162
  */
-__device__ __hip_bfloat162 __habs2(const __hip_bfloat162 a) {
+__device__ inline __hip_bfloat162 __habs2(const __hip_bfloat162 a) {
   return __hip_bfloat162{__habs(a.x), __habs(a.y)};
 }
 
@@ -414,7 +414,7 @@ __device__ __hip_bfloat162 __habs2(const __hip_bfloat162 a) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_ARITH
  * \brief Adds two bfloat162 values
  */
-__device__ __hip_bfloat162 __hadd2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline __hip_bfloat162 __hadd2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hip_bfloat162{__hadd(a.x, b.x), __hadd(a.y, b.y)};
 }
 
@@ -422,7 +422,7 @@ __device__ __hip_bfloat162 __hadd2(const __hip_bfloat162 a, const __hip_bfloat16
  * \ingroup HIP_INTRINSIC_BFLOAT162_ARITH
  * \brief Performs FMA of given bfloat162 values
  */
-__device__ __hip_bfloat162 __hfma2(const __hip_bfloat162 a, const __hip_bfloat162 b,
+__device__ inline __hip_bfloat162 __hfma2(const __hip_bfloat162 a, const __hip_bfloat162 b,
                                    const __hip_bfloat162 c) {
   return __hip_bfloat162{__hfma(a.x, b.x, c.x), __hfma(a.y, b.y, c.y)};
 }
@@ -431,7 +431,7 @@ __device__ __hip_bfloat162 __hfma2(const __hip_bfloat162 a, const __hip_bfloat16
  * \ingroup HIP_INTRINSIC_BFLOAT162_ARITH
  * \brief Multiplies two bfloat162 values
  */
-__device__ __hip_bfloat162 __hmul2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline __hip_bfloat162 __hmul2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hip_bfloat162{__hmul(a.x, b.x), __hmul(a.y, b.y)};
 }
 
@@ -439,7 +439,7 @@ __device__ __hip_bfloat162 __hmul2(const __hip_bfloat162 a, const __hip_bfloat16
  * \ingroup HIP_INTRINSIC_BFLOAT162_ARITH
  * \brief Converts a bfloat162 into negative
  */
-__device__ __hip_bfloat162 __hneg2(const __hip_bfloat162 a) {
+__device__ inline __hip_bfloat162 __hneg2(const __hip_bfloat162 a) {
   return __hip_bfloat162{__hneg(a.x), __hneg(a.y)};
 }
 
@@ -447,7 +447,7 @@ __device__ __hip_bfloat162 __hneg2(const __hip_bfloat162 a) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_ARITH
  * \brief Subtracts two bfloat162 values
  */
-__device__ __hip_bfloat162 __hsub2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline __hip_bfloat162 __hsub2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hip_bfloat162{__hsub(a.x, b.x), __hsub(a.y, b.y)};
 }
 
@@ -455,7 +455,7 @@ __device__ __hip_bfloat162 __hsub2(const __hip_bfloat162 a, const __hip_bfloat16
  * \ingroup HIP_INTRINSIC_BFLOAT16_COMP
  * \brief Compare two bfloat162 values
  */
-__device__ bool __heq(const __hip_bfloat16 a, const __hip_bfloat16 b) {
+__device__ inline bool __heq(const __hip_bfloat16 a, const __hip_bfloat16 b) {
   return __bfloat162float(a) == __bfloat162float(b);
 }
 
@@ -463,7 +463,7 @@ __device__ bool __heq(const __hip_bfloat16 a, const __hip_bfloat16 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_COMP
  * \brief Compare two bfloat162 values - unordered equal
  */
-__device__ bool __hequ(const __hip_bfloat16 a, const __hip_bfloat16 b) {
+__device__ inline bool __hequ(const __hip_bfloat16 a, const __hip_bfloat16 b) {
   return !(__bfloat162float(a) < __bfloat162float(b)) &&
       !(__bfloat162float(a) > __bfloat162float(b));
 }
@@ -472,7 +472,7 @@ __device__ bool __hequ(const __hip_bfloat16 a, const __hip_bfloat16 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_COMP
  * \brief Compare two bfloat162 values - greater than
  */
-__device__ bool __hgt(const __hip_bfloat16 a, const __hip_bfloat16 b) {
+__device__ inline bool __hgt(const __hip_bfloat16 a, const __hip_bfloat16 b) {
   return __bfloat162float(a) > __bfloat162float(b);
 }
 
@@ -480,7 +480,7 @@ __device__ bool __hgt(const __hip_bfloat16 a, const __hip_bfloat16 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_COMP
  * \brief Compare two bfloat162 values - unordered greater than
  */
-__device__ bool __hgtu(const __hip_bfloat16 a, const __hip_bfloat16 b) {
+__device__ inline bool __hgtu(const __hip_bfloat16 a, const __hip_bfloat16 b) {
   return !(__bfloat162float(a) <= __bfloat162float(b));
 }
 
@@ -488,7 +488,7 @@ __device__ bool __hgtu(const __hip_bfloat16 a, const __hip_bfloat16 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_COMP
  * \brief Compare two bfloat162 values - greater than equal
  */
-__device__ bool __hge(const __hip_bfloat16 a, const __hip_bfloat16 b) {
+__device__ inline bool __hge(const __hip_bfloat16 a, const __hip_bfloat16 b) {
   return __bfloat162float(a) >= __bfloat162float(b);
 }
 
@@ -496,7 +496,7 @@ __device__ bool __hge(const __hip_bfloat16 a, const __hip_bfloat16 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_COMP
  * \brief Compare two bfloat162 values - unordered greater than equal
  */
-__device__ bool __hgeu(const __hip_bfloat16 a, const __hip_bfloat16 b) {
+__device__ inline bool __hgeu(const __hip_bfloat16 a, const __hip_bfloat16 b) {
   return !(__bfloat162float(a) < __bfloat162float(b));
 }
 
@@ -504,7 +504,7 @@ __device__ bool __hgeu(const __hip_bfloat16 a, const __hip_bfloat16 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_COMP
  * \brief Compare two bfloat162 values - not equal
  */
-__device__ bool __hne(const __hip_bfloat16 a, const __hip_bfloat16 b) {
+__device__ inline bool __hne(const __hip_bfloat16 a, const __hip_bfloat16 b) {
   return __bfloat162float(a) != __bfloat162float(b);
 }
 
@@ -512,7 +512,7 @@ __device__ bool __hne(const __hip_bfloat16 a, const __hip_bfloat16 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_COMP
  * \brief Compare two bfloat162 values - unordered not equal
  */
-__device__ bool __hneu(const __hip_bfloat16 a, const __hip_bfloat16 b) {
+__device__ inline bool __hneu(const __hip_bfloat16 a, const __hip_bfloat16 b) {
   return !(__bfloat162float(a) == __bfloat162float(b));
 }
 
@@ -520,7 +520,7 @@ __device__ bool __hneu(const __hip_bfloat16 a, const __hip_bfloat16 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_COMP
  * \brief Compare two bfloat162 values - return max
  */
-__device__ __hip_bfloat16 __hmax(const __hip_bfloat16 a, const __hip_bfloat16 b) {
+__device__ inline __hip_bfloat16 __hmax(const __hip_bfloat16 a, const __hip_bfloat16 b) {
   return __float2bfloat16(fmaxf(__bfloat162float(a), __bfloat162float(b)));
 }
 
@@ -528,7 +528,7 @@ __device__ __hip_bfloat16 __hmax(const __hip_bfloat16 a, const __hip_bfloat16 b)
  * \ingroup HIP_INTRINSIC_BFLOAT16_COMP
  * \brief Compare two bfloat162 values - return min
  */
-__device__ __hip_bfloat16 __hmin(const __hip_bfloat16 a, const __hip_bfloat16 b) {
+__device__ inline __hip_bfloat16 __hmin(const __hip_bfloat16 a, const __hip_bfloat16 b) {
   return __float2bfloat16(fminf(__bfloat162float(a), __bfloat162float(b)));
 }
 
@@ -536,7 +536,7 @@ __device__ __hip_bfloat16 __hmin(const __hip_bfloat16 a, const __hip_bfloat16 b)
  * \ingroup HIP_INTRINSIC_BFLOAT16_COMP
  * \brief Compare two bfloat162 values - less than operator
  */
-__device__ bool __hlt(const __hip_bfloat16 a, const __hip_bfloat16 b) {
+__device__ inline bool __hlt(const __hip_bfloat16 a, const __hip_bfloat16 b) {
   return __bfloat162float(a) < __bfloat162float(b);
 }
 
@@ -544,7 +544,7 @@ __device__ bool __hlt(const __hip_bfloat16 a, const __hip_bfloat16 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_COMP
  * \brief Compare two bfloat162 values - unordered less than
  */
-__device__ bool __hltu(const __hip_bfloat16 a, const __hip_bfloat16 b) {
+__device__ inline bool __hltu(const __hip_bfloat16 a, const __hip_bfloat16 b) {
   return !(__bfloat162float(a) >= __bfloat162float(b));
 }
 
@@ -552,7 +552,7 @@ __device__ bool __hltu(const __hip_bfloat16 a, const __hip_bfloat16 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_COMP
  * \brief Compare two bfloat162 values - less than
  */
-__device__ bool __hle(const __hip_bfloat16 a, const __hip_bfloat16 b) {
+__device__ inline bool __hle(const __hip_bfloat16 a, const __hip_bfloat16 b) {
   return __bfloat162float(a) <= __bfloat162float(b);
 }
 
@@ -560,7 +560,7 @@ __device__ bool __hle(const __hip_bfloat16 a, const __hip_bfloat16 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_COMP
  * \brief Compare two bfloat162 values - unordered less than equal
  */
-__device__ bool __hleu(const __hip_bfloat16 a, const __hip_bfloat16 b) {
+__device__ inline bool __hleu(const __hip_bfloat16 a, const __hip_bfloat16 b) {
   return !(__bfloat162float(a) > __bfloat162float(b));
 }
 
@@ -568,19 +568,19 @@ __device__ bool __hleu(const __hip_bfloat16 a, const __hip_bfloat16 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_COMP
  * \brief Checks if number is inf
  */
-__device__ int __hisinf(const __hip_bfloat16 a) { return isinf(__bfloat162float(a)); }
+__device__ inline int __hisinf(const __hip_bfloat16 a) { return isinf(__bfloat162float(a)); }
 
 /**
  * \ingroup HIP_INTRINSIC_BFLOAT16_COMP
  * \brief Checks if number is nan
  */
-__device__ bool __hisnan(const __hip_bfloat16 a) { return isnan(__bfloat162float(a)); }
+__device__ inline bool __hisnan(const __hip_bfloat16 a) { return isnan(__bfloat162float(a)); }
 
 /**
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
  * \brief Checks if two numbers are equal
  */
-__device__ bool __hbeq2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline bool __hbeq2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __heq(a.x, b.x) && __heq(a.y, b.y);
 }
 
@@ -588,7 +588,7 @@ __device__ bool __hbeq2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
  * \brief Checks if two numbers are equal - unordered
  */
-__device__ bool __hbequ2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline bool __hbequ2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hequ(a.x, b.x) && __hequ(a.y, b.y);
 }
 
@@ -596,7 +596,7 @@ __device__ bool __hbequ2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
  * \brief Check for a >= b
  */
-__device__ bool __hbge2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline bool __hbge2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hge(a.x, b.x) && __hge(a.y, b.y);
 }
 
@@ -604,7 +604,7 @@ __device__ bool __hbge2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
  * \brief Check for a >= b - unordered
  */
-__device__ bool __hbgeu2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline bool __hbgeu2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hgeu(a.x, b.x) && __hgeu(a.y, b.y);
 }
 
@@ -612,7 +612,7 @@ __device__ bool __hbgeu2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
  * \brief Check for a > b
  */
-__device__ bool __hbgt2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline bool __hbgt2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hgt(a.x, b.x) && __hgt(a.y, b.y);
 }
 
@@ -620,7 +620,7 @@ __device__ bool __hbgt2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
  * \brief Check for a > b - unordered
  */
-__device__ bool __hbgtu2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline bool __hbgtu2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hgtu(a.x, b.x) && __hgtu(a.y, b.y);
 }
 
@@ -628,7 +628,7 @@ __device__ bool __hbgtu2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
  * \brief Check for a <= b
  */
-__device__ bool __hble2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline bool __hble2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hle(a.x, b.x) && __hle(a.y, b.y);
 }
 
@@ -636,7 +636,7 @@ __device__ bool __hble2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
  * \brief Check for a <= b - unordered
  */
-__device__ bool __hbleu2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline bool __hbleu2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hleu(a.x, b.x) && __hleu(a.y, b.y);
 }
 
@@ -644,7 +644,7 @@ __device__ bool __hbleu2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
  * \brief Check for a < b
  */
-__device__ bool __hblt2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline bool __hblt2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hlt(a.x, b.x) && __hlt(a.y, b.y);
 }
 
@@ -652,7 +652,7 @@ __device__ bool __hblt2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
  * \brief Check for a < b - unordered
  */
-__device__ bool __hbltu2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline bool __hbltu2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hltu(a.x, b.x) && __hltu(a.y, b.y);
 }
 
@@ -660,7 +660,7 @@ __device__ bool __hbltu2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
  * \brief Check for a != b
  */
-__device__ bool __hbne2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline bool __hbne2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hne(a.x, b.x) && __hne(a.y, b.y);
 }
 
@@ -668,7 +668,7 @@ __device__ bool __hbne2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
  * \brief Check for a != b
  */
-__device__ bool __hbneu2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline bool __hbneu2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hneu(a.x, b.x) && __hneu(a.y, b.y);
 }
 
@@ -676,7 +676,7 @@ __device__ bool __hbneu2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
  * \brief Check for a != b, returns 1.0 if equal, otherwise 0.0
  */
-__device__ __hip_bfloat162 __heq2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline __hip_bfloat162 __heq2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hip_bfloat162{{__heq(a.x, b.x) ? __float2bfloat16(1.0f) : __float2bfloat16(0.0f)},
                          {__heq(a.y, b.y) ? __float2bfloat16(1.0f) : __float2bfloat16(0.0f)}};
 }
@@ -685,7 +685,7 @@ __device__ __hip_bfloat162 __heq2(const __hip_bfloat162 a, const __hip_bfloat162
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
  * \brief Check for a >= b, returns 1.0 if greater than equal, otherwise 0.0
  */
-__device__ __hip_bfloat162 __hge2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline __hip_bfloat162 __hge2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hip_bfloat162{{__hge(a.x, b.x) ? __float2bfloat16(1.0f) : __float2bfloat16(0.0f)},
                          {__hge(a.y, b.y) ? __float2bfloat16(1.0f) : __float2bfloat16(0.0f)}};
 }
@@ -694,7 +694,7 @@ __device__ __hip_bfloat162 __hge2(const __hip_bfloat162 a, const __hip_bfloat162
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
  * \brief Check for a > b, returns 1.0 if greater than equal, otherwise 0.0
  */
-__device__ __hip_bfloat162 __hgt2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline __hip_bfloat162 __hgt2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hip_bfloat162{{__hgt(a.x, b.x) ? __float2bfloat16(1.0f) : __float2bfloat16(0.0f)},
                          {__hgt(a.y, b.y) ? __float2bfloat16(1.0f) : __float2bfloat16(0.0f)}};
 }
@@ -703,7 +703,7 @@ __device__ __hip_bfloat162 __hgt2(const __hip_bfloat162 a, const __hip_bfloat162
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
  * \brief Check for a is NaN, returns 1.0 if NaN, otherwise 0.0
  */
-__device__ __hip_bfloat162 __hisnan2(const __hip_bfloat162 a) {
+__device__ inline __hip_bfloat162 __hisnan2(const __hip_bfloat162 a) {
   return __hip_bfloat162{
       {isnan(__bfloat162float(a.x)) ? __float2bfloat16(1.0f) : __float2bfloat16(0.0f)},
       {isnan(__bfloat162float(a.y)) ? __float2bfloat16(1.0f) : __float2bfloat16(0.0f)}};
@@ -713,7 +713,7 @@ __device__ __hip_bfloat162 __hisnan2(const __hip_bfloat162 a) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
  * \brief Check for a <= b, returns 1.0 if greater than equal, otherwise 0.0
  */
-__device__ __hip_bfloat162 __hle2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline __hip_bfloat162 __hle2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hip_bfloat162{{__hle(a.x, b.x) ? __float2bfloat16(1.0f) : __float2bfloat16(0.0f)},
                          {__hle(a.y, b.y) ? __float2bfloat16(1.0f) : __float2bfloat16(0.0f)}};
 }
@@ -722,7 +722,7 @@ __device__ __hip_bfloat162 __hle2(const __hip_bfloat162 a, const __hip_bfloat162
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
  * \brief Check for a < b, returns 1.0 if greater than equal, otherwise 0.0
  */
-__device__ __hip_bfloat162 __hlt2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline __hip_bfloat162 __hlt2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hip_bfloat162{{__hlt(a.x, b.x) ? __float2bfloat16(1.0f) : __float2bfloat16(0.0f)},
                          {__hlt(a.y, b.y) ? __float2bfloat16(1.0f) : __float2bfloat16(0.0f)}};
 }
@@ -731,7 +731,7 @@ __device__ __hip_bfloat162 __hlt2(const __hip_bfloat162 a, const __hip_bfloat162
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
  * \brief Returns max of two elements
  */
-__device__ __hip_bfloat162 __hmax2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline __hip_bfloat162 __hmax2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hip_bfloat162{
       __float2bfloat16(fmaxf(__bfloat162float(a.x), __bfloat162float(b.x))),
       __float2bfloat16(fmaxf(__bfloat162float(a.y), __bfloat162float(b.y)))};
@@ -741,7 +741,7 @@ __device__ __hip_bfloat162 __hmax2(const __hip_bfloat162 a, const __hip_bfloat16
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
  * \brief Returns min of two elements
  */
-__device__ __hip_bfloat162 __hmin2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline __hip_bfloat162 __hmin2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hip_bfloat162{
       __float2bfloat16(fminf(__bfloat162float(a.x), __bfloat162float(b.x))),
       __float2bfloat16(fminf(__bfloat162float(a.y), __bfloat162float(b.y)))};
@@ -751,7 +751,7 @@ __device__ __hip_bfloat162 __hmin2(const __hip_bfloat162 a, const __hip_bfloat16
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
  * \brief Checks for not equal to
  */
-__device__ __hip_bfloat162 __hne2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
+__device__ inline __hip_bfloat162 __hne2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hip_bfloat162{{__hne(a.x, b.x) ? __float2bfloat16(1.0f) : __float2bfloat16(0.0f)},
                          {__hne(a.y, b.y) ? __float2bfloat16(1.0f) : __float2bfloat16(0.0f)}};
 }
@@ -760,7 +760,7 @@ __device__ __hip_bfloat162 __hne2(const __hip_bfloat162 a, const __hip_bfloat162
  * \ingroup HIP_INTRINSIC_BFLOAT16_MATH
  * \brief Calculate ceil of bfloat16
  */
-__device__ __hip_bfloat16 hceil(const __hip_bfloat16 h) {
+__device__ inline __hip_bfloat16 hceil(const __hip_bfloat16 h) {
   return __float2bfloat16(ceilf(__bfloat162float(h)));
 }
 
@@ -768,7 +768,7 @@ __device__ __hip_bfloat16 hceil(const __hip_bfloat16 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_MATH
  * \brief Calculate cosine of bfloat16
  */
-__device__ __hip_bfloat16 hcos(const __hip_bfloat16 h) {
+__device__ inline __hip_bfloat16 hcos(const __hip_bfloat16 h) {
   return __float2bfloat16(cosf(__bfloat162float(h)));
 }
 
@@ -776,7 +776,7 @@ __device__ __hip_bfloat16 hcos(const __hip_bfloat16 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_MATH
  * \brief Calculate exponential of bfloat16
  */
-__device__ __hip_bfloat16 hexp(const __hip_bfloat16 h) {
+__device__ inline __hip_bfloat16 hexp(const __hip_bfloat16 h) {
   return __float2bfloat16(expf(__bfloat162float(h)));
 }
 
@@ -784,7 +784,7 @@ __device__ __hip_bfloat16 hexp(const __hip_bfloat16 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_MATH
  * \brief Calculate exponential 10 of bfloat16
  */
-__device__ __hip_bfloat16 hexp10(const __hip_bfloat16 h) {
+__device__ inline __hip_bfloat16 hexp10(const __hip_bfloat16 h) {
   return __float2bfloat16(exp10f(__bfloat162float(h)));
 }
 
@@ -792,7 +792,7 @@ __device__ __hip_bfloat16 hexp10(const __hip_bfloat16 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_MATH
  * \brief Calculate exponential 2 of bfloat16
  */
-__device__ __hip_bfloat16 hexp2(const __hip_bfloat16 h) {
+__device__ inline __hip_bfloat16 hexp2(const __hip_bfloat16 h) {
   return __float2bfloat16(exp2f(__bfloat162float(h)));
 }
 
@@ -800,7 +800,7 @@ __device__ __hip_bfloat16 hexp2(const __hip_bfloat16 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_MATH
  * \brief Calculate floor of bfloat16
  */
-__device__ __hip_bfloat16 hfloor(const __hip_bfloat16 h) {
+__device__ inline __hip_bfloat16 hfloor(const __hip_bfloat16 h) {
   return __float2bfloat16(floorf(__bfloat162float(h)));
 }
 
@@ -808,7 +808,7 @@ __device__ __hip_bfloat16 hfloor(const __hip_bfloat16 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_MATH
  * \brief Calculate natural log of bfloat16
  */
-__device__ __hip_bfloat16 hlog(const __hip_bfloat16 h) {
+__device__ inline __hip_bfloat16 hlog(const __hip_bfloat16 h) {
   return __float2bfloat16(logf(__bfloat162float(h)));
 }
 
@@ -816,7 +816,7 @@ __device__ __hip_bfloat16 hlog(const __hip_bfloat16 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_MATH
  * \brief Calculate log 10 of bfloat16
  */
-__device__ __hip_bfloat16 hlog10(const __hip_bfloat16 h) {
+__device__ inline __hip_bfloat16 hlog10(const __hip_bfloat16 h) {
   return __float2bfloat16(log10f(__bfloat162float(h)));
 }
 
@@ -824,7 +824,7 @@ __device__ __hip_bfloat16 hlog10(const __hip_bfloat16 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_MATH
  * \brief Calculate log 2 of bfloat16
  */
-__device__ __hip_bfloat16 hlog2(const __hip_bfloat16 h) {
+__device__ inline __hip_bfloat16 hlog2(const __hip_bfloat16 h) {
   return __float2bfloat16(log2f(__bfloat162float(h)));
 }
 
@@ -832,7 +832,7 @@ __device__ __hip_bfloat16 hlog2(const __hip_bfloat16 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_MATH
  * \brief Calculate reciprocal
  */
-__device__ __hip_bfloat16 hrcp(const __hip_bfloat16 h) {
+__device__ inline __hip_bfloat16 hrcp(const __hip_bfloat16 h) {
   return __float2bfloat16(1.0f / (__bfloat162float(h)));
 }
 
@@ -840,7 +840,7 @@ __device__ __hip_bfloat16 hrcp(const __hip_bfloat16 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_MATH
  * \brief Round to nearest int
  */
-__device__ __hip_bfloat16 hrint(const __hip_bfloat16 h) {
+__device__ inline __hip_bfloat16 hrint(const __hip_bfloat16 h) {
   return __float2bfloat16(rintf(__bfloat162float(h)));
 }
 
@@ -848,7 +848,7 @@ __device__ __hip_bfloat16 hrint(const __hip_bfloat16 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_MATH
  * \brief Reciprocal square root
  */
-__device__ __hip_bfloat16 hrsqrt(const __hip_bfloat16 h) {
+__device__ inline __hip_bfloat16 hrsqrt(const __hip_bfloat16 h) {
   return __float2bfloat16(rsqrtf(__bfloat162float(h)));
 }
 
@@ -856,7 +856,7 @@ __device__ __hip_bfloat16 hrsqrt(const __hip_bfloat16 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_MATH
  * \brief Calculate sin of bfloat16
  */
-__device__ __hip_bfloat16 hsin(const __hip_bfloat16 h) {
+__device__ inline __hip_bfloat16 hsin(const __hip_bfloat16 h) {
   return __float2bfloat16(sinf(__bfloat162float(h)));
 }
 
@@ -864,7 +864,7 @@ __device__ __hip_bfloat16 hsin(const __hip_bfloat16 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_MATH
  * \brief Calculate sqrt of bfloat16
  */
-__device__ __hip_bfloat16 hsqrt(const __hip_bfloat16 h) {
+__device__ inline __hip_bfloat16 hsqrt(const __hip_bfloat16 h) {
   return __float2bfloat16(sqrtf(__bfloat162float(h)));
 }
 
@@ -872,7 +872,7 @@ __device__ __hip_bfloat16 hsqrt(const __hip_bfloat16 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT16_MATH
  * \brief Calculate truncate of bfloat16
  */
-__device__ __hip_bfloat16 htrunc(const __hip_bfloat16 h) {
+__device__ inline __hip_bfloat16 htrunc(const __hip_bfloat16 h) {
   return __float2bfloat16(truncf(__bfloat162float(h)));
 }
 
@@ -880,7 +880,7 @@ __device__ __hip_bfloat16 htrunc(const __hip_bfloat16 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_MATH
  * \brief Calculate ceil of bfloat162
  */
-__device__ __hip_bfloat162 h2ceil(const __hip_bfloat162 h) {
+__device__ inline __hip_bfloat162 h2ceil(const __hip_bfloat162 h) {
   return __hip_bfloat162{hceil(h.x), hceil(h.y)};
 }
 
@@ -888,7 +888,7 @@ __device__ __hip_bfloat162 h2ceil(const __hip_bfloat162 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_MATH
  * \brief Calculate cosine of bfloat162
  */
-__device__ __hip_bfloat162 h2cos(const __hip_bfloat162 h) {
+__device__ inline __hip_bfloat162 h2cos(const __hip_bfloat162 h) {
   return __hip_bfloat162{hcos(h.x), hcos(h.y)};
 }
 
@@ -896,7 +896,7 @@ __device__ __hip_bfloat162 h2cos(const __hip_bfloat162 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_MATH
  * \brief Calculate exponential of bfloat162
  */
-__device__ __hip_bfloat162 h2exp(const __hip_bfloat162 h) {
+__device__ inline __hip_bfloat162 h2exp(const __hip_bfloat162 h) {
   return __hip_bfloat162{hexp(h.x), hexp(h.y)};
 }
 
@@ -904,7 +904,7 @@ __device__ __hip_bfloat162 h2exp(const __hip_bfloat162 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_MATH
  * \brief Calculate exponential 10 of bfloat162
  */
-__device__ __hip_bfloat162 h2exp10(const __hip_bfloat162 h) {
+__device__ inline __hip_bfloat162 h2exp10(const __hip_bfloat162 h) {
   return __hip_bfloat162{hexp10(h.x), hexp10(h.y)};
 }
 
@@ -912,7 +912,7 @@ __device__ __hip_bfloat162 h2exp10(const __hip_bfloat162 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_MATH
  * \brief Calculate exponential 2 of bfloat162
  */
-__device__ __hip_bfloat162 h2exp2(const __hip_bfloat162 h) {
+__device__ inline __hip_bfloat162 h2exp2(const __hip_bfloat162 h) {
   return __hip_bfloat162{hexp2(h.x), hexp2(h.y)};
 }
 
@@ -920,7 +920,7 @@ __device__ __hip_bfloat162 h2exp2(const __hip_bfloat162 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_MATH
  * \brief Calculate floor of bfloat162
  */
-__device__ __hip_bfloat162 h2floor(const __hip_bfloat162 h) {
+__device__ inline __hip_bfloat162 h2floor(const __hip_bfloat162 h) {
   return __hip_bfloat162{hfloor(h.x), hfloor(h.y)};
 }
 
@@ -928,7 +928,7 @@ __device__ __hip_bfloat162 h2floor(const __hip_bfloat162 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_MATH
  * \brief Calculate natural log of bfloat162
  */
-__device__ __hip_bfloat162 h2log(const __hip_bfloat162 h) {
+__device__ inline __hip_bfloat162 h2log(const __hip_bfloat162 h) {
   return __hip_bfloat162{hlog(h.x), hlog(h.y)};
 }
 
@@ -936,7 +936,7 @@ __device__ __hip_bfloat162 h2log(const __hip_bfloat162 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_MATH
  * \brief Calculate log 10 of bfloat162
  */
-__device__ __hip_bfloat162 h2log10(const __hip_bfloat162 h) {
+__device__ inline __hip_bfloat162 h2log10(const __hip_bfloat162 h) {
   return __hip_bfloat162{hlog10(h.x), hlog10(h.y)};
 }
 
@@ -944,7 +944,7 @@ __device__ __hip_bfloat162 h2log10(const __hip_bfloat162 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_MATH
  * \brief Calculate log 2 of bfloat162
  */
-__device__ __hip_bfloat162 h2log2(const __hip_bfloat162 h) {
+__device__ inline __hip_bfloat162 h2log2(const __hip_bfloat162 h) {
   return __hip_bfloat162{hlog2(h.x), hlog2(h.y)};
 }
 
@@ -952,7 +952,7 @@ __device__ __hip_bfloat162 h2log2(const __hip_bfloat162 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_MATH
  * \brief Calculate vector reciprocal
  */
-__device__ __hip_bfloat162 h2rcp(const __hip_bfloat162 h) {
+__device__ inline __hip_bfloat162 h2rcp(const __hip_bfloat162 h) {
   return __hip_bfloat162{hrcp(h.x), hrcp(h.y)};
 }
 
@@ -960,7 +960,7 @@ __device__ __hip_bfloat162 h2rcp(const __hip_bfloat162 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_MATH
  * \brief Calculate vector round to nearest int
  */
-__device__ __hip_bfloat162 h2rint(const __hip_bfloat162 h) {
+__device__ inline __hip_bfloat162 h2rint(const __hip_bfloat162 h) {
   return __hip_bfloat162{hrint(h.x), hrint(h.y)};
 }
 
@@ -968,7 +968,7 @@ __device__ __hip_bfloat162 h2rint(const __hip_bfloat162 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_MATH
  * \brief Calculate vector reciprocal square root
  */
-__device__ __hip_bfloat162 h2rsqrt(const __hip_bfloat162 h) {
+__device__ inline __hip_bfloat162 h2rsqrt(const __hip_bfloat162 h) {
   return __hip_bfloat162{hrsqrt(h.x), hrsqrt(h.y)};
 }
 
@@ -976,7 +976,7 @@ __device__ __hip_bfloat162 h2rsqrt(const __hip_bfloat162 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_MATH
  * \brief Calculate sin of bfloat162
  */
-__device__ __hip_bfloat162 h2sin(const __hip_bfloat162 h) {
+__device__ inline __hip_bfloat162 h2sin(const __hip_bfloat162 h) {
   return __hip_bfloat162{hsin(h.x), hsin(h.y)};
 }
 
@@ -984,7 +984,7 @@ __device__ __hip_bfloat162 h2sin(const __hip_bfloat162 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_MATH
  * \brief Calculate sqrt of bfloat162
  */
-__device__ __hip_bfloat162 h2sqrt(const __hip_bfloat162 h) {
+__device__ inline __hip_bfloat162 h2sqrt(const __hip_bfloat162 h) {
   return __hip_bfloat162{hsqrt(h.x), hsqrt(h.y)};
 }
 
@@ -992,58 +992,58 @@ __device__ __hip_bfloat162 h2sqrt(const __hip_bfloat162 h) {
  * \ingroup HIP_INTRINSIC_BFLOAT162_MATH
  * \brief Calculate truncate of bfloat162
  */
-__device__ __hip_bfloat162 h2trunc(const __hip_bfloat162 h) {
+__device__ inline __hip_bfloat162 h2trunc(const __hip_bfloat162 h) {
   return __hip_bfloat162{htrunc(h.x), htrunc(h.y)};
 }
 
 // Conversion functions with specific rounding modes
-__device__ int __bfloat162int_rd(const __hip_bfloat16 h) {
+__device__ inline int __bfloat162int_rd(const __hip_bfloat16 h) {
   return static_cast<int>(floorf(__bfloat162float(h)));
 }
 
-__device__ int __bfloat162int_rn(const __hip_bfloat16 h) {
+__device__ inline int __bfloat162int_rn(const __hip_bfloat16 h) {
   return static_cast<int>(roundf(__bfloat162float(h)));
 }
 
-__device__ int __bfloat162int_ru(const __hip_bfloat16 h) {
+__device__ inline int __bfloat162int_ru(const __hip_bfloat16 h) {
   return static_cast<int>(ceilf(__bfloat162float(h)));
 }
 
 // Conversion functions for 64-bit integers
-__device__ long long int __bfloat162ll_rd(const __hip_bfloat16 h) {
+__device__ inline long long int __bfloat162ll_rd(const __hip_bfloat16 h) {
   return static_cast<long long int>(floorf(__bfloat162float(h)));
 }
 
-__device__ long long int __bfloat162ll_rn(const __hip_bfloat16 h) {
+__device__ inline long long int __bfloat162ll_rn(const __hip_bfloat16 h) {
   return static_cast<long long int>(roundf(__bfloat162float(h)));
 }
 
-__device__ long long int __bfloat162ll_ru(const __hip_bfloat16 h) {
+__device__ inline long long int __bfloat162ll_ru(const __hip_bfloat16 h) {
   return static_cast<long long int>(ceilf(__bfloat162float(h)));
 }
 
 // Conversion functions for unsigned types
-__device__ unsigned int __bfloat162uint_rd(const __hip_bfloat16 h) {
+__device__ inline unsigned int __bfloat162uint_rd(const __hip_bfloat16 h) {
   return static_cast<unsigned int>(floorf(__bfloat162float(h)));
 }
 
-__device__ unsigned int __bfloat162uint_rn(const __hip_bfloat16 h) {
+__device__ inline unsigned int __bfloat162uint_rn(const __hip_bfloat16 h) {
   return static_cast<unsigned int>(roundf(__bfloat162float(h)));
 }
 
-__device__ unsigned int __bfloat162uint_ru(const __hip_bfloat16 h) {
+__device__ inline unsigned int __bfloat162uint_ru(const __hip_bfloat16 h) {
   return static_cast<unsigned int>(ceilf(__bfloat162float(h)));
 }
 
-__device__ unsigned long long int __bfloat162ull_rd(const __hip_bfloat16 h) {
+__device__ inline unsigned long long int __bfloat162ull_rd(const __hip_bfloat16 h) {
   return static_cast<unsigned long long int>(floorf(__bfloat162float(h)));
 }
 
-__device__ unsigned long long int __bfloat162ull_rn(const __hip_bfloat16 h) {
+__device__ inline unsigned long long int __bfloat162ull_rn(const __hip_bfloat16 h) {
   return static_cast<unsigned long long int>(roundf(__bfloat162float(h)));
 }
 
-__device__ unsigned long long int __bfloat162ull_ru(const __hip_bfloat16 h) {
+__device__ inline unsigned long long int __bfloat162ull_ru(const __hip_bfloat16 h) {
   return static_cast<unsigned long long int>(ceilf(__bfloat162float(h)));
 }
 
@@ -1052,76 +1052,76 @@ __host__ __device__ inline __hip_bfloat162 __float2bfloat162_rn(const float a) {
 __host__ __device__ inline __hip_bfloat162 __floats2bfloat162_rn(const float a, const float b) { return __hip_bfloat162{__float2bfloat16(a), __float2bfloat16(b)}; }
 
 // Load/store instructions
-__device__ __hip_bfloat16 __ldca(const __hip_bfloat16* ptr) { 
+__device__ inline __hip_bfloat16 __ldca(const __hip_bfloat16* ptr) { 
     return *ptr;
 }
-__device__ __hip_bfloat162 __ldca(const __hip_bfloat162* ptr) { 
+__device__ inline __hip_bfloat162 __ldca(const __hip_bfloat162* ptr) { 
     return *ptr;
 }
-__device__ __hip_bfloat16 __ldcg(const __hip_bfloat16* ptr) { 
+__device__ inline __hip_bfloat16 __ldcg(const __hip_bfloat16* ptr) { 
     return *ptr;
 }
-__device__ __hip_bfloat162 __ldcg(const __hip_bfloat162* ptr) { 
+__device__ inline __hip_bfloat162 __ldcg(const __hip_bfloat162* ptr) { 
     return *ptr;
 }
-__device__ __hip_bfloat16 __ldcs(const __hip_bfloat16* ptr) { 
+__device__ inline __hip_bfloat16 __ldcs(const __hip_bfloat16* ptr) { 
     return *ptr;
 }
-__device__ __hip_bfloat162 __ldcs(const __hip_bfloat162* ptr) { 
+__device__ inline __hip_bfloat162 __ldcs(const __hip_bfloat162* ptr) { 
     return *ptr;
 }
-__device__ __hip_bfloat16 __ldcv(const __hip_bfloat16* ptr) { 
+__device__ inline __hip_bfloat16 __ldcv(const __hip_bfloat16* ptr) { 
     return *ptr;
 }
-__device__ __hip_bfloat162 __ldcv(const __hip_bfloat162* ptr) { 
+__device__ inline __hip_bfloat162 __ldcv(const __hip_bfloat162* ptr) { 
     return *ptr;
 }
-__device__ __hip_bfloat16 __ldg(const __hip_bfloat16* ptr) { 
+__device__ inline __hip_bfloat16 __ldg(const __hip_bfloat16* ptr) { 
     return *ptr;
 }
-__device__ __hip_bfloat162 __ldg(const __hip_bfloat162* ptr) { 
+__device__ inline __hip_bfloat162 __ldg(const __hip_bfloat162* ptr) { 
     return *ptr;
 }
-__device__ __hip_bfloat16 __ldlu(const __hip_bfloat16* ptr) { 
+__device__ inline __hip_bfloat16 __ldlu(const __hip_bfloat16* ptr) { 
     return *ptr;
 }
-__device__ __hip_bfloat162 __ldlu(const __hip_bfloat162* ptr) { 
+__device__ inline __hip_bfloat162 __ldlu(const __hip_bfloat162* ptr) { 
     return *ptr;
 }
 
-__device__ void __stcg(__hip_bfloat16* ptr, __hip_bfloat16 value) { 
+__device__ inline void __stcg(__hip_bfloat16* ptr, __hip_bfloat16 value) { 
     *ptr = value;
 }
-__device__ void __stcg(__hip_bfloat162* ptr, __hip_bfloat162 value) { 
+__device__ inline void __stcg(__hip_bfloat162* ptr, __hip_bfloat162 value) { 
     *ptr = value;
 }
-__device__ void __stcs(__hip_bfloat16* ptr, __hip_bfloat16 value) { 
+__device__ inline void __stcs(__hip_bfloat16* ptr, __hip_bfloat16 value) { 
     *ptr = value;
 }
-__device__ void __stcs(__hip_bfloat162* ptr, __hip_bfloat162 value) { 
+__device__ inline void __stcs(__hip_bfloat162* ptr, __hip_bfloat162 value) { 
     *ptr = value;
 }
-__device__ void __stwb(__hip_bfloat16* ptr, __hip_bfloat16 value) { 
+__device__ inline void __stwb(__hip_bfloat16* ptr, __hip_bfloat16 value) { 
     *ptr = value;
 }
-__device__ void __stwb(__hip_bfloat162* ptr, __hip_bfloat162 value) { 
+__device__ inline void __stwb(__hip_bfloat162* ptr, __hip_bfloat162 value) { 
     *ptr = value;
 }
-__device__ void __stwt(__hip_bfloat16* ptr, __hip_bfloat16 value) { 
+__device__ inline void __stwt(__hip_bfloat16* ptr, __hip_bfloat16 value) { 
     *ptr = value;
 }
-__device__ void __stwt(__hip_bfloat162* ptr, __hip_bfloat162 value) { 
+__device__ inline void __stwt(__hip_bfloat162* ptr, __hip_bfloat162 value) { 
     *ptr = value;
 }
 
 // Shuffle operations
-__device__ __hip_bfloat16 __shfl_down_sync(unsigned mask, __hip_bfloat16 var, unsigned int delta, int width = 32) {
+__device__ inline __hip_bfloat16 __shfl_down_sync(unsigned mask, __hip_bfloat16 var, unsigned int delta, int width = 32) {
     float f = __bfloat162float(var);
     float shuffled = __shfl_down_sync(mask, f, delta, width);
     return __float2bfloat16(shuffled);
 }
 
-__device__ __hip_bfloat162 __shfl_down_sync(unsigned mask, __hip_bfloat162 var, unsigned int delta, int width = 32) {
+__device__ inline __hip_bfloat162 __shfl_down_sync(unsigned mask, __hip_bfloat162 var, unsigned int delta, int width = 32) {
     float x = __bfloat162float(var.x);
     float y = __bfloat162float(var.y);
     float shuffled_x = __shfl_down_sync(mask, x, delta, width);
@@ -1129,13 +1129,13 @@ __device__ __hip_bfloat162 __shfl_down_sync(unsigned mask, __hip_bfloat162 var, 
     return __hip_bfloat162{__float2bfloat16(shuffled_x), __float2bfloat16(shuffled_y)};
 }
 
-__device__ __hip_bfloat16 __shfl_sync(unsigned mask, __hip_bfloat16 var, int delta, int width = 32) {
+__device__ inline __hip_bfloat16 __shfl_sync(unsigned mask, __hip_bfloat16 var, int delta, int width = 32) {
     float f = __bfloat162float(var);
     float shuffled = __shfl_sync(mask, f, delta, width);
     return __float2bfloat16(shuffled);
 }
 
-__device__ __hip_bfloat162 __shfl_sync(unsigned mask, __hip_bfloat162 var, int delta, int width = 32) {
+__device__ inline __hip_bfloat162 __shfl_sync(unsigned mask, __hip_bfloat162 var, int delta, int width = 32) {
     float x = __bfloat162float(var.x);
     float y = __bfloat162float(var.y);
     float shuffled_x = __shfl_sync(mask, x, delta, width);
@@ -1143,13 +1143,13 @@ __device__ __hip_bfloat162 __shfl_sync(unsigned mask, __hip_bfloat162 var, int d
     return __hip_bfloat162{__float2bfloat16(shuffled_x), __float2bfloat16(shuffled_y)};
 }
 
-__device__ __hip_bfloat16 __shfl_up_sync(unsigned mask, __hip_bfloat16 var, unsigned int delta, int width = 32) {
+__device__ inline __hip_bfloat16 __shfl_up_sync(unsigned mask, __hip_bfloat16 var, unsigned int delta, int width = 32) {
     float f = __bfloat162float(var);
     float shuffled = __shfl_up_sync(mask, f, delta, width);
     return __float2bfloat16(shuffled);
 }
 
-__device__ __hip_bfloat162 __shfl_up_sync(unsigned mask, __hip_bfloat162 var, unsigned int delta, int width = 32) {
+__device__ inline __hip_bfloat162 __shfl_up_sync(unsigned mask, __hip_bfloat162 var, unsigned int delta, int width = 32) {
     float x = __bfloat162float(var.x);
     float y = __bfloat162float(var.y);
     float shuffled_x = __shfl_up_sync(mask, x, delta, width);
@@ -1157,13 +1157,13 @@ __device__ __hip_bfloat162 __shfl_up_sync(unsigned mask, __hip_bfloat162 var, un
     return __hip_bfloat162{__float2bfloat16(shuffled_x), __float2bfloat16(shuffled_y)};
 }
 
-__device__ __hip_bfloat16 __shfl_xor_sync(unsigned mask, __hip_bfloat16 var, int delta, int width = 32) {
+__device__ inline __hip_bfloat16 __shfl_xor_sync(unsigned mask, __hip_bfloat16 var, int delta, int width = 32) {
     float f = __bfloat162float(var);
     float shuffled = __shfl_xor_sync(mask, f, delta, width);
     return __float2bfloat16(shuffled);
 }
 
-__device__ __hip_bfloat162 __shfl_xor_sync(unsigned mask, __hip_bfloat162 var, int delta, int width = 32) {
+__device__ inline __hip_bfloat162 __shfl_xor_sync(unsigned mask, __hip_bfloat162 var, int delta, int width = 32) {
     float x = __bfloat162float(var.x);
     float y = __bfloat162float(var.y);
     float shuffled_x = __shfl_xor_sync(mask, x, delta, width);

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -158,6 +158,8 @@ add_shell_test(TestHipccArgOrder.bash)
 if(NOT APPLE)
   add_shell_test(TestSeparateCompilation.bash)
   add_shell_test(TestRDCNoDataLayoutWarning.bash)
+  # Two translation units both including hip_bf16.h, device-linked with -fgpu-rdc.
+  add_shell_test(TestBFloat16RDC.bash)
 endif()
 add_subdirectory(rdcLink)
 add_test(NAME "TestHipccMultiSource" COMMAND 

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -142,6 +142,8 @@ add_shell_test(TestHipcc621.bash)
 add_shell_test(TestHipccAcceptCFiles.bash)
 add_shell_test(TestRDCWithSingleHipccCmd.bash)
 add_shell_test(TestRDCWithMultipleHipccCmds.bash)
+# Two translation units both including hip_bf16.h, device-linked with -fgpu-rdc.
+add_shell_test(TestBFloat16RDC.bash)
 add_shell_test(TestWholeProgramCompilation.bash)
 add_shell_test(TestHipccDashX.bash)
 add_shell_test(TestHipccFp16Include.bash)

--- a/tests/compiler/TestBFloat16RDC.bash
+++ b/tests/compiler/TestBFloat16RDC.bash
@@ -1,0 +1,48 @@
+#!/bin/bash
+# hip_bf16.h must be includable from more than one translation unit of a
+# relocatable-device-code build.
+#
+# spirv_hip_bf16.h defined its free functions as plain '__device__' with no
+# 'inline', so every TU emitted a strong device definition. Without RDC each TU
+# becomes its own SPIR-V module and nothing notices; with -fgpu-rdc all the
+# device modules are llvm-linked together and the link dies with
+#
+#   error: Linking globals named '_Z20__bfloat162bfloat16214__hip_bfloat16':
+#          symbol multiply defined!
+#
+# That broke every -fgpu-rdc application, which is the configuration Kokkos
+# requires for device-side virtual dispatch
+# (Kokkos_ENABLE_HIP_RELOCATABLE_DEVICE_CODE, used by kynema-ugf / Nalu-Wind).
+#
+# This needs its own driver because the failure only shows up at the device
+# link of two TUs, which no single-file compile test reaches.
+set -eu
+
+OUT_DIR=@CMAKE_CURRENT_BINARY_DIR@/@TEST_NAME@.d
+HIPCC=@CMAKE_BINARY_DIR@/bin/hipcc
+
+rm -rf ${OUT_DIR}
+mkdir -p ${OUT_DIR}
+
+cat > ${OUT_DIR}/a.hip <<'SRC'
+#include <hip/hip_runtime.h>
+#include <hip/hip_bf16.h>
+#include <cstdio>
+__global__ void ka(__hip_bfloat16 *Out) { *Out = __hip_bfloat16(1.5f); }
+void useB();
+int main() { useB(); printf("PASSED\n"); return 0; }
+SRC
+
+cat > ${OUT_DIR}/b.hip <<'SRC'
+#include <hip/hip_runtime.h>
+#include <hip/hip_bf16.h>
+__global__ void kb(__hip_bfloat162 *Out, __hip_bfloat16 X) {
+  *Out = __bfloat162bfloat162(X);
+}
+void useB() {}
+SRC
+
+${HIPCC} -fgpu-rdc -c ${OUT_DIR}/a.hip -o ${OUT_DIR}/a.o
+${HIPCC} -fgpu-rdc -c ${OUT_DIR}/b.hip -o ${OUT_DIR}/b.o
+${HIPCC} -fgpu-rdc ${OUT_DIR}/a.o ${OUT_DIR}/b.o -o ${OUT_DIR}/bf
+${OUT_DIR}/bf

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -247,3 +247,6 @@ add_hip_runtime_test(TestSyncthreadsAndOrCount.hip)
 # __clz(0)-poison miscompile only manifests at -O1 and above.
 add_hip_runtime_test(TestSnakeMiscompileO2.hip)
 target_compile_options(TestSnakeMiscompileO2 PRIVATE -O2)
+
+# __short_as_bfloat16 / __ushort_as_bfloat16 must reinterpret bits (#1385).
+add_hip_runtime_test(TestBFloat16AsCasts.hip)

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -1,5 +1,4 @@
-#=============================================================================
-#  CMake build system files
+#======================================================================#  CMake build system files
 #
 #  Copyright (c) 2023 chipStar developers
 #
@@ -21,8 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 #
-#=============================================================================
-
+#======================================================================
 set(CHIP_SKIP_TEST 77)
 
 function(add_hip_runtime_test MAIN_SOURCE)
@@ -267,3 +265,6 @@ add_test(NAME TestModuleCacheInvalidation
     -P ${CMAKE_SOURCE_DIR}/tests/run_module_cache_invalidation_test.cmake)
 set_tests_properties(TestModuleCacheInvalidation PROPERTIES
   SKIP_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST")
+
+# __short_as_bfloat16 / __ushort_as_bfloat16 must reinterpret bits (#1385).
+add_hip_runtime_test(TestBFloat16AsCasts.hip)

--- a/tests/runtime/TestBFloat16AsCasts.hip
+++ b/tests/runtime/TestBFloat16AsCasts.hip
@@ -1,0 +1,58 @@
+// __short_as_bfloat16 and __ushort_as_bfloat16 must reinterpret the bits, not
+// convert the value (CHIP-SPV/chipStar#1385).
+//
+// They used to build the result as __hip_bfloat16{a}. chipStar's
+// __hip_bfloat16 is not an aggregate, it has a converting constructor from
+// float, so that selected the constructor and __ushort_as_bfloat16(0x3F80)
+// returned 16256.0 instead of 1.0. Including <hip/hip_bf16.h> at all from a
+// plain -I path was a hard error for the same reason, since the conversion is
+// narrowing, so this file doubles as the compile check.
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_bf16.h>
+
+#include <cstdio>
+
+__global__ void asCasts(float *Out, unsigned short *Bits) {
+  // 0x3F80 is the bfloat16 encoding of 1.0f, 0xC000 that of -2.0f.
+  __hip_bfloat16 A = __ushort_as_bfloat16(0x3F80);
+  __hip_bfloat16 B = __short_as_bfloat16((short)0xC000);
+  Out[0] = __bfloat162float(A);
+  Out[1] = __bfloat162float(B);
+  Bits[0] = __bfloat16_as_ushort(A);
+  Bits[1] = (unsigned short)__bfloat16_as_short(B);
+}
+
+int main() {
+  float *DOut = nullptr;
+  unsigned short *DBits = nullptr;
+  (void)hipMalloc(&DOut, 2 * sizeof(float));
+  (void)hipMalloc(&DBits, 2 * sizeof(unsigned short));
+
+  asCasts<<<1, 1>>>(DOut, DBits);
+  (void)hipDeviceSynchronize();
+
+  float HOut[2] = {0.0f, 0.0f};
+  unsigned short HBits[2] = {0, 0};
+  (void)hipMemcpy(HOut, DOut, sizeof(HOut), hipMemcpyDeviceToHost);
+  (void)hipMemcpy(HBits, DBits, sizeof(HBits), hipMemcpyDeviceToHost);
+
+  bool Ok = true;
+  if (HOut[0] != 1.0f || HOut[1] != -2.0f) {
+    printf("FAIL: values %f, %f (want 1.000000, -2.000000)\n", HOut[0],
+           HOut[1]);
+    Ok = false;
+  }
+  if (HBits[0] != 0x3F80 || HBits[1] != 0xC000) {
+    printf("FAIL: bits 0x%04X, 0x%04X (want 0x3F80, 0xC000)\n", HBits[0],
+           HBits[1]);
+    Ok = false;
+  }
+
+  (void)hipFree(DOut);
+  (void)hipFree(DBits);
+
+  if (Ok)
+    printf("PASSED\n");
+  return Ok ? 0 : 1;
+}


### PR DESCRIPTION
Two fixes in `spirv_hip_bf16.h`, one commit each.

The free functions were declared plain `__device__` with no `inline`, so with `-fgpu-rdc` the device link of any two translation units that include `hip_bf16.h` failed with `symbol multiply defined!`. The sibling headers already write `__device__ inline`.

`__short_as_bfloat16` and `__ushort_as_bfloat16` built their result with brace initialization, which selected the converting constructor from `float` and converted the value instead of reinterpreting the bits. They now assign `data` directly.

Fixes #1383
Fixes #1385
