### PR TITLE
Expand llvm.{u,s}mul.with.overflow before SPIR-V emission

### DIFF
--- a/llvm_passes/CMakeLists.txt
+++ b/llvm_passes/CMakeLists.txt
@@ -103,6 +103,7 @@ add_library(LLVMHipPasses MODULE HipPasses.cpp
     HipEmitLoweredNames.cpp HipWarps.cpp HipKernelArgSpiller.cpp
     HipLowerZeroLengthArrays.cpp HipSanityChecks.cpp HipLowerSwitch.cpp
     HipLowerMemset.cpp HipIGBADetector.cpp HipPromoteInts.cpp
+    HipLowerOverflowIntrinsics.cpp
     HipSpirvFunctionReorderPass.cpp
     HipVerify.cpp
     ${EXTRA_OBJS})

--- a/llvm_passes/CMakeLists.txt
+++ b/llvm_passes/CMakeLists.txt
@@ -103,6 +103,7 @@ add_library(LLVMHipPasses MODULE HipPasses.cpp
     HipEmitLoweredNames.cpp HipWarps.cpp HipKernelArgSpiller.cpp
     HipLowerZeroLengthArrays.cpp HipSanityChecks.cpp HipLowerSwitch.cpp
     HipLowerMemset.cpp HipLowerFPAtomicMinMax.cpp HipIGBADetector.cpp HipPromoteInts.cpp
+    HipLowerOverflowIntrinsics.cpp
     HipSpirvFunctionReorderPass.cpp
     HipVerify.cpp HipCanonicalizeGEP.cpp
     ${EXTRA_OBJS})

