### PR TITLE
ci: move docker build and publish to a GitHub-hosted runner

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -8,17 +8,17 @@ jobs:
   docker:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
 
     - name: Show disk usage
       run: df -h
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v4
 
     - name: Login to DockerHub
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: docker/login-action@v2
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -27,7 +27,7 @@ jobs:
     # and never COPYs from the build context, so a persistent layer cache makes that
     # clone a cache hit and republishes a stale build under :latest.
     - name: Build and push Docker image
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./docker/DockerfileLatest

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -3,6 +3,14 @@ name: Docker Build and Publish
 on:
   push:
     branches: [ main ]
+  # TEMPORARY: build on PRs and publish a throwaway pveleskopglc/chipstar:pr-<N>
+  # tag so the image can be pulled and GPU-tested before this lands on main.
+  # Reduced to a build-only check once validated.
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/publish-docker.yml'
+      - 'docker/**'
 
 jobs:
   docker:
@@ -17,11 +25,20 @@ jobs:
       uses: docker/setup-buildx-action@v4
 
     - name: Login to DockerHub
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    # TEMPORARY: :latest must never be published from a PR.
+    - name: Select image tag
+      id: tag
+      run: |
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          echo "tag=pveleskopglc/chipstar:pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+        else
+          echo "tag=pveleskopglc/chipstar:latest" >> $GITHUB_OUTPUT
+        fi
 
     # No build cache on purpose. DockerfileLatest git-clones chipStar inside a RUN
     # and never COPYs from the build context, so a persistent layer cache makes that
@@ -31,8 +48,8 @@ jobs:
       with:
         context: .
         file: ./docker/DockerfileLatest
-        push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        tags: pveleskopglc/chipstar:latest
+        push: true
+        tags: ${{ steps.tag.outputs.tag }}
 
     - name: Report disk usage
       if: always()

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -3,9 +3,7 @@ name: Docker Build and Publish
 on:
   push:
     branches: [ main ]
-  # TEMPORARY: build on PRs and publish a throwaway pveleskopglc/chipstar:pr-<N>
-  # tag so the image can be pulled and GPU-tested before this lands on main.
-  # Reduced to a build-only check once validated.
+  # Build-only check: PRs touching the image build it but never publish it.
   pull_request:
     branches: [ main ]
     paths:
@@ -25,20 +23,11 @@ jobs:
       uses: docker/setup-buildx-action@v4
 
     - name: Login to DockerHub
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-    # TEMPORARY: :latest must never be published from a PR.
-    - name: Select image tag
-      id: tag
-      run: |
-        if [ "${{ github.event_name }}" = "pull_request" ]; then
-          echo "tag=pveleskopglc/chipstar:pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-        else
-          echo "tag=pveleskopglc/chipstar:latest" >> $GITHUB_OUTPUT
-        fi
 
     # No build cache on purpose. DockerfileLatest git-clones chipStar inside a RUN
     # and never COPYs from the build context, so a persistent layer cache makes that
@@ -48,8 +37,8 @@ jobs:
       with:
         context: .
         file: ./docker/DockerfileLatest
-        push: true
-        tags: ${{ steps.tag.outputs.tag }}
+        push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        tags: pveleskopglc/chipstar:latest
 
     - name: Report disk usage
       if: always()

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -6,20 +6,26 @@ on:
 
 jobs:
   docker:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
-    
+
+    - name: Show disk usage
+      run: df -h
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
-    
+
     - name: Login to DockerHub
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    
+
+    # No build cache on purpose. DockerfileLatest git-clones chipStar inside a RUN
+    # and never COPYs from the build context, so a persistent layer cache makes that
+    # clone a cache hit and republishes a stale build under :latest.
     - name: Build and push Docker image
       uses: docker/build-push-action@v4
       with:
@@ -27,14 +33,7 @@ jobs:
         file: ./docker/DockerfileLatest
         push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         tags: pveleskopglc/chipstar:latest
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
 
-  cleanup:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [docker]
-    runs-on: [self-hosted, Linux, X64]
-    steps:
-    - name: Clean up old Docker images
-      run: |
-        docker image prune -af
+    - name: Report disk usage
+      if: always()
+      run: df -h


### PR DESCRIPTION
Moves the docker publish job from the self-hosted runner to ubuntu-22.04. Nothing in the build needs local hardware: the GPU smoke test was already removed from DockerfileLatest (docker build has no /dev/dri passthrough) and LLVM/pocl/oneAPI/NEO are prebuilt in the base image. Measured 14 minutes and 85G of free disk to spare.

Also drops the local buildx cache. DockerfileLatest git-clones chipStar inside a RUN and never COPYs from the build context, so a persistent layer cache makes that clone a cache hit and republishes a stale build under :latest.

Validated by temporarily publishing the PR image and pulling it: it enumerated the real Intel Arc B570 over OpenCL (not pocl), MatrixMultiply passed, and the baked-in chipStar matched current main. That scaffolding is removed; PRs touching docker/** now build without publishing.