### PR TITLE
Make DeviceVarMtx recursive to avoid teardown self-deadlock

### DIFF
--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1395,7 +1395,7 @@ public:
 
   hipDeviceProp_t getDeviceProps() { return HipDeviceProps_; }
   bool getPerThreadStreamUsed() const { return PerThreadStreamUsed_; }
-  std::mutex DeviceVarMtx;
+  std::recursive_mutex DeviceVarMtx;
   std::mutex DeviceMtx;
   std::mutex QueueAddRemoveMtx;
 

--- a/src/macros.hh
+++ b/src/macros.hh
@@ -26,10 +26,13 @@
 #include "logging.hh"
 #include "iostream"
 #include "CHIPException.hh"
+#include <type_traits>
 
 #define CONCAT(a, b) CONCAT_INNER(a, b)
 #define CONCAT_INNER(a, b) a##b
-#define LOCK(x) std::lock_guard<std::mutex> CONCAT(Lock, __LINE__)(x);
+#define LOCK(x)                                                                \
+  std::lock_guard<std::remove_reference_t<decltype(x)>>                        \
+      CONCAT(Lock, __LINE__)(x);
 
 #ifdef CHIP_ERROR_IF_NOT_IMPLEMENTED
 #define UNIMPLEMENTED(x)                                                       \


### PR DESCRIPTION
getOrCreateModule() holds DeviceVarMtx across compile(). If the backend exits the process during compile (e.g. the SPIR-V translator calls exit() on an invalid module), the atexit path deallocateDeviceVariables() re-locks DeviceVarMtx on the same thread and deadlocks.