--- a/llvm_passes/HipLowerOverflowIntrinsics.cpp
+++ b/llvm_passes/HipLowerOverflowIntrinsics.cpp
@@ -1,0 +1,142 @@
+//===- HipLowerOverflowIntrinsics.cpp -------------------------------------===//
+//
+// Part of the chipStar Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Expands llvm.umul.with.overflow / llvm.smul.with.overflow into plain
+// integer arithmetic.
+//
+// Why: clang emits llvm.umul.with.overflow.i64 for the element-count times
+// element-size computation of a C++ array-new expression ("new T[n]"), so any
+// device code that news an array hits it, and both SPIR-V emission lanes
+// chipStar uses fail on it.
+//
+// Through the in-tree SPIR-V backend, the intrinsic becomes OpUMulExtended.
+// IGC's SPIR-V reader mangles that instruction's operands as signed while its
+// builtin module defines only the unsigned overloads, so the module build
+// fails with
+//
+//   error: undefined reference to `_Z20__spirv_UMulExtendedll'
+//
+// See intel/intel-graphics-compiler#432. Through the llvm-spirv translator,
+// llvm.smul.with.overflow has no lowering at all and translation aborts with
+// "InvalidFunctionCall: Unexpected llvm intrinsic". Since chipStar puts all of
+// a binary's device code in one module, either failure takes down every kernel
+// in the program.
+//
+// Expanding both intrinsics here means neither construct reaches SPIR-V.
+// The overflow predicate is computed with a division rather than a 128-bit
+// multiply because i128 is not portable across the SPIR-V consumers chipStar
+// targets. These intrinsics come from allocation-size checks, which are not
+// hot code. The pass must stay after any InstCombine run, which re-forms both
+// intrinsics from exactly the shapes emitted here.
+//
+// Copyright (c) 2026 chipStar developers
+//===----------------------------------------------------------------------===//
+
+#include "HipLowerOverflowIntrinsics.h"
+
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "PassPluginCompat.h"
+#include "llvm/Support/Debug.h"
+
+#define PASS_NAME "hip-lower-overflow-intrinsics"
+#define DEBUG_TYPE PASS_NAME
+
+using namespace llvm;
+
+namespace {
+
+/// Replace one *.with.overflow call with the equivalent plain arithmetic.
+///
+/// Unsigned:  lo = a * b;  ov = a != 0 && b > (UMAX / a)
+/// Signed:    lo = a * b;  ov = (a == -1 && b == INT_MIN)
+///                            || (a != 0 && a != -1 && (lo / a) != b)
+///
+/// The divisor is fed through a select so the division is never by zero and
+/// never sdiv INT_MIN by -1, on any path, including the ones whose result is
+/// discarded.
+static bool expandCall(IntrinsicInst *II) {
+  IRBuilder<> B(II);
+  Value *A = II->getArgOperand(0);
+  Value *Bv = II->getArgOperand(1);
+  Type *Ty = A->getType();
+  if (!Ty->isIntegerTy())
+    return false;
+
+  Value *Lo = nullptr;
+  Value *Ov = nullptr;
+
+  if (II->getIntrinsicID() == Intrinsic::umul_with_overflow) {
+    Lo = B.CreateMul(A, Bv, "umulov.lo");
+    Constant *Zero = ConstantInt::get(Ty, 0);
+    Constant *One = ConstantInt::get(Ty, 1);
+    Constant *UMax = Constant::getAllOnesValue(Ty);
+    Value *ANotZero = B.CreateICmpNE(A, Zero, "umulov.anz");
+    Value *SafeA = B.CreateSelect(ANotZero, A, One, "umulov.safea");
+    Value *Limit = B.CreateUDiv(UMax, SafeA, "umulov.limit");
+    Value *Over = B.CreateICmpUGT(Bv, Limit, "umulov.gt");
+    Ov = B.CreateAnd(ANotZero, Over, "umulov.ov");
+  } else if (II->getIntrinsicID() == Intrinsic::smul_with_overflow) {
+    // ov = (a == -1 && b == INT_MIN) || (a != 0 && a != -1 && (a * b) / a != b)
+    //
+    // a == -1 has to be split out rather than folded into the division,
+    // because sdiv INT_MIN, -1 is itself undefined.
+    unsigned Bits = Ty->getIntegerBitWidth();
+    Lo = B.CreateMul(A, Bv, "smulov.lo");
+    Constant *Zero = ConstantInt::get(Ty, 0);
+    Constant *One = ConstantInt::get(Ty, 1);
+    Constant *NegOne = Constant::getAllOnesValue(Ty);
+    Constant *IntMin = ConstantInt::get(Ty, APInt::getSignedMinValue(Bits));
+    Value *ANotZero = B.CreateICmpNE(A, Zero, "smulov.anz");
+    Value *AIsNegOne = B.CreateICmpEQ(A, NegOne, "smulov.aneg1");
+    Value *NegOneOv = B.CreateAnd(AIsNegOne,
+                                  B.CreateICmpEQ(Bv, IntMin, "smulov.bmin"),
+                                  "smulov.ovneg1");
+    Value *Divisible = B.CreateAnd(ANotZero, B.CreateNot(AIsNegOne),
+                                   "smulov.divisible");
+    Value *SafeA = B.CreateSelect(Divisible, A, One, "smulov.safea");
+    Value *Back = B.CreateSDiv(Lo, SafeA, "smulov.back");
+    Value *Ne = B.CreateICmpNE(Back, Bv, "smulov.ne");
+    Ov = B.CreateOr(NegOneOv, B.CreateAnd(Divisible, Ne, "smulov.divov"),
+                    "smulov.ov");
+  } else {
+    return false;
+  }
+
+  Value *Agg = UndefValue::get(II->getType());
+  Agg = B.CreateInsertValue(Agg, Lo, 0, "ov.agg.lo");
+  Agg = B.CreateInsertValue(Agg, Ov, 1, "ov.agg");
+  II->replaceAllUsesWith(Agg);
+  II->eraseFromParent();
+  return true;
+}
+
+} // namespace
+
+PreservedAnalyses HipLowerOverflowIntrinsicsPass::run(Module &M,
+                                                      ModuleAnalysisManager &AM) {
+  SmallVector<IntrinsicInst *, 8> Worklist;
+  for (Function &F : M)
+    for (BasicBlock &BB : F)
+      for (Instruction &I : BB)
+        if (auto *II = dyn_cast<IntrinsicInst>(&I))
+          if (II->getIntrinsicID() == Intrinsic::umul_with_overflow ||
+              II->getIntrinsicID() == Intrinsic::smul_with_overflow)
+            Worklist.push_back(II);
+
+  bool Changed = false;
+  for (IntrinsicInst *II : Worklist)
+    Changed |= expandCall(II);
+
+  return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
+}

