### PR TITLE
devicelib: re-export the global modf overloads into std

### DIFF
--- a/include/hip/spirv_hip_devicelib.hh
+++ b/include/hip/spirv_hip_devicelib.hh
@@ -200,6 +200,26 @@ __HIP_OVERLOAD1(double, atan);
 __HIP_OVERLOAD1(double, acos);
 __HIP_OVERLOAD1(double, asin);
 __HIP_OVERLOAD1(double, tan);
+
+// libstdc++ pulls the C `modf` into std with a using-declaration, which covers
+// the double overload, but its float overload is a host-only inline. The device
+// `float modf(float, float *)` lives in the global namespace only, so a device
+// call written as `using std::modf; modf(x, &integral)` has no viable candidate
+// (float * does not convert to double *). Kokkos writes every math call that
+// way.
+//
+// Re-export the global overload set rather than declaring a new function here.
+// libstdc++'s <math.h> does `using std::modf;` at global scope, so a distinct
+// std::modf(float, float *) would collide with the global one declared in
+// devicelib/single_precision/sp_math.hh:
+//
+//   math.h:54:12: error: target of using declaration conflicts with
+//   declaration already in scope
+//
+// and every translation unit that includes <math.h> would stop compiling. A
+// using-declaration names the same entity, so bouncing it back out to the
+// global namespace is a no-op.
+using ::modf;
 } // namespace std
 
 #pragma pop_macro("__DEF_FLOAT_FUN")

--- a/tests/devicelib/CMakeLists.txt
+++ b/tests/devicelib/CMakeLists.txt
@@ -63,3 +63,7 @@ set_tests_properties(irif_no_i128 PROPERTIES
 add_hip_test(TestAtomicMinMaxFloat.cpp)
 set_tests_properties(TestAtomicMinMaxFloat PROPERTIES
   PASS_REGULAR_EXPRESSION "PASS")
+
+add_hip_test(TestStdModfFloat.cpp)
+set_tests_properties(TestStdModfFloat PROPERTIES
+  PASS_REGULAR_EXPRESSION "PASSED")

--- a/tests/devicelib/TestStdModfFloat.cpp
+++ b/tests/devicelib/TestStdModfFloat.cpp
@@ -1,0 +1,90 @@
+// Reproduces: std::modf has no single-precision device overload.
+//
+// chipStar declares `__device__ float modf(float, float *)` in the global
+// namespace but never pulls it into namespace std, so a device call written
+// the portable way
+//
+//   using std::modf; modf(x, &integral);
+//
+// sees only libstdc++'s host-only float overload and fails to compile.
+// Every other float function Kokkos routes through this idiom (frexp, ldexp,
+// scalbn, nearbyint, lrint) survives because the double overload is a viable
+// device candidate after a float to double conversion; modf cannot convert
+// float * to double *, so it has no device candidate at all.
+
+#include <hip/hip_runtime.h>
+// <math.h> is deliberately included as well: libstdc++'s <math.h> re-exports
+// std::modf into the global namespace, so declaring a *new* std::modf(float,
+// float *) here instead of re-exporting the global one makes this line fail
+// with "target of using declaration conflicts with declaration already in
+// scope" and takes out every translation unit that includes <math.h>.
+#include <math.h>
+#include <cmath>
+#include <cstdio>
+
+#define CHECK(X)                                                               \
+  do {                                                                         \
+    hipError_t E = (X);                                                        \
+    if (E != hipSuccess) {                                                     \
+      printf("FAILED: %s -> %s\n", #X, hipGetErrorString(E));                  \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+__device__ float callModfFloat(float X, float *Integral) {
+  using std::modf;
+  return modf(X, Integral);
+}
+
+__device__ double callModfDouble(double X, double *Integral) {
+  using std::modf;
+  return modf(X, Integral);
+}
+
+__global__ void run(float *FOut, double *DOut) {
+  FOut[1] = callModfFloat(-3.25f, &FOut[0]);
+  FOut[3] = callModfFloat(3.75f, &FOut[2]);
+  DOut[1] = callModfDouble(-3.25, &DOut[0]);
+}
+
+int main() {
+  float *FOut;
+  double *DOut;
+  CHECK(hipMalloc(&FOut, 4 * sizeof(float)));
+  CHECK(hipMalloc(&DOut, 2 * sizeof(double)));
+
+  hipLaunchKernelGGL(run, dim3(1), dim3(1), 0, 0, FOut, DOut);
+  CHECK(hipDeviceSynchronize());
+
+  float F[4];
+  double D[2];
+  CHECK(hipMemcpy(F, FOut, sizeof(F), hipMemcpyDeviceToHost));
+  CHECK(hipMemcpy(D, DOut, sizeof(D), hipMemcpyDeviceToHost));
+
+  int Errors = 0;
+  if (F[0] != -3.0f || F[1] != -0.25f) {
+    printf("float modf(-3.25): integral %f fractional %f, expected -3 -0.25\n",
+           F[0], F[1]);
+    ++Errors;
+  }
+  if (F[2] != 3.0f || F[3] != 0.75f) {
+    printf("float modf(3.75): integral %f fractional %f, expected 3 0.75\n",
+           F[2], F[3]);
+    ++Errors;
+  }
+  if (D[0] != -3.0 || D[1] != -0.25) {
+    printf("double modf(-3.25): integral %f fractional %f, expected -3 -0.25\n",
+           D[0], D[1]);
+    ++Errors;
+  }
+
+  CHECK(hipFree(FOut));
+  CHECK(hipFree(DOut));
+
+  if (Errors) {
+    printf("FAILED\n");
+    return 1;
+  }
+  printf("PASSED\n");
+  return 0;
+}


### PR DESCRIPTION
Fixes #1399

libstdc++ gives std only a host-only float modf inline plus a using-declaration for the double C function, so a device call written as `using std::modf; modf(x, &integral)` on a float has no viable candidate: float * does not convert to double *.

The fix re-exports the existing global overload set with `using ::modf;` rather than declaring a new std::modf(float, float *). The first version of this PR did declare a new one, and that regressed `#include <math.h>`: libstdc++'s <math.h> does `using std::modf;` at global scope, which then conflicts with the global `::modf(float, float *)` in sp_math.hh:

    math.h:54:12: error: target of using declaration conflicts with declaration already in scope

That broke two stk_search translation units. Thanks for catching it. A using-declaration names the same entity, so bouncing it back out to the global namespace is a no-op.

tests/devicelib/TestStdModfFloat.cpp now includes <math.h> for exactly that reason, so the test pins the shape of the fix as well as its effect. Verified on Intel Arc B570 (OpenCL): with the new-declaration version the test does not compile, with the re-export version it is PASSED, and a bare `#include <math.h>` plus `int main(){}` compiles again. Checked values are modf(-3.25f) and modf(3.75f) for float and modf(-3.25) for double.