### PR TITLE
llvm_passes: lower atomicrmw fmin and fmax to cmpxchg loops

### DIFF
--- a/llvm_passes/CMakeLists.txt
+++ b/llvm_passes/CMakeLists.txt
@@ -102,7 +102,7 @@ add_library(LLVMHipPasses MODULE HipPasses.cpp
     HipPrintf.cpp HipGlobalVariables.cpp HipCleanup.cpp HipTextureLowering.cpp HipAbort.cpp
     HipEmitLoweredNames.cpp HipWarps.cpp HipKernelArgSpiller.cpp
     HipLowerZeroLengthArrays.cpp HipSanityChecks.cpp HipLowerSwitch.cpp
-    HipLowerMemset.cpp HipIGBADetector.cpp HipPromoteInts.cpp
+    HipLowerMemset.cpp HipLowerFPAtomicMinMax.cpp HipIGBADetector.cpp HipPromoteInts.cpp
     HipSpirvFunctionReorderPass.cpp
     HipVerify.cpp HipCanonicalizeGEP.cpp
     ${EXTRA_OBJS})

--- a/llvm_passes/CMakeLists.txt
+++ b/llvm_passes/CMakeLists.txt
@@ -102,7 +102,7 @@ add_library(LLVMHipPasses MODULE HipPasses.cpp
     HipPrintf.cpp HipGlobalVariables.cpp HipCleanup.cpp HipTextureLowering.cpp HipAbort.cpp
     HipEmitLoweredNames.cpp HipWarps.cpp HipKernelArgSpiller.cpp
     HipLowerZeroLengthArrays.cpp HipSanityChecks.cpp HipLowerSwitch.cpp
-    HipLowerMemset.cpp HipIGBADetector.cpp HipPromoteInts.cpp
+    HipLowerMemset.cpp HipLowerFPAtomicMinMax.cpp HipIGBADetector.cpp HipPromoteInts.cpp
     HipSpirvFunctionReorderPass.cpp
     HipVerify.cpp
     ${EXTRA_OBJS})