--- a/llvm_passes/HipLowerOverflowIntrinsics.cpp
+++ b/llvm_passes/HipLowerOverflowIntrinsics.cpp
@@ -1,0 +1,137 @@
+//===- HipLowerOverflowIntrinsics.cpp -------------------------------------===//
+//
+// Part of the chipStar Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Expands llvm.umul.with.overflow / llvm.smul.with.overflow into plain
+// integer arithmetic.
+//
+// Why: clang emits llvm.umul.with.overflow.i64 for the element-count times
+// element-size computation of a C++ array-new expression ("new T[n]"), so any
+// device code that news an array hits it. The LLVM SPIR-V producer cannot
+// express the intrinsic directly, so it emits a helper function named
+// spirv.llvm_umul_with_overflow_i64 and calls that. IGC then reads the SPIR-V
+// back into LLVM IR, maps the helper back onto the intrinsic, renames the
+// original declaration to "old_llvm.umul.with.overflow.i64" and never
+// produces a body for it -- the module build fails with
+//
+//   error: undefined reference to `old_llvm.umul.with.overflow.i64'
+//
+// and, because chipStar puts all of a binary's device code in one module,
+// that single unresolved symbol takes down every kernel in the program.
+//
+// Expanding the intrinsic here means the construct never reaches SPIR-V.
+// The overflow predicate is computed with a division rather than a 128-bit
+// multiply because i128 is not portable across the SPIR-V consumers chipStar
+// targets. These intrinsics come from allocation-size checks, which are not
+// hot code.
+//
+// Copyright (c) 2026 chipStar developers
+//===----------------------------------------------------------------------===//
+
+#include "HipLowerOverflowIntrinsics.h"
+
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "PassPluginCompat.h"
+#include "llvm/Support/Debug.h"
+
+#define PASS_NAME "hip-lower-overflow-intrinsics"
+#define DEBUG_TYPE PASS_NAME
+
+using namespace llvm;
+
+namespace {
+
+/// Replace one *.with.overflow call with the equivalent plain arithmetic.
+///
+/// Unsigned:  lo = a * b;  ov = a != 0 && b > (UMAX / a)
+/// Signed:    lo = a * b;  ov = (a == -1 && b == INT_MIN)
+///                            || (a != 0 && a != -1 && (lo / a) != b)
+///
+/// The divisor is fed through a select so the division is never by zero and
+/// never sdiv INT_MIN by -1, on any path, including the ones whose result is
+/// discarded.
+static bool expandCall(IntrinsicInst *II) {
+  IRBuilder<> B(II);
+  Value *A = II->getArgOperand(0);
+  Value *Bv = II->getArgOperand(1);
+  Type *Ty = A->getType();
+  if (!Ty->isIntegerTy())
+    return false;
+
+  Value *Lo = nullptr;
+  Value *Ov = nullptr;
+
+  if (II->getIntrinsicID() == Intrinsic::umul_with_overflow) {
+    Lo = B.CreateMul(A, Bv, "umulov.lo");
+    Constant *Zero = ConstantInt::get(Ty, 0);
+    Constant *One = ConstantInt::get(Ty, 1);
+    Constant *UMax = Constant::getAllOnesValue(Ty);
+    Value *ANotZero = B.CreateICmpNE(A, Zero, "umulov.anz");
+    Value *SafeA = B.CreateSelect(ANotZero, A, One, "umulov.safea");
+    Value *Limit = B.CreateUDiv(UMax, SafeA, "umulov.limit");
+    Value *Over = B.CreateICmpUGT(Bv, Limit, "umulov.gt");
+    Ov = B.CreateAnd(ANotZero, Over, "umulov.ov");
+  } else if (II->getIntrinsicID() == Intrinsic::smul_with_overflow) {
+    // ov = (a == -1 && b == INT_MIN) || (a != 0 && a != -1 && (a * b) / a != b)
+    //
+    // a == -1 has to be split out rather than folded into the division,
+    // because sdiv INT_MIN, -1 is itself undefined.
+    unsigned Bits = Ty->getIntegerBitWidth();
+    Lo = B.CreateMul(A, Bv, "smulov.lo");
+    Constant *Zero = ConstantInt::get(Ty, 0);
+    Constant *One = ConstantInt::get(Ty, 1);
+    Constant *NegOne = Constant::getAllOnesValue(Ty);
+    Constant *IntMin = ConstantInt::get(Ty, APInt::getSignedMinValue(Bits));
+    Value *ANotZero = B.CreateICmpNE(A, Zero, "smulov.anz");
+    Value *AIsNegOne = B.CreateICmpEQ(A, NegOne, "smulov.aneg1");
+    Value *NegOneOv = B.CreateAnd(AIsNegOne,
+                                  B.CreateICmpEQ(Bv, IntMin, "smulov.bmin"),
+                                  "smulov.ovneg1");
+    Value *Divisible = B.CreateAnd(ANotZero, B.CreateNot(AIsNegOne),
+                                   "smulov.divisible");
+    Value *SafeA = B.CreateSelect(Divisible, A, One, "smulov.safea");
+    Value *Back = B.CreateSDiv(Lo, SafeA, "smulov.back");
+    Value *Ne = B.CreateICmpNE(Back, Bv, "smulov.ne");
+    Ov = B.CreateOr(NegOneOv, B.CreateAnd(Divisible, Ne, "smulov.divov"),
+                    "smulov.ov");
+  } else {
+    return false;
+  }
+
+  Value *Agg = UndefValue::get(II->getType());
+  Agg = B.CreateInsertValue(Agg, Lo, 0, "ov.agg.lo");
+  Agg = B.CreateInsertValue(Agg, Ov, 1, "ov.agg");
+  II->replaceAllUsesWith(Agg);
+  II->eraseFromParent();
+  return true;
+}
+
+} // namespace
+
+PreservedAnalyses HipLowerOverflowIntrinsicsPass::run(Module &M,
+                                                      ModuleAnalysisManager &AM) {
+  SmallVector<IntrinsicInst *, 8> Worklist;
+  for (Function &F : M)
+    for (BasicBlock &BB : F)
+      for (Instruction &I : BB)
+        if (auto *II = dyn_cast<IntrinsicInst>(&I))
+          if (II->getIntrinsicID() == Intrinsic::umul_with_overflow ||
+              II->getIntrinsicID() == Intrinsic::smul_with_overflow)
+            Worklist.push_back(II);
+
+  bool Changed = false;
+  for (IntrinsicInst *II : Worklist)
+    Changed |= expandCall(II);
+
+  return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
+}

