### PR TITLE
devicelib: provide __builtin_amdgcn_atomic_inc32 and dec32 on SPIR-V

### DIFF
--- a/include/hip/devicelib/atomics.hh
+++ b/include/hip/devicelib/atomics.hh
@@ -299,6 +299,27 @@ atomicDec(unsigned *address, unsigned val) { // Undocumented
   return __chip_atomic_dec2_u(address, val);
 }
 
+// AMD GCN builtins for the wrapping atomic increment/decrement. Clang only
+// declares them for the amdgcn target, so code written against ROCm HIP (for
+// example desul's atomic_fetch_inc_mod / atomic_fetch_dec_mod, which Kokkos
+// bundles) does not compile for SPIR-V. Their semantics are exactly
+// atomicInc/atomicDec, which chipStar already implements, so forward to those.
+// The memory order and scope arguments are accepted and ignored, matching the
+// relaxed device-scope behaviour of __chip_atomic_{inc,dec}2_u.
+extern "C++" inline __device__ unsigned int
+__builtin_amdgcn_atomic_inc32(unsigned int *address, unsigned int val,
+                              int /*order*/, const char * /*scope*/,
+                              bool /*isVolatile*/ = false) {
+  return __chip_atomic_inc2_u(address, val);
+}
+
+extern "C++" inline __device__ unsigned int
+__builtin_amdgcn_atomic_dec32(unsigned int *address, unsigned int val,
+                              int /*order*/, const char * /*scope*/,
+                              bool /*isVolatile*/ = false) {
+  return __chip_atomic_dec2_u(address, val);
+}
+
 extern "C" __device__ int __chip_atomic_cmpxchg_i(int *address, int compare,
                                                   int val);
 extern "C++" inline __device__ int atomicCAS(int *address, int compare,

--- a/tests/devicelib/CMakeLists.txt
+++ b/tests/devicelib/CMakeLists.txt
@@ -63,3 +63,7 @@ set_tests_properties(irif_no_i128 PROPERTIES
 add_hip_test(TestAtomicMinMaxFloat.cpp)
 set_tests_properties(TestAtomicMinMaxFloat PROPERTIES
   PASS_REGULAR_EXPRESSION "PASS")
+
+add_hip_test(TestAtomicIncDecMod.cpp)
+set_tests_properties(TestAtomicIncDecMod PROPERTIES
+  PASS_REGULAR_EXPRESSION "PASSED")

--- a/tests/devicelib/CMakeLists.txt
+++ b/tests/devicelib/CMakeLists.txt
@@ -67,3 +67,7 @@ set_tests_properties(TestAtomicMinMaxFloat PROPERTIES
 add_hip_test(TestStdModfFloat.cpp)
 set_tests_properties(TestStdModfFloat PROPERTIES
   PASS_REGULAR_EXPRESSION "PASSED")
+
+add_hip_test(TestAtomicIncDecMod.cpp)
+set_tests_properties(TestAtomicIncDecMod PROPERTIES
+  PASS_REGULAR_EXPRESSION "PASSED")

--- a/tests/devicelib/TestAtomicIncDecMod.cpp
+++ b/tests/devicelib/TestAtomicIncDecMod.cpp
@@ -1,0 +1,110 @@
+// Reproduces: __builtin_amdgcn_atomic_inc32 / __builtin_amdgcn_atomic_dec32 are
+// undeclared on chipStar's SPIR-V target. desul (bundled with Kokkos) uses them
+// to implement atomic_fetch_inc_mod / atomic_fetch_dec_mod, so every HIP
+// translation unit that pulls in desul/atomics/Fetch_Op_HIP.hpp fails to
+// compile.
+//
+// inc32 semantics: old = *ptr; *ptr = (old >= val) ? 0 : old + 1; return old;
+// dec32 semantics: old = *ptr; *ptr = (old == 0 || old > val) ? val : old - 1;
+//                  return old;
+
+#include <hip/hip_runtime.h>
+#include <cstdio>
+
+#define CHECK(X)                                                               \
+  do {                                                                         \
+    hipError_t E = (X);                                                        \
+    if (E != hipSuccess) {                                                     \
+      printf("FAILED: %s -> %s\n", #X, hipGetErrorString(E));                  \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+// One thread walks the counter through a full wrap cycle and records every
+// value returned, so the exact modular semantics are checked and not just the
+// endpoint.
+__global__ void incSequence(unsigned *Counter, unsigned *Out, unsigned Mod,
+                            unsigned Steps) {
+  for (unsigned I = 0; I < Steps; ++I)
+    Out[I] = __builtin_amdgcn_atomic_inc32(Counter, Mod, __ATOMIC_RELAXED,
+                                           "agent");
+}
+
+__global__ void decSequence(unsigned *Counter, unsigned *Out, unsigned Mod,
+                            unsigned Steps) {
+  for (unsigned I = 0; I < Steps; ++I)
+    Out[I] = __builtin_amdgcn_atomic_dec32(Counter, Mod, __ATOMIC_RELAXED,
+                                           "agent");
+}
+
+// Every thread bumps the same wrapping counter once; the final value must be
+// NumThreads modulo (Mod + 1).
+__global__ void incContended(unsigned *Counter, unsigned Mod) {
+  __builtin_amdgcn_atomic_inc32(Counter, Mod, __ATOMIC_RELAXED, "agent");
+}
+
+int main() {
+  constexpr unsigned Mod = 4;   // counter wraps back to 0 after reaching Mod
+  constexpr unsigned Steps = 12;
+
+  unsigned *Counter, *Out;
+  CHECK(hipMalloc(&Counter, sizeof(unsigned)));
+  CHECK(hipMalloc(&Out, Steps * sizeof(unsigned)));
+
+  unsigned Host[Steps];
+  int Errors = 0;
+
+  // --- inc ---
+  unsigned Zero = 0;
+  CHECK(hipMemcpy(Counter, &Zero, sizeof(unsigned), hipMemcpyHostToDevice));
+  hipLaunchKernelGGL(incSequence, dim3(1), dim3(1), 0, 0, Counter, Out, Mod,
+                     Steps);
+  CHECK(hipDeviceSynchronize());
+  CHECK(hipMemcpy(Host, Out, sizeof(Host), hipMemcpyDeviceToHost));
+  for (unsigned I = 0; I < Steps; ++I) {
+    unsigned Expected = I % (Mod + 1);
+    if (Host[I] != Expected) {
+      printf("inc32 step %u: got %u expected %u\n", I, Host[I], Expected);
+      ++Errors;
+    }
+  }
+
+  // --- dec ---
+  unsigned Start = Mod;
+  CHECK(hipMemcpy(Counter, &Start, sizeof(unsigned), hipMemcpyHostToDevice));
+  hipLaunchKernelGGL(decSequence, dim3(1), dim3(1), 0, 0, Counter, Out, Mod,
+                     Steps);
+  CHECK(hipDeviceSynchronize());
+  CHECK(hipMemcpy(Host, Out, sizeof(Host), hipMemcpyDeviceToHost));
+  for (unsigned I = 0; I < Steps; ++I) {
+    unsigned Expected = Mod - (I % (Mod + 1));
+    if (Host[I] != Expected) {
+      printf("dec32 step %u: got %u expected %u\n", I, Host[I], Expected);
+      ++Errors;
+    }
+  }
+
+  // --- contended inc ---
+  constexpr unsigned NumThreads = 1024;
+  CHECK(hipMemcpy(Counter, &Zero, sizeof(unsigned), hipMemcpyHostToDevice));
+  hipLaunchKernelGGL(incContended, dim3(4), dim3(NumThreads / 4), 0, 0, Counter,
+                     Mod);
+  CHECK(hipDeviceSynchronize());
+  unsigned Final = 0;
+  CHECK(hipMemcpy(&Final, Counter, sizeof(unsigned), hipMemcpyDeviceToHost));
+  unsigned ExpectedFinal = NumThreads % (Mod + 1);
+  if (Final != ExpectedFinal) {
+    printf("contended inc32: got %u expected %u\n", Final, ExpectedFinal);
+    ++Errors;
+  }
+
+  CHECK(hipFree(Counter));
+  CHECK(hipFree(Out));
+
+  if (Errors) {
+    printf("FAILED\n");
+    return 1;
+  }
+  printf("PASSED\n");
+  return 0;
+}


### PR DESCRIPTION
Fixes #1390

Clang declares these builtins only for the amdgcn target, so HIP code written against ROCm that uses them does not compile for SPIR-V. desul, bundled by Kokkos, uses them for atomic_fetch_inc_mod and atomic_fetch_dec_mod.

Their semantics match atomicInc and atomicDec, already implemented by __chip_atomic_inc2_u and __chip_atomic_dec2_u, so the shims forward to those.

New test tests/devicelib/TestAtomicIncDecMod.cpp, verified on Intel Arc B570 (OpenCL): fails to compile before the header change, PASSED after.