--- a/llvm_passes/HipLowerFPAtomicMinMax.cpp
+++ b/llvm_passes/HipLowerFPAtomicMinMax.cpp
@@ -1,0 +1,142 @@
+//===- HipLowerFPAtomicMinMax.cpp -----------------------------------------===//
+//
+// Part of the chipStar Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Clang lowers __hip_atomic_fetch_min / __hip_atomic_fetch_max on a floating
+// point type to `atomicrmw fmin` / `fmax`. llvm-spirv can only translate those
+// with SPV_EXT_shader_atomic_float_min_max, which is not in the extension allow
+// list chipStar's driver passes to the translator, so the link fails with
+//
+//   RequiresExtension: Feature requires the following SPIR-V extension:
+//    SPV_EXT_shader_atomic_float_min_max
+//
+// Widening the allow list would only move the failure to program build time on
+// drivers without cl_ext_float_atomics. Expand the operation to a cmpxchg loop
+// instead, which every target chipStar supports can run, and which is what
+// devicelib.cl already does for atomicMin and atomicMax.
+//
+// (c) 2026 chipStar developers
+//===----------------------------------------------------------------------===//
+
+#include "HipLowerFPAtomicMinMax.h"
+
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Intrinsics.h>
+#include <llvm/Passes/PassBuilder.h>
+#include "PassPluginCompat.h"
+
+#define PASS_NAME "hip-lower-fp-atomic-min-max"
+#define DEBUG_TYPE PASS_NAME
+
+using namespace llvm;
+
+static bool isFPMinMax(const AtomicRMWInst &RMW) {
+  return RMW.getOperation() == AtomicRMWInst::FMin ||
+         RMW.getOperation() == AtomicRMWInst::FMax;
+}
+
+/// Replace `RMW` with
+///
+///   loop:  %loaded = phi [ %init, %entry ], [ %prev, %loop ]
+///          %new    = llvm.minnum/maxnum(%loaded, %operand)
+///          %pair   = cmpxchg ptr, bitcast(%loaded), bitcast(%new)
+///          %prev   = bitcast(extractvalue %pair, 0)
+///          br (extractvalue %pair, 1), %end, %loop
+///
+/// and hand the original value, %loaded, back to the users of `RMW`.
+static void expandToCmpXchgLoop(AtomicRMWInst *RMW) {
+  Type *ValueTy = RMW->getType();
+  LLVMContext &Ctx = RMW->getContext();
+  Value *Ptr = RMW->getPointerOperand();
+  Value *Operand = RMW->getValOperand();
+
+  IntegerType *IntTy =
+      IntegerType::get(Ctx, ValueTy->getPrimitiveSizeInBits());
+
+  BasicBlock *EntryBB = RMW->getParent();
+  BasicBlock *EndBB = EntryBB->splitBasicBlock(RMW->getIterator(), "atomicrmw.end");
+  BasicBlock *LoopBB =
+      BasicBlock::Create(Ctx, "atomicrmw.start", EntryBB->getParent(), EndBB);
+
+  // splitBasicBlock left an unconditional branch to EndBB; retarget it.
+  EntryBB->getTerminator()->eraseFromParent();
+  IRBuilder<> Builder(EntryBB);
+  LoadInst *Init = Builder.CreateAlignedLoad(ValueTy, Ptr, RMW->getAlign());
+  Init->setAtomic(AtomicOrdering::Monotonic, RMW->getSyncScopeID());
+  Init->setVolatile(RMW->isVolatile());
+  Builder.CreateBr(LoopBB);
+
+  Builder.SetInsertPoint(LoopBB);
+  PHINode *Loaded = Builder.CreatePHI(ValueTy, 2, "loaded");
+  Loaded->addIncoming(Init, EntryBB);
+
+  Intrinsic::ID ID = RMW->getOperation() == AtomicRMWInst::FMin
+                         ? Intrinsic::minnum
+                         : Intrinsic::maxnum;
+  Value *New = Builder.CreateBinaryIntrinsic(ID, Loaded, Operand);
+
+  // cmpxchg only accepts integer and pointer types.
+  Value *LoadedInt = Builder.CreateBitCast(Loaded, IntTy);
+  Value *NewInt = Builder.CreateBitCast(New, IntTy);
+  AtomicOrdering Success = RMW->getOrdering();
+  AtomicOrdering Failure =
+      AtomicCmpXchgInst::getStrongestFailureOrdering(Success);
+  AtomicCmpXchgInst *Pair =
+      Builder.CreateAtomicCmpXchg(Ptr, LoadedInt, NewInt, RMW->getAlign(),
+                                  Success, Failure, RMW->getSyncScopeID());
+  Pair->setVolatile(RMW->isVolatile());
+  Pair->setWeak(false);
+
+  Value *PrevInt = Builder.CreateExtractValue(Pair, 0, "prev");
+  Value *Done = Builder.CreateExtractValue(Pair, 1, "done");
+  Value *Prev = Builder.CreateBitCast(PrevInt, ValueTy);
+  Loaded->addIncoming(Prev, LoopBB);
+  Builder.CreateCondBr(Done, EndBB, LoopBB);
+
+  RMW->replaceAllUsesWith(Loaded);
+  RMW->eraseFromParent();
+}
+
+static bool lowerFPAtomicMinMax(Function &F) {
+  SmallVector<AtomicRMWInst *, 8> WorkList;
+  for (auto &BB : F)
+    for (auto &I : BB)
+      if (auto *RMW = dyn_cast<AtomicRMWInst>(&I))
+        if (isFPMinMax(*RMW))
+          WorkList.push_back(RMW);
+
+  for (auto *RMW : WorkList)
+    expandToCmpXchgLoop(RMW);
+
+  return !WorkList.empty();
+}
+
+PreservedAnalyses HipLowerFPAtomicMinMaxPass::run(Function &F,
+                                                  FunctionAnalysisManager &AM) {
+  return lowerFPAtomicMinMax(F) ? PreservedAnalyses::none()
+                                : PreservedAnalyses::all();
+}
+
+extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
+llvmGetPassPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, PASS_NAME, LLVM_VERSION_STRING,
+          [](PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](StringRef Name, FunctionPassManager &FPM,
+                   ArrayRef<PassBuilder::PipelineElement>) {
+                  if (Name == PASS_NAME) {
+                    FPM.addPass(HipLowerFPAtomicMinMaxPass());
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}

--- a/llvm_passes/HipLowerFPAtomicMinMax.h
+++ b/llvm_passes/HipLowerFPAtomicMinMax.h
@@ -1,0 +1,29 @@
+//===- HipLowerFPAtomicMinMax.h -------------------------------------------===//
+//
+// Part of the chipStar Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Expands `atomicrmw fmin` and `atomicrmw fmax` to cmpxchg loops so the module
+// does not require SPV_EXT_shader_atomic_float_min_max.
+//
+// (c) 2026 chipStar developers
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_PASSES_HIP_LOWER_FP_ATOMIC_MIN_MAX_H
+#define LLVM_PASSES_HIP_LOWER_FP_ATOMIC_MIN_MAX_H
+
+#include <llvm/IR/PassManager.h>
+
+using namespace llvm;
+
+class HipLowerFPAtomicMinMaxPass
+    : public PassInfoMixin<HipLowerFPAtomicMinMaxPass> {
+public:
+  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  static bool isRequired() { return true; }
+};
+
+#endif

--- a/llvm_passes/HipPasses.cpp
+++ b/llvm_passes/HipPasses.cpp
@@ -30,6 +30,7 @@
 #include "HipSanityChecks.h"
 #include "HipLowerSwitch.h"
 #include "HipLowerMemset.h"
+#include "HipLowerFPAtomicMinMax.h"
 #include "HipIGBADetector.h"
 #include "HipPromoteInts.h"
 #include "HipSpirvFunctionReorderPass.h"
@@ -182,6 +183,7 @@ static void addFullLinkTimePasses(ModulePassManager &MPM) {
   addPassWithVerification(MPM, HipPrintfToOpenCLPrintfPass(), "HipPrintfToOpenCLPrintfPass");
   addPassWithVerification(MPM, createModuleToFunctionPassAdaptor(HipDefrostPass()), "HipDefrostPass");
   addPassWithVerification(MPM, createModuleToFunctionPassAdaptor(HipLowerMemsetPass()), "HipLowerMemsetPass");
+  addPassWithVerification(MPM, createModuleToFunctionPassAdaptor(HipLowerFPAtomicMinMaxPass()), "HipLowerFPAtomicMinMaxPass");
   addPassWithVerification(MPM, HipAbortPass(), "HipAbortPass");
   // This pass must appear after HipDynMemExternReplaceNewPass.
   addPassWithVerification(MPM, HipGlobalVariablesPass(), "HipGlobalVariablesPass");

--- a/llvm_passes/HipPasses.cpp
+++ b/llvm_passes/HipPasses.cpp
@@ -29,6 +29,7 @@
 #include "HipSanityChecks.h"
 #include "HipLowerSwitch.h"
 #include "HipLowerMemset.h"
+#include "HipLowerFPAtomicMinMax.h"
 #include "HipIGBADetector.h"
 #include "HipPromoteInts.h"
 #include "HipSpirvFunctionReorderPass.h"
@@ -171,6 +172,7 @@ static void addFullLinkTimePasses(ModulePassManager &MPM) {
   addPassWithVerification(MPM, HipPrintfToOpenCLPrintfPass(), "HipPrintfToOpenCLPrintfPass");
   addPassWithVerification(MPM, createModuleToFunctionPassAdaptor(HipDefrostPass()), "HipDefrostPass");
   addPassWithVerification(MPM, createModuleToFunctionPassAdaptor(HipLowerMemsetPass()), "HipLowerMemsetPass");
+  addPassWithVerification(MPM, createModuleToFunctionPassAdaptor(HipLowerFPAtomicMinMaxPass()), "HipLowerFPAtomicMinMaxPass");
   addPassWithVerification(MPM, HipAbortPass(), "HipAbortPass");
   // This pass must appear after HipDynMemExternReplaceNewPass.
   addPassWithVerification(MPM, HipGlobalVariablesPass(), "HipGlobalVariablesPass");

--- a/tests/devicelib/CMakeLists.txt
+++ b/tests/devicelib/CMakeLists.txt
@@ -71,3 +71,7 @@ set_tests_properties(TestStdModfFloat PROPERTIES
 add_hip_test(TestAtomicIncDecMod.cpp)
 set_tests_properties(TestAtomicIncDecMod PROPERTIES
   PASS_REGULAR_EXPRESSION "PASSED")
+
+add_hip_test(TestAtomicFPMinMaxBuiltins.cpp)
+set_tests_properties(TestAtomicFPMinMaxBuiltins PROPERTIES
+  PASS_REGULAR_EXPRESSION "PASSED")

--- a/tests/devicelib/CMakeLists.txt
+++ b/tests/devicelib/CMakeLists.txt
@@ -63,3 +63,7 @@ set_tests_properties(irif_no_i128 PROPERTIES
 add_hip_test(TestAtomicMinMaxFloat.cpp)
 set_tests_properties(TestAtomicMinMaxFloat PROPERTIES
   PASS_REGULAR_EXPRESSION "PASS")
+
+add_hip_test(TestAtomicFPMinMaxBuiltins.cpp)
+set_tests_properties(TestAtomicFPMinMaxBuiltins PROPERTIES
+  PASS_REGULAR_EXPRESSION "PASSED")

--- a/tests/devicelib/TestAtomicFPMinMaxBuiltins.cpp
+++ b/tests/devicelib/TestAtomicFPMinMaxBuiltins.cpp
@@ -1,0 +1,105 @@
+// Reproduces: __hip_atomic_fetch_min / __hip_atomic_fetch_max on a floating
+// point type lower to `atomicrmw fmin` / `fmax`, which llvm-spirv can only
+// translate with SPV_EXT_shader_atomic_float_min_max. That extension is not in
+// chipStar's allow list, so the program does not even link:
+//
+//   RequiresExtension: Feature requires the following SPIR-V extension:
+//    SPV_EXT_shader_atomic_float_min_max
+//   clang++: error: hipspv-link command failed with exit code 18
+//
+// This is a different path from atomicMin(float *, float), which chipStar
+// routes to the CAS-based __chip_atomic_min_f32 in devicelib and which already
+// works (see TestAtomicMinMaxFloat.cpp).
+
+#include <hip/hip_runtime.h>
+#include <cstdio>
+
+#define CHECK(X)                                                               \
+  do {                                                                         \
+    hipError_t E = (X);                                                        \
+    if (E != hipSuccess) {                                                     \
+      printf("FAILED: %s -> %s\n", #X, hipGetErrorString(E));                  \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+constexpr int NumThreads = 256;
+
+__global__ void reduceFloat(float *Min, float *Max) {
+  float V = static_cast<float>(threadIdx.x) - 100.0f;
+  __hip_atomic_fetch_min(Min, V, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+  __hip_atomic_fetch_max(Max, V, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+}
+
+__global__ void reduceDouble(double *Min, double *Max) {
+  double V = static_cast<double>(threadIdx.x) - 100.0;
+  __hip_atomic_fetch_min(Min, V, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+  __hip_atomic_fetch_max(Max, V, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+}
+
+// The return value is the value seen before the update, so a single thread
+// walking a known sequence pins down the semantics exactly.
+__global__ void returnsPreviousValue(float *Cell, float *Seen) {
+  Seen[0] = __hip_atomic_fetch_min(Cell, 5.0f, __ATOMIC_RELAXED,
+                                   __HIP_MEMORY_SCOPE_AGENT); // was 10, now 5
+  Seen[1] = __hip_atomic_fetch_min(Cell, 7.0f, __ATOMIC_RELAXED,
+                                   __HIP_MEMORY_SCOPE_AGENT); // stays 5
+  Seen[2] = __hip_atomic_fetch_max(Cell, 9.0f, __ATOMIC_RELAXED,
+                                   __HIP_MEMORY_SCOPE_AGENT); // was 5, now 9
+}
+
+int main() {
+  float *F;
+  double *D;
+  CHECK(hipMalloc(&F, 6 * sizeof(float)));
+  CHECK(hipMalloc(&D, 2 * sizeof(double)));
+
+  float FInit[6] = {1e30f, -1e30f, 10.0f, 0.0f, 0.0f, 0.0f};
+  double DInit[2] = {1e300, -1e300};
+  CHECK(hipMemcpy(F, FInit, sizeof(FInit), hipMemcpyHostToDevice));
+  CHECK(hipMemcpy(D, DInit, sizeof(DInit), hipMemcpyHostToDevice));
+
+  hipLaunchKernelGGL(reduceFloat, dim3(1), dim3(NumThreads), 0, 0, &F[0],
+                     &F[1]);
+  hipLaunchKernelGGL(reduceDouble, dim3(1), dim3(NumThreads), 0, 0, &D[0],
+                     &D[1]);
+  hipLaunchKernelGGL(returnsPreviousValue, dim3(1), dim3(1), 0, 0, &F[2],
+                     &F[3]);
+  CHECK(hipDeviceSynchronize());
+
+  float FOut[6];
+  double DOut[2];
+  CHECK(hipMemcpy(FOut, F, sizeof(FOut), hipMemcpyDeviceToHost));
+  CHECK(hipMemcpy(DOut, D, sizeof(DOut), hipMemcpyDeviceToHost));
+
+  int Errors = 0;
+  if (FOut[0] != -100.0f || FOut[1] != float(NumThreads - 1) - 100.0f) {
+    printf("float reduction: min %f max %f, expected %f %f\n", FOut[0], FOut[1],
+           -100.0f, float(NumThreads - 1) - 100.0f);
+    ++Errors;
+  }
+  if (DOut[0] != -100.0 || DOut[1] != double(NumThreads - 1) - 100.0) {
+    printf("double reduction: min %f max %f, expected %f %f\n", DOut[0],
+           DOut[1], -100.0, double(NumThreads - 1) - 100.0);
+    ++Errors;
+  }
+  if (FOut[3] != 10.0f || FOut[4] != 5.0f || FOut[5] != 5.0f) {
+    printf("returned previous values: %f %f %f, expected 10 5 5\n", FOut[3],
+           FOut[4], FOut[5]);
+    ++Errors;
+  }
+  if (FOut[2] != 9.0f) {
+    printf("final cell %f, expected 9\n", FOut[2]);
+    ++Errors;
+  }
+
+  CHECK(hipFree(F));
+  CHECK(hipFree(D));
+
+  if (Errors) {
+    printf("FAILED\n");
+    return 1;
+  }
+  printf("PASSED\n");
+  return 0;
+}


### PR DESCRIPTION
Fixes #1403

__hip_atomic_fetch_min and __hip_atomic_fetch_max on a floating point type lower to atomicrmw fmin and fmax, which llvm-spirv can only translate with SPV_EXT_shader_atomic_float_min_max. That extension is not in the allow list chipStar's driver hands the translator, so the link dies.

Widening the allow list was the other option, but it would only move the failure to program build time on drivers without cl_ext_float_atomics. The new pass expands the operation to a cmpxchg loop, which every target chipStar supports can run, and which is what devicelib.cl already does for atomicMin and atomicMax.

New test tests/devicelib/TestAtomicFPMinMaxBuiltins.cpp, verified on Intel Arc B570 (OpenCL): does not link before, PASSED after. It covers float and double, a contended reduction, and the returned previous value.

Found while getting the Kokkos HIP backend running on chipStar; desul uses these builtins, which took out Kokkos_ContainersUnitTest_Serial and Kokkos_ContainersUnitTest_HIP.