--- a/llvm_passes/HipLowerOverflowIntrinsics.h
+++ b/llvm_passes/HipLowerOverflowIntrinsics.h
@@ -1,0 +1,34 @@
+//===- HipLowerOverflowIntrinsics.h ---------------------------------------===//
+//
+// Part of the chipStar Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Expands llvm.{u,s}mul.with.overflow into plain integer arithmetic so the
+// SPIR-V producer never has to emit the spirv.llvm_*_with_overflow_* helper
+// functions.
+//
+// Copyright (c) 2026 chipStar developers
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_PASSES_HIP_LOWER_OVERFLOW_INTRINSICS_H
+#define LLVM_PASSES_HIP_LOWER_OVERFLOW_INTRINSICS_H
+
+#include "llvm/IR/PassManager.h"
+
+using namespace llvm;
+
+#if LLVM_VERSION_MAJOR < 14
+#error LLVM 14+ required.
+#endif
+
+class HipLowerOverflowIntrinsicsPass
+    : public PassInfoMixin<HipLowerOverflowIntrinsicsPass> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  static bool isRequired() { return true; }
+};
+
+#endif

--- a/llvm_passes/HipLowerOverflowIntrinsics.h
+++ b/llvm_passes/HipLowerOverflowIntrinsics.h
@@ -1,0 +1,33 @@
+//===- HipLowerOverflowIntrinsics.h ---------------------------------------===//
+//
+// Part of the chipStar Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Expands llvm.{u,s}mul.with.overflow into plain integer arithmetic so that
+// neither intrinsic reaches SPIR-V emission.
+//
+// Copyright (c) 2026 chipStar developers
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_PASSES_HIP_LOWER_OVERFLOW_INTRINSICS_H
+#define LLVM_PASSES_HIP_LOWER_OVERFLOW_INTRINSICS_H
+
+#include "llvm/IR/PassManager.h"
+
+using namespace llvm;
+
+#if LLVM_VERSION_MAJOR < 14
+#error LLVM 14+ required.
+#endif
+
+class HipLowerOverflowIntrinsicsPass
+    : public PassInfoMixin<HipLowerOverflowIntrinsicsPass> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  static bool isRequired() { return true; }
+};
+
+#endif

