### PR TITLE
Do not deadlock when the device compiler exits during a module build (#1393)

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1473,6 +1473,12 @@ chipstar::Module *chipstar::Device::getOrCreateModule(const SPVModule &SrcMod) {
 
   logDebug("Compile module {}", static_cast<const void *>(&SrcMod));
 
+  // The backend compiler runs with DeviceVarMtx held, and some backends end
+  // the process with exit() rather than reporting a rejected module. Let
+  // CHIPUninitializeCallOnce() detect that so it does not deadlock on the lock
+  // held here.
+  BackendModuleBuildScope BuildScope;
+
   auto start = std::chrono::high_resolution_clock::now();
   auto *Module = compile(SrcMod);
   auto end = std::chrono::high_resolution_clock::now();

--- a/src/CHIPDriver.cc
+++ b/src/CHIPDriver.cc
@@ -203,10 +203,33 @@ extern void CHIPInitialize() {
   std::call_once(Initialized, &CHIPInitializeCallOnce);
 }
 
+/// Nesting depth of backend module builds on this thread.
+static thread_local unsigned BackendModuleBuildDepth = 0;
+
+bool isThreadInBackendModuleBuild() { return BackendModuleBuildDepth > 0; }
+
+BackendModuleBuildScope::BackendModuleBuildScope() { ++BackendModuleBuildDepth; }
+
+BackendModuleBuildScope::~BackendModuleBuildScope() { --BackendModuleBuildDepth; }
+
 void CHIPUninitializeCallOnce() {
   logDebug("Uninitializing CHIP...");
   if (ChipEnvVars.getSkipUninit()) {
     logWarn("Uninitialization skipped");
+    return;
+  }
+  if (isThreadInBackendModuleBuild()) {
+    // The backend compiler ended the process from inside a module build, so
+    // this runs as an atexit handler on the thread that is still holding
+    // Device::DeviceVarMtx. Tearing down here would block on that lock
+    // forever, turning a device compiler error into a silent hang.
+    logError("chipStar shutdown was entered from inside a backend module "
+             "build: the device compiler ended the process instead of "
+             "reporting an error. This normally means the device does not "
+             "support a capability the SPIR-V module requires, such as "
+             "SPV_INTEL_function_pointers for indirect calls. Skipping "
+             "runtime teardown, which would deadlock on the lock the build is "
+             "still holding.");
     return;
   }
   if (Backend) {

--- a/src/CHIPDriver.hh
+++ b/src/CHIPDriver.hh
@@ -105,6 +105,31 @@ void CHIPInitializeCallOnce();
  */
 void CHIPUninitializeCallOnce();
 
+/**
+ * @brief
+ * True while the calling thread is inside a backend module build.
+ *
+ * Some backend compilers end the process with exit() instead of reporting a
+ * rejected module. PoCL's SPIR-V reader does this when the module needs an
+ * extension the target does not have, e.g. SPV_INTEL_function_pointers. exit()
+ * runs chipStar's atexit handler on the same thread, so the handler must not
+ * try to take the device lock the build is still holding.
+ */
+bool isThreadInBackendModuleBuild();
+
+/**
+ * @brief
+ * Marks the calling thread as being inside a backend module build for the
+ * lifetime of the object. See isThreadInBackendModuleBuild().
+ */
+class BackendModuleBuildScope {
+public:
+  BackendModuleBuildScope();
+  ~BackendModuleBuildScope();
+  BackendModuleBuildScope(const BackendModuleBuildScope &) = delete;
+  BackendModuleBuildScope &operator=(const BackendModuleBuildScope &) = delete;
+};
+
 extern hipError_t CHIPReinitialize(const uintptr_t *NativeHandles,
                                    int NumHandles);
 

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -13,3 +13,15 @@ set_tests_properties(TestFixUmul64hi PROPERTIES
   TIMEOUT 60)
 
 add_hip_test(test_shutdown_crossqueue_dep.cpp)
+
+add_hip_test(TestFixCompilerExitDuringModuleBuild.cpp)
+# A backend compiler that rejects a SPIR-V module by calling exit() (PoCL does
+# this for unsupported extensions) used to deadlock chipStar: the atexit
+# handler re-entered Device::DeviceVarMtx, which the same thread was already
+# holding across the build. The test bounds itself, so the TIMEOUT below is
+# only a backstop.
+set_tests_properties(TestFixCompilerExitDuringModuleBuild PROPERTIES
+  PASS_REGULAR_EXPRESSION "PASS"
+  FAIL_REGULAR_EXPRESSION "FAIL"
+  TIMEOUT 120)
+target_link_libraries(TestFixCompilerExitDuringModuleBuild ${CMAKE_DL_LIBS})

--- a/tests/regression/TestFixCompilerExitDuringModuleBuild.cpp
+++ b/tests/regression/TestFixCompilerExitDuringModuleBuild.cpp
@@ -1,0 +1,133 @@
+// Reproduces: chipStar deadlocks at exit when the backend compiler terminates
+// the process from inside a module build.
+//
+// Some OpenCL implementations call exit() instead of returning an error when
+// they reject a SPIR-V module.  PoCL does this through the SPIR-V reader when
+// the module needs a capability the target does not have, for example
+// SPV_INTEL_function_pointers:
+//
+//   InvalidModule: Invalid SPIR-V module: input SPIR-V module uses extension
+//   'SPV_INTEL_function_pointers' which were disabled by --spirv-ext option
+//
+// exit() runs the atexit handlers, one of which is chipStar's
+// __hip_module_dtor -> __hipUnregisterFatBinary -> CHIPUninitialize ->
+// Device::deallocateDeviceVariables.  That takes Device::DeviceVarMtx, which
+// the very same thread is already holding in Device::getOrCreateModule() for
+// the duration of the backend compile.  std::mutex is not recursive, so the
+// process wedges forever instead of failing.
+//
+// This test interposes the backend module build entry points so the failure is
+// reproduced without needing a driver that rejects the module.  A definition in
+// the executable takes precedence over the shared library one, so libCHIP's
+// call lands here.  The test is bounded: the parent kills the child and reports
+// FAIL rather than letting the harness time out.
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE // for RTLD_NEXT
+#endif
+
+#include <hip/hip_runtime.h>
+
+#include <dlfcn.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cstdio>
+#include <cstdlib>
+
+// Exit code the interposed build call terminates the child with.
+static const int ExitCodeFromCompiler = 42;
+// Set in the child so the interposers only fire there.
+static const char *ArmEnvVar = "CHIPSTAR_TESTFIX_EXIT_IN_MODULE_BUILD";
+// Upper bound on how long the child may take, in tenths of a second.
+static const int ChildTimeoutTenths = 450;
+
+static bool armed() { return getenv(ArmEnvVar) != nullptr; }
+
+static void exitLikeARejectingCompiler(const char *Fn) {
+  fprintf(stderr, "interposed %s: terminating the process the way a compiler "
+                  "rejecting the module would\n",
+          Fn);
+  exit(ExitCodeFromCompiler);
+}
+
+// clBuildProgram and zeModuleCreate take only pointer-sized and integer
+// arguments, so these opaque prototypes are ABI compatible with the real ones.
+extern "C" int clBuildProgram(void *Program, unsigned NumDevices,
+                              const void *DeviceList, const char *Options,
+                              void *Notify, void *UserData) {
+  if (armed())
+    exitLikeARejectingCompiler("clBuildProgram");
+  using FnTy = int (*)(void *, unsigned, const void *, const char *, void *,
+                       void *);
+  FnTy Real = (FnTy)dlsym(RTLD_NEXT, "clBuildProgram");
+  if (!Real)
+    return -6; // CL_OUT_OF_HOST_MEMORY
+  return Real(Program, NumDevices, DeviceList, Options, Notify, UserData);
+}
+
+extern "C" int zeModuleCreate(void *Context, void *Device, const void *Desc,
+                              void *Module, void *BuildLog) {
+  if (armed())
+    exitLikeARejectingCompiler("zeModuleCreate");
+  using FnTy = int (*)(void *, void *, const void *, void *, void *);
+  FnTy Real = (FnTy)dlsym(RTLD_NEXT, "zeModuleCreate");
+  if (!Real)
+    return 0x78000001; // ZE_RESULT_ERROR_UNINITIALIZED
+  return Real(Context, Device, Desc, Module, BuildLog);
+}
+
+__global__ void touch(int *Out) { *Out = 1; }
+
+// Runs in the child: the first launch compiles the module, which lands in the
+// interposed build call above and terminates the process from underneath the
+// held DeviceVarMtx.
+static int runChild() {
+  int *Ptr = nullptr;
+  if (hipMalloc(&Ptr, sizeof(int)) != hipSuccess)
+    return 0; // No usable device; the parent reports this as a skip.
+  touch<<<1, 1>>>(Ptr);
+  (void)hipDeviceSynchronize();
+  (void)hipFree(Ptr);
+  return 0; // The interposers never fired.
+}
+
+int main(int Argc, char **Argv) {
+  (void)Argc;
+  if (armed())
+    return runChild();
+
+  pid_t Pid = fork();
+  if (Pid < 0) {
+    printf("HIP_SKIP_THIS_TEST: fork failed\n");
+    return 0;
+  }
+  if (Pid == 0) {
+    setenv(ArmEnvVar, "1", 1);
+    execv(Argv[0], Argv);
+    _exit(127);
+  }
+
+  int Status = 0;
+  for (int Tenths = 0; Tenths < ChildTimeoutTenths; ++Tenths) {
+    if (waitpid(Pid, &Status, WNOHANG) == Pid) {
+      if (WIFEXITED(Status) && WEXITSTATUS(Status) == ExitCodeFromCompiler) {
+        printf("PASS: runtime shut down cleanly after the backend compiler "
+               "terminated the process during a module build\n");
+        return 0;
+      }
+      printf("HIP_SKIP_THIS_TEST: module build was not interposed (status "
+             "0x%x)\n",
+             Status);
+      return 0;
+    }
+    usleep(100000);
+  }
+
+  kill(Pid, SIGKILL);
+  (void)waitpid(Pid, &Status, 0);
+  printf("FAIL: runtime deadlocked in its exit handler after the backend "
+         "compiler terminated the process during a module build\n");
+  return 1;
+}


### PR DESCRIPTION
Fixes #1393. `Device::getOrCreateModule()` held `DeviceVarMtx` across the backend compile, so a driver calling `std::exit()` there ran the atexit handler on the same thread and `deallocateDeviceVariables()` blocked on the mutex the build still held. A thread local marker around the backend build lets `CHIPUninitializeCallOnce` skip teardown and log why, so the process exits with the compiler code instead of hanging.

Regression test added: it interposes `clBuildProgram` and `zeModuleCreate` so libCHIP dispatches into them, then forks and re execs so the parent bounds the child rather than burning the harness timeout. Before the fix it reports the deadlock after 45.8 s; after, it passes in 1.6 s. Skips cleanly where the interposer cannot fire.

Trade off worth noting: this path skips teardown, so the process exits with the compiler exit code and leaks whatever the runtime held. That is acceptable since the process is already dying, but it is deliberate rather than incidental.

Regression runs: dgpu opencl 1014/1014, dgpu level0 1045/1046, the single failure being `TestStaticLibRDC` which passes standalone in 75.9 s and timed out only under concurrent load.

Upstream causes are filed separately at pocl/pocl#2258 and KhronosGroup/SPIRV-LLVM-Translator#3939.