--- a/llvm_passes/HipPasses.cpp
+++ b/llvm_passes/HipPasses.cpp
@@ -33,6 +33,7 @@
 #include "HipLowerFPAtomicMinMax.h"
 #include "HipIGBADetector.h"
 #include "HipPromoteInts.h"
+#include "HipLowerOverflowIntrinsics.h"
 #include "HipSpirvFunctionReorderPass.h"
 #include "HipVerify.h"
 #include "HipCanonicalizeGEP.h"
@@ -210,6 +211,15 @@ static void addFullLinkTimePasses(ModulePassManager &MPM) {
   // Fix InvalidBitWidth errors due to non-standard integer types
   addPassWithVerification(MPM, HipPromoteIntsPass(), "HipPromoteIntsPass");
 
+  // Expand llvm.{u,s}mul.with.overflow, which clang emits for device-side
+  // array-new and __builtin_mul_overflow. Left in place, the backend lane
+  // emits OpUMulExtended, which IGC rejects with an undefined reference to
+  // _Z20__spirv_UMulExtendedll, and the translator lane cannot lower the
+  // signed intrinsic at all. Either failure takes down every kernel in the
+  // module.
+  addPassWithVerification(MPM, HipLowerOverflowIntrinsicsPass(),
+                          "HipLowerOverflowIntrinsicsPass");
+
   // Must be last: removes __chip_*/__hip_* globals and stubs their users.
   // Runs after HipIGBADetectorPass which creates __chip_module_has_no_IGBAs.
   addPassWithVerification(MPM, HipCleanupPass(), "HipCleanupPass");
@@ -253,6 +263,12 @@ llvmGetPassPluginInfo() {
                   // Register merged IR+SPIR-V validation pass as standalone (legacy - use hip-verify instead)
                   if (Name == "ir-spirv-validate") {
                     MPM.addPass(HipVerifyPass("IR+SPIR-V validation"));
+                    return true;
+                  }
+                  // Register the overflow intrinsic lowering as standalone,
+                  // which makes it directly testable with opt.
+                  if (Name == "hip-lower-overflow-intrinsics") {
+                    MPM.addPass(HipLowerOverflowIntrinsicsPass());
                     return true;
                   }
                   // Register SPIR-V function reorder pass as standalone

--- a/llvm_passes/HipPasses.cpp
+++ b/llvm_passes/HipPasses.cpp
@@ -31,6 +31,7 @@
 #include "HipLowerMemset.h"
 #include "HipIGBADetector.h"
 #include "HipPromoteInts.h"
+#include "HipLowerOverflowIntrinsics.h"
 #include "HipSpirvFunctionReorderPass.h"
 #include "HipVerify.h"
 
@@ -197,6 +198,15 @@ static void addFullLinkTimePasses(ModulePassManager &MPM) {
   // Fix InvalidBitWidth errors due to non-standard integer types
   addPassWithVerification(MPM, HipPromoteIntsPass(), "HipPromoteIntsPass");
 
+  // Expand llvm.{u,s}mul.with.overflow, which clang emits for device-side
+  // array-new and __builtin_mul_overflow. Left in place the SPIR-V producer
+  // emits a spirv.llvm_umul_with_overflow_* helper that the consumer maps
+  // back onto the intrinsic and leaves undefined as
+  // old_llvm.umul.with.overflow.i64, failing the build of every kernel in
+  // the module.
+  addPassWithVerification(MPM, HipLowerOverflowIntrinsicsPass(),
+                          "HipLowerOverflowIntrinsicsPass");
+
   // Must be last: removes __chip_*/__hip_* globals and stubs their users.
   // Runs after HipIGBADetectorPass which creates __chip_module_has_no_IGBAs.
   addPassWithVerification(MPM, HipCleanupPass(), "HipCleanupPass");
@@ -235,6 +245,12 @@ llvmGetPassPluginInfo() {
                   // Register merged IR+SPIR-V validation pass as standalone (legacy - use hip-verify instead)
                   if (Name == "ir-spirv-validate") {
                     MPM.addPass(HipVerifyPass("IR+SPIR-V validation"));
+                    return true;
+                  }
+                  // Register the overflow intrinsic lowering as standalone,
+                  // which makes it directly testable with opt.
+                  if (Name == "hip-lower-overflow-intrinsics") {
+                    MPM.addPass(HipLowerOverflowIntrinsicsPass());
                     return true;
                   }
                   // Register SPIR-V function reorder pass as standalone

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -13,9 +13,8 @@ set_tests_properties(TestFixUmul64hi PROPERTIES
   TIMEOUT 60)
 
 add_hip_test(TestFix1391UmulWithOverflow.hip)
-# Reproduce #1391: llvm.umul.with.overflow reaching SPIR-V as a
-# spirv.llvm_umul_with_overflow_* helper, which the consumer maps back to the
-# intrinsic and leaves as an undefined old_llvm.umul.with.overflow.i64,
+# Reproduce #1391: llvm.umul.with.overflow reaching SPIR-V as OpUMulExtended,
+# which IGC rejects with an undefined reference to _Z20__spirv_UMulExtendedll,
 # failing the build of every kernel in the module.
 set_tests_properties(TestFix1391UmulWithOverflow PROPERTIES
   PASS_REGULAR_EXPRESSION "PASS"

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -12,4 +12,14 @@ set_tests_properties(TestFixUmul64hi PROPERTIES
   PASS_REGULAR_EXPRESSION "PASS"
   TIMEOUT 60)
 
+add_hip_test(TestFix1391UmulWithOverflow.hip)
+# Reproduce #1391: llvm.umul.with.overflow reaching SPIR-V as a
+# spirv.llvm_umul_with_overflow_* helper, which the consumer maps back to the
+# intrinsic and leaves as an undefined old_llvm.umul.with.overflow.i64,
+# failing the build of every kernel in the module.
+set_tests_properties(TestFix1391UmulWithOverflow PROPERTIES
+  PASS_REGULAR_EXPRESSION "PASS"
+  FAIL_REGULAR_EXPRESSION "FAIL"
+  TIMEOUT 60)
+
 add_hip_test(test_shutdown_crossqueue_dep.cpp)

--- a/tests/regression/TestFix1391UmulWithOverflow.hip
+++ b/tests/regression/TestFix1391UmulWithOverflow.hip
@@ -1,0 +1,95 @@
+// Regression test for: llvm.umul.with.overflow in device code must not reach
+// the SPIR-V consumer as a spirv.llvm_umul_with_overflow_* helper.
+//
+// Bug (#1391): clang emits llvm.umul.with.overflow.i64 for the count times
+// size computation of a device-side "new T[n]", and for __builtin_mul_overflow.
+// The LLVM SPIR-V producer cannot express the intrinsic, so it emits a helper
+// function named spirv.llvm_umul_with_overflow_i64 and calls that. The
+// consumer reads the SPIR-V back into LLVM IR, maps the helper onto the
+// intrinsic again, renames the declaration to old_llvm.umul.with.overflow.i64
+// and never gives it a body:
+//
+//   error: undefined reference to `old_llvm.umul.with.overflow.i64'
+//   error: backend compiler failed build.
+//
+// chipStar puts all device code of a binary into one module, so that single
+// unresolved symbol makes every kernel in the program fail to build, while
+// hipDeviceSynchronize() keeps returning hipSuccess and the outputs keep
+// their initial values.
+//
+// Fix: expand llvm.{u,s}mul.with.overflow into plain integer arithmetic in the
+// post-link pass pipeline so the construct never reaches SPIR-V.
+//
+// This uses __builtin_mul_overflow rather than "new T[n]" so it exercises the
+// intrinsic without also depending on the device heap.
+
+#include <hip/hip_runtime.h>
+#include <cstdio>
+#include <cstdint>
+
+__global__ void testUmulOverflow(uint64_t *Lo, uint64_t *Ov) {
+  uint64_t R = 0;
+
+  // 6 * 7 = 42, no overflow.
+  Ov[0] = __builtin_mul_overflow((uint64_t)6, (uint64_t)7, &R) ? 1 : 0;
+  Lo[0] = R;
+
+  // UINT64_MAX * 2 overflows, low half is 0xFFFFFFFFFFFFFFFE.
+  R = 0;
+  Ov[1] = __builtin_mul_overflow(UINT64_MAX, (uint64_t)2, &R) ? 1 : 0;
+  Lo[1] = R;
+
+  // 0 * UINT64_MAX does not overflow. Guards the divide-by-zero edge of any
+  // expansion that computes the overflow predicate with a division.
+  R = 0;
+  Ov[2] = __builtin_mul_overflow((uint64_t)0, UINT64_MAX, &R) ? 1 : 0;
+  Lo[2] = R;
+
+  // 2^32 * 2^32 = 2^64 overflows, low half is 0.
+  R = 0;
+  Ov[3] = __builtin_mul_overflow((uint64_t)1 << 32, (uint64_t)1 << 32, &R) ? 1 : 0;
+  Lo[3] = R;
+}
+
+int main() {
+  const int N = 4;
+  uint64_t *DLo = nullptr, *DOv = nullptr;
+  if (hipMalloc(&DLo, N * sizeof(uint64_t)) != hipSuccess) {
+    printf("SKIP: no GPU\n");
+    return 0;
+  }
+  if (hipMalloc(&DOv, N * sizeof(uint64_t)) != hipSuccess) {
+    printf("SKIP: no GPU\n");
+    return 0;
+  }
+  hipMemset(DLo, 0, N * sizeof(uint64_t));
+  hipMemset(DOv, 0, N * sizeof(uint64_t));
+
+  hipLaunchKernelGGL(testUmulOverflow, dim3(1), dim3(1), 0, 0, DLo, DOv);
+  if (hipDeviceSynchronize() != hipSuccess) {
+    printf("FAIL: kernel launch or sync failed\n");
+    return 1;
+  }
+
+  uint64_t HLo[N] = {0}, HOv[N] = {0};
+  hipMemcpy(HLo, DLo, sizeof(HLo), hipMemcpyDeviceToHost);
+  hipMemcpy(HOv, DOv, sizeof(HOv), hipMemcpyDeviceToHost);
+  hipFree(DLo);
+  hipFree(DOv);
+
+  const uint64_t WantLo[N] = {42, UINT64_MAX - 1, 0, 0};
+  const uint64_t WantOv[N] = {0, 1, 0, 1};
+
+  int Bad = 0;
+  for (int I = 0; I < N; ++I) {
+    if (HLo[I] != WantLo[I] || HOv[I] != WantOv[I]) {
+      printf("  case %d: got lo=%llu ov=%llu, want lo=%llu ov=%llu\n", I,
+             (unsigned long long)HLo[I], (unsigned long long)HOv[I],
+             (unsigned long long)WantLo[I], (unsigned long long)WantOv[I]);
+      ++Bad;
+    }
+  }
+
+  printf(Bad == 0 ? "PASS\n" : "FAIL\n");
+  return Bad == 0 ? 0 : 1;
+}

--- a/tests/regression/TestFix1391UmulWithOverflow.hip
+++ b/tests/regression/TestFix1391UmulWithOverflow.hip
@@ -1,24 +1,23 @@
-// Regression test for: llvm.umul.with.overflow in device code must not reach
-// the SPIR-V consumer as a spirv.llvm_umul_with_overflow_* helper.
+// Regression test for: llvm.{u,s}mul.with.overflow in device code must not
+// reach the SPIR-V consumer.
 //
 // Bug (#1391): clang emits llvm.umul.with.overflow.i64 for the count times
 // size computation of a device-side "new T[n]", and for __builtin_mul_overflow.
-// The LLVM SPIR-V producer cannot express the intrinsic, so it emits a helper
-// function named spirv.llvm_umul_with_overflow_i64 and calls that. The
-// consumer reads the SPIR-V back into LLVM IR, maps the helper onto the
-// intrinsic again, renames the declaration to old_llvm.umul.with.overflow.i64
-// and never gives it a body:
+// Through the in-tree SPIR-V backend the intrinsic becomes OpUMulExtended,
+// whose operands IGC's SPIR-V reader mangles as signed while its builtin
+// module defines only the unsigned overloads:
 //
-//   error: undefined reference to `old_llvm.umul.with.overflow.i64'
+//   error: undefined reference to `_Z20__spirv_UMulExtendedll'
 //   error: backend compiler failed build.
 //
-// chipStar puts all device code of a binary into one module, so that single
-// unresolved symbol makes every kernel in the program fail to build, while
-// hipDeviceSynchronize() keeps returning hipSuccess and the outputs keep
-// their initial values.
+// Through the llvm-spirv translator, llvm.smul.with.overflow has no lowering
+// and translation aborts outright. chipStar puts all device code of a binary
+// into one module, so either failure makes every kernel in the program fail to
+// build, while hipDeviceSynchronize() keeps returning hipSuccess and the
+// outputs keep their initial values.
 //
 // Fix: expand llvm.{u,s}mul.with.overflow into plain integer arithmetic in the
-// post-link pass pipeline so the construct never reaches SPIR-V.
+// post-link pass pipeline so neither construct reaches SPIR-V.
 //
 // This uses __builtin_mul_overflow rather than "new T[n]" so it exercises the
 // intrinsic without also depending on the device heap.


### PR DESCRIPTION
Fixes #1391

Expands `llvm.umul.with.overflow` and `llvm.smul.with.overflow` into plain integer arithmetic in the post-link pass pipeline, so neither construct reaches SPIR-V.

Both emission lanes fail on these otherwise. Through the in-tree SPIR-V backend, `llvm.umul.with.overflow` becomes `OpUMulExtended`, whose operands IGC's SPIR-V reader mangles as signed while IGC's builtin module defines only the unsigned overloads:

    error: undefined reference to `_Z20__spirv_UMulExtendedll'
    in function: '__spirv_UMulExtended(long, long)' called by kernel: 'k'
    error: backend compiler failed build.

Filed as intel/intel-graphics-compiler#432, and fixed upstream by KhronosGroup/SPIRV-LLVM-Translator#3963, which is on `main` only and not on the release branch IGC builds against. Through the llvm-spirv translator lane, `llvm.smul.with.overflow` has no lowering at all and translation aborts with `InvalidFunctionCall: Unexpected llvm intrinsic`. chipStar puts all device code of a binary into one module, so either failure takes down every kernel in the program.

Verified with `ocloc compile -spirv_input` on hand-built, `spirv-val` clean modules:

    OpUMulExtended   Aurora PVC IGC 2.11.29: fails    Arc B570 IGC 2.38.2: fails
    OpSMulExtended   Arc B570 IGC 2.38.2: builds
    OpIAddCarry, OpISubBorrow (uadd/usub.with.overflow): build, so this pass does not need to cover them

The overflow predicate uses a division rather than a 128-bit multiply because 128-bit integers are outside the OpenCL SPIR-V environment, and neither emission lane will produce one:

    llvm-spirv:            InvalidBitWidth: Invalid bit width in input: 128
    llc -mtriple=spirv64:  LLVM ERROR: OpTypeInt type with a width other than 8, 16, 32 or 64 bits
                           requires the following SPIR-V extension: SPV_ALTERA_arbitrary_precision_integers

Forcing that extension on the backend produces a module IGC then rejects, `InvalidModule: input SPIR-V module uses unknown extension 'SPV_ALTERA_arbitrary_precision_integers'`. The OpenCL SPIR-V environment spec (`env/required_capabilities.asciidoc`) lists `Int8`, `Int16` and `Int64` as the required integer capabilities and equates `OpTypeInt` to `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long` and `ulong`, with nothing wider.

These intrinsics come from allocation-size checks, so they are not hot. The signed case splits out `a == -1` instead of folding it into the division, because `sdiv INT_MIN, -1` is itself undefined.

Removal of the pass, once both upstream gaps close, is tracked by #1475.

The regression test uses `__builtin_mul_overflow` rather than `new T[n]`, because device-side allocation currently faults at address 0 (#1402, `__chipspv_device_heap` is never given a heap), so a `new T[n]` test would crash regardless of this fix.