### PR TITLE
llvm_passes: expand llvm.llround and llvm.llrint

### DIFF
--- a/llvm_passes/CMakeLists.txt
+++ b/llvm_passes/CMakeLists.txt
@@ -118,6 +118,7 @@ add_library(LLVMHipPasses MODULE
     HipLowerFPAtomicMinMax.cpp
     HipLowerMemset.cpp
     HipLowerOverflowIntrinsics.cpp
+    HipLowerRoundIntrinsics.cpp
     HipLowerSwitch.cpp
     HipLowerZeroLengthArrays.cpp
     HipPasses.cpp

--- a/llvm_passes/CMakeLists.txt
+++ b/llvm_passes/CMakeLists.txt
@@ -102,7 +102,8 @@ add_library(LLVMHipPasses MODULE HipPasses.cpp
     HipPrintf.cpp HipGlobalVariables.cpp HipCleanup.cpp HipTextureLowering.cpp HipAbort.cpp
     HipEmitLoweredNames.cpp HipWarps.cpp HipKernelArgSpiller.cpp
     HipLowerZeroLengthArrays.cpp HipSanityChecks.cpp HipLowerSwitch.cpp
-    HipLowerMemset.cpp HipIGBADetector.cpp HipPromoteInts.cpp
+    HipLowerMemset.cpp HipLowerRoundIntrinsics.cpp
+    HipIGBADetector.cpp HipPromoteInts.cpp
     HipSpirvFunctionReorderPass.cpp
     HipVerify.cpp
     ${EXTRA_OBJS})

--- a/llvm_passes/HipLowerRoundIntrinsics.cpp
+++ b/llvm_passes/HipLowerRoundIntrinsics.cpp
@@ -1,0 +1,111 @@
+//===- HipLowerRoundIntrinsics.cpp ----------------------------------------===//
+//
+// Part of the chipStar Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// libstdc++ declares std::llround and std::llrint for float as constexpr, which
+// HIP turns into implicitly __host__ __device__ functions. They therefore win
+// overload resolution in device code over anything chipStar could add (a plain
+// __device__ overload with the same signature is rejected outright), and expand
+// to __builtin_llroundf, i.e. an llvm.llround intrinsic. llvm-spirv has no
+// translation for it:
+//
+//   InvalidFunctionCall: Unexpected llvm intrinsic: llvm.llround.i64.f32
+//
+// The failure surfaces at hipspv-link with no source location at all. Since the
+// problem cannot be fixed in the headers, expand the intrinsic here: round in
+// floating point with llvm.round / llvm.rint, which the translator maps to the
+// OpenCL round and rint ExtInsts, then convert to the integer result. Calling
+// the devicelib entry points instead does not work, because devicelib is linked
+// in before the post-link passes run and only the symbols already referenced at
+// that point are pulled in.
+//
+// (c) 2026 chipStar developers
+//===----------------------------------------------------------------------===//
+
+#include "HipLowerRoundIntrinsics.h"
+
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Intrinsics.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Passes/PassBuilder.h>
+#include "PassPluginCompat.h"
+
+#define PASS_NAME "hip-lower-round-intrinsics"
+#define DEBUG_TYPE PASS_NAME
+
+using namespace llvm;
+
+/// The intrinsic llvm.llround / llvm.llrint expands to, or not_intrinsic when
+/// \p ID is something else.
+static Intrinsic::ID getRoundingIntrinsic(Intrinsic::ID ID) {
+  switch (ID) {
+  case Intrinsic::llround:
+    // llround rounds halfway cases away from zero, which is llvm.round.
+    return Intrinsic::round;
+  case Intrinsic::llrint:
+    // llrint follows the current rounding mode, which is llvm.rint.
+    return Intrinsic::rint;
+  default:
+    return Intrinsic::not_intrinsic;
+  }
+}
+
+static bool lowerRoundIntrinsics(Module &M) {
+  SmallVector<CallInst *, 8> WorkList;
+  for (auto &F : M)
+    for (auto &BB : F)
+      for (auto &I : BB)
+        if (auto *Call = dyn_cast<CallInst>(&I))
+          if (Function *Callee = Call->getCalledFunction())
+            if (Call->arg_size() == 1 &&
+                Call->getArgOperand(0)->getType()->isFloatingPointTy() &&
+                getRoundingIntrinsic(Callee->getIntrinsicID()) !=
+                    Intrinsic::not_intrinsic)
+              WorkList.push_back(Call);
+
+  for (auto *Call : WorkList) {
+    Value *Arg = Call->getArgOperand(0);
+    Intrinsic::ID Rounding =
+        getRoundingIntrinsic(Call->getCalledFunction()->getIntrinsicID());
+
+    IRBuilder<> Builder(Call);
+    // Round in floating point, which llvm-spirv maps to the OpenCL round and
+    // rint ExtInsts, then convert. The value is already integral at that point,
+    // so the truncating conversion is exact.
+    Value *Rounded = Builder.CreateUnaryIntrinsic(Rounding, Arg);
+    Value *Result = Builder.CreateFPToSI(Rounded, Call->getType());
+
+    Call->replaceAllUsesWith(Result);
+    Call->eraseFromParent();
+  }
+
+  return !WorkList.empty();
+}
+
+PreservedAnalyses HipLowerRoundIntrinsicsPass::run(Module &M,
+                                                   ModuleAnalysisManager &AM) {
+  return lowerRoundIntrinsics(M) ? PreservedAnalyses::none()
+                                 : PreservedAnalyses::all();
+}
+
+extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
+llvmGetPassPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, PASS_NAME, LLVM_VERSION_STRING,
+          [](PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](StringRef Name, ModulePassManager &MPM,
+                   ArrayRef<PassBuilder::PipelineElement>) {
+                  if (Name == PASS_NAME) {
+                    MPM.addPass(HipLowerRoundIntrinsicsPass());
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}

--- a/llvm_passes/HipLowerRoundIntrinsics.cpp
+++ b/llvm_passes/HipLowerRoundIntrinsics.cpp
@@ -1,0 +1,132 @@
+//===- HipLowerRoundIntrinsics.cpp ----------------------------------------===//
+//
+// Part of the chipStar Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Expands the type-crossing rounding intrinsics -- llvm.lround, llvm.llround,
+// llvm.lrint and llvm.llrint -- which take a floating point value and return an
+// integer. OpenCL.std has no instruction for that shape: every one of its
+// rounding instructions (ceil, floor, rint, round, trunc) is float to float, so
+// these four need a two instruction expansion rather than a 1:1 ExtInst. A
+// producer that does not do that expansion itself rejects the module:
+//
+//   InvalidFunctionCall: Unexpected llvm intrinsic: llvm.llround.i64.f32
+//
+// and, with the in-tree SPIR-V backend:
+//
+//   LLVM ERROR: unable to legalize instruction: %8:iid(s64) = G_INTRINSIC_LRINT
+//
+// The failure surfaces at hipspv-link with no source location at all, and it
+// cannot be headed off in the headers: libstdc++ declares these for float as
+// constexpr, which HIP turns into implicitly __host__ __device__ functions, so
+// they win overload resolution over anything chipStar could add (a plain
+// __device__ overload with the same signature is rejected outright).
+//
+// So expand them here: round in floating point with llvm.round / llvm.rint,
+// which both producers map to the OpenCL round and rint ExtInsts, then convert
+// to the integer result. Calling the devicelib entry points instead does not
+// work, because devicelib is linked in before the post-link passes run and only
+// the symbols already referenced at that point are pulled in.
+//
+// All four are handled, not just the ones that happen to be untranslatable
+// today, so that the set is defined by the shape of the intrinsic rather than
+// by which producer version is in use. Of the four, only lround is handled by
+// both producers as things stand, and both lower it to exactly this expansion
+// (OpExtInst round, then OpConvertFToS), so covering it changes no emitted
+// code. Taking the whole set also means the pass can be deleted in one go once
+// the producers cover all of it.
+//
+// (c) 2026 chipStar developers
+//===----------------------------------------------------------------------===//
+
+#include "HipLowerRoundIntrinsics.h"
+
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Intrinsics.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Passes/PassBuilder.h>
+#include "PassPluginCompat.h"
+
+#define PASS_NAME "hip-lower-round-intrinsics"
+#define DEBUG_TYPE PASS_NAME
+
+using namespace llvm;
+
+/// The floating point rounding intrinsic a type-crossing rounder expands to, or
+/// not_intrinsic when \p ID is something else.
+static Intrinsic::ID getRoundingIntrinsic(Intrinsic::ID ID) {
+  switch (ID) {
+  case Intrinsic::lround:
+  case Intrinsic::llround:
+    // lround and llround round halfway cases away from zero, which is
+    // llvm.round.
+    return Intrinsic::round;
+  case Intrinsic::lrint:
+  case Intrinsic::llrint:
+    // lrint and llrint follow the current rounding mode, which is llvm.rint.
+    return Intrinsic::rint;
+  default:
+    return Intrinsic::not_intrinsic;
+  }
+}
+
+static bool lowerRoundIntrinsics(Module &M) {
+  SmallVector<CallInst *, 8> WorkList;
+  for (auto &F : M)
+    for (auto &BB : F)
+      for (auto &I : BB)
+        if (auto *Call = dyn_cast<CallInst>(&I))
+          if (Function *Callee = Call->getCalledFunction())
+            if (Call->arg_size() == 1 &&
+                Call->getArgOperand(0)->getType()->isFloatingPointTy() &&
+                getRoundingIntrinsic(Callee->getIntrinsicID()) !=
+                    Intrinsic::not_intrinsic)
+              WorkList.push_back(Call);
+
+  for (auto *Call : WorkList) {
+    Value *Arg = Call->getArgOperand(0);
+    Intrinsic::ID Rounding =
+        getRoundingIntrinsic(Call->getCalledFunction()->getIntrinsicID());
+
+    IRBuilder<> Builder(Call);
+    // Round in floating point, which llvm-spirv maps to the OpenCL round and
+    // rint ExtInsts, then convert. The value is already integral at that point,
+    // so the truncating conversion is exact.
+    Value *Rounded = Builder.CreateUnaryIntrinsic(Rounding, Arg);
+    Value *Result = Builder.CreateFPToSI(Rounded, Call->getType());
+
+    Call->replaceAllUsesWith(Result);
+    Call->eraseFromParent();
+  }
+
+  return !WorkList.empty();
+}
+
+PreservedAnalyses HipLowerRoundIntrinsicsPass::run(Module &M,
+                                                   ModuleAnalysisManager &AM) {
+  return lowerRoundIntrinsics(M) ? PreservedAnalyses::none()
+                                 : PreservedAnalyses::all();
+}
+
+#ifndef CHIP_COMBINED_PASS_PLUGIN
+extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
+llvmGetPassPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, PASS_NAME, LLVM_VERSION_STRING,
+          [](PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](StringRef Name, ModulePassManager &MPM,
+                   ArrayRef<PassBuilder::PipelineElement>) {
+                  if (Name == PASS_NAME) {
+                    MPM.addPass(HipLowerRoundIntrinsicsPass());
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}
+#endif // CHIP_COMBINED_PASS_PLUGIN

--- a/llvm_passes/HipLowerRoundIntrinsics.h
+++ b/llvm_passes/HipLowerRoundIntrinsics.h
@@ -1,0 +1,31 @@
+//===- HipLowerRoundIntrinsics.h ------------------------------------------===//
+//
+// Part of the chipStar Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Expands the type-crossing rounding intrinsics llvm.lround.*, llvm.llround.*,
+// llvm.lrint.* and llvm.llrint.* to llvm.round / llvm.rint plus a conversion.
+// They return an integer, and OpenCL.std has only float to float rounding
+// instructions, so neither SPIR-V producer can translate them directly.
+//
+// (c) 2026 chipStar developers
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_PASSES_HIP_LOWER_ROUND_INTRINSICS_H
+#define LLVM_PASSES_HIP_LOWER_ROUND_INTRINSICS_H
+
+#include <llvm/IR/PassManager.h>
+
+using namespace llvm;
+
+class HipLowerRoundIntrinsicsPass
+    : public PassInfoMixin<HipLowerRoundIntrinsicsPass> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  static bool isRequired() { return true; }
+};
+
+#endif

--- a/llvm_passes/HipLowerRoundIntrinsics.h
+++ b/llvm_passes/HipLowerRoundIntrinsics.h
@@ -1,0 +1,29 @@
+//===- HipLowerRoundIntrinsics.h ------------------------------------------===//
+//
+// Part of the chipStar Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Expands llvm.llround.* and llvm.llrint.*, which llvm-spirv cannot translate,
+// to llvm.round / llvm.rint plus a conversion.
+//
+// (c) 2026 chipStar developers
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_PASSES_HIP_LOWER_ROUND_INTRINSICS_H
+#define LLVM_PASSES_HIP_LOWER_ROUND_INTRINSICS_H
+
+#include <llvm/IR/PassManager.h>
+
+using namespace llvm;
+
+class HipLowerRoundIntrinsicsPass
+    : public PassInfoMixin<HipLowerRoundIntrinsicsPass> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  static bool isRequired() { return true; }
+};
+
+#endif

--- a/llvm_passes/HipPasses.cpp
+++ b/llvm_passes/HipPasses.cpp
@@ -31,6 +31,7 @@
 #include "HipLowerSwitch.h"
 #include "HipLowerMemset.h"
 #include "HipLowerFPAtomicMinMax.h"
+#include "HipLowerRoundIntrinsics.h"
 #include "HipIGBADetector.h"
 #include "HipPromoteInts.h"
 #include "HipLowerOverflowIntrinsics.h"
@@ -185,6 +186,7 @@ static void addFullLinkTimePasses(ModulePassManager &MPM) {
   addPassWithVerification(MPM, createModuleToFunctionPassAdaptor(HipDefrostPass()), "HipDefrostPass");
   addPassWithVerification(MPM, createModuleToFunctionPassAdaptor(HipLowerMemsetPass()), "HipLowerMemsetPass");
   addPassWithVerification(MPM, createModuleToFunctionPassAdaptor(HipLowerFPAtomicMinMaxPass()), "HipLowerFPAtomicMinMaxPass");
+  addPassWithVerification(MPM, HipLowerRoundIntrinsicsPass(), "HipLowerRoundIntrinsicsPass");
   addPassWithVerification(MPM, HipAbortPass(), "HipAbortPass");
   // This pass must appear after HipDynMemExternReplaceNewPass.
   addPassWithVerification(MPM, HipGlobalVariablesPass(), "HipGlobalVariablesPass");

--- a/llvm_passes/HipPasses.cpp
+++ b/llvm_passes/HipPasses.cpp
@@ -29,6 +29,7 @@
 #include "HipSanityChecks.h"
 #include "HipLowerSwitch.h"
 #include "HipLowerMemset.h"
+#include "HipLowerRoundIntrinsics.h"
 #include "HipIGBADetector.h"
 #include "HipPromoteInts.h"
 #include "HipSpirvFunctionReorderPass.h"
@@ -171,6 +172,7 @@ static void addFullLinkTimePasses(ModulePassManager &MPM) {
   addPassWithVerification(MPM, HipPrintfToOpenCLPrintfPass(), "HipPrintfToOpenCLPrintfPass");
   addPassWithVerification(MPM, createModuleToFunctionPassAdaptor(HipDefrostPass()), "HipDefrostPass");
   addPassWithVerification(MPM, createModuleToFunctionPassAdaptor(HipLowerMemsetPass()), "HipLowerMemsetPass");
+  addPassWithVerification(MPM, HipLowerRoundIntrinsicsPass(), "HipLowerRoundIntrinsicsPass");
   addPassWithVerification(MPM, HipAbortPass(), "HipAbortPass");
   // This pass must appear after HipDynMemExternReplaceNewPass.
   addPassWithVerification(MPM, HipGlobalVariablesPass(), "HipGlobalVariablesPass");

--- a/tests/devicelib/CMakeLists.txt
+++ b/tests/devicelib/CMakeLists.txt
@@ -63,3 +63,7 @@ set_tests_properties(irif_no_i128 PROPERTIES
 add_hip_test(TestAtomicMinMaxFloat.cpp)
 set_tests_properties(TestAtomicMinMaxFloat PROPERTIES
   PASS_REGULAR_EXPRESSION "PASS")
+
+add_hip_test(TestStdLlroundFloat.cpp)
+set_tests_properties(TestStdLlroundFloat PROPERTIES
+  PASS_REGULAR_EXPRESSION "PASSED")

--- a/tests/devicelib/CMakeLists.txt
+++ b/tests/devicelib/CMakeLists.txt
@@ -75,3 +75,7 @@ set_tests_properties(TestAtomicIncDecMod PROPERTIES
 add_hip_test(TestAtomicFPMinMaxBuiltins.cpp)
 set_tests_properties(TestAtomicFPMinMaxBuiltins PROPERTIES
   PASS_REGULAR_EXPRESSION "PASSED")
+
+add_hip_test(TestStdLlroundFloat.cpp)
+set_tests_properties(TestStdLlroundFloat PROPERTIES
+  PASS_REGULAR_EXPRESSION "PASSED")

--- a/tests/devicelib/TestStdLlroundFloat.cpp
+++ b/tests/devicelib/TestStdLlroundFloat.cpp
@@ -1,0 +1,78 @@
+// Reproduces: std::llround and std::llrint on a float expand to
+// __builtin_llroundf / __builtin_llrintf, i.e. llvm.llround / llvm.llrint,
+// which llvm-spirv cannot translate:
+//
+//   InvalidFunctionCall: Unexpected llvm intrinsic: llvm.llround.i64.f32
+//   clang++: error: hipspv-link command failed with exit code 8
+//
+// libstdc++'s float overloads are constexpr, so HIP has already made them
+// implicitly __host__ __device__ and they win overload resolution over
+// chipStar's own device declarations. lround, lrint, nearbyint, rint, round
+// and trunc all translate; only these two do not.
+
+#include <hip/hip_runtime.h>
+#include <cmath>
+#include <cstdio>
+
+#define CHECK(X)                                                               \
+  do {                                                                         \
+    hipError_t E = (X);                                                        \
+    if (E != hipSuccess) {                                                     \
+      printf("FAILED: %s -> %s\n", #X, hipGetErrorString(E));                  \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+__global__ void run(const float *In, const double *InD, long long *Out) {
+  using std::llrint;
+  using std::llround;
+  Out[0] = llround(In[0]);
+  Out[1] = llround(In[1]);
+  Out[2] = llrint(In[0]);
+  Out[3] = llround(InD[0]);
+  Out[4] = llrint(InD[0]);
+}
+
+int main() {
+  float HostIn[2] = {2.5f, -2.5f};
+  double HostInD[1] = {7.5};
+
+  float *In;
+  double *InD;
+  long long *Out;
+  CHECK(hipMalloc(&In, sizeof(HostIn)));
+  CHECK(hipMalloc(&InD, sizeof(HostInD)));
+  CHECK(hipMalloc(&Out, 5 * sizeof(long long)));
+  CHECK(hipMemcpy(In, HostIn, sizeof(HostIn), hipMemcpyHostToDevice));
+  CHECK(hipMemcpy(InD, HostInD, sizeof(HostInD), hipMemcpyHostToDevice));
+
+  hipLaunchKernelGGL(run, dim3(1), dim3(1), 0, 0, In, InD, Out);
+  CHECK(hipDeviceSynchronize());
+
+  long long HostOut[5];
+  CHECK(hipMemcpy(HostOut, Out, sizeof(HostOut), hipMemcpyDeviceToHost));
+
+  // llround rounds half away from zero; llrint follows the rounding mode,
+  // which is round to nearest even by default.
+  const long long Expected[5] = {3, -3, 2, 8, 8};
+  const char *Names[5] = {"llround(2.5f)", "llround(-2.5f)", "llrint(2.5f)",
+                          "llround(7.5)", "llrint(7.5)"};
+
+  int Errors = 0;
+  for (int I = 0; I < 5; ++I)
+    if (HostOut[I] != Expected[I]) {
+      printf("%s: got %lld expected %lld\n", Names[I], HostOut[I], Expected[I]);
+      ++Errors;
+    }
+
+  CHECK(hipFree(In));
+  CHECK(hipFree(InD));
+  CHECK(hipFree(Out));
+
+  if (Errors) {
+    printf("FAILED\n");
+    return 1;
+  }
+  printf("PASSED\n");
+  return 0;
+}

--- a/tests/devicelib/TestStdLlroundFloat.cpp
+++ b/tests/devicelib/TestStdLlroundFloat.cpp
@@ -1,0 +1,113 @@
+// Reproduces: the type-crossing rounding intrinsics (floating point in,
+// integer out) have no single OpenCL.std ExtInst, because every OpenCL.std
+// rounding instruction is float to float. A producer that does not expand them
+// itself rejects the module outright:
+//
+//   InvalidFunctionCall: Unexpected llvm intrinsic: llvm.llround.i64.f32
+//   clang++: error: hipspv-link command failed with exit code 8
+//
+// and with the in-tree SPIR-V backend:
+//
+//   LLVM ERROR: unable to legalize instruction: %8:iid(s64) = G_INTRINSIC_LRINT
+//
+// The failure surfaces at hipspv-link with no source location at all.
+//
+// libstdc++'s float overloads are constexpr, so HIP has already made them
+// implicitly __host__ __device__ and they win overload resolution over
+// chipStar's own device declarations. That is how std::llround and std::llrint
+// on a float reach llvm.llround / llvm.llrint, and how std::lround on a float
+// reaches llvm.lround. std::lrint is different: chipStar declares lrint(float)
+// in sp_math.hh and pulls it into namespace std, so std::lrint(float) resolves
+// to the devicelib entry point and never forms the intrinsic. llvm.lrint is
+// therefore reached here through __builtin_lrintf directly.
+
+#include <hip/hip_runtime.h>
+#include <cmath>
+#include <cstdio>
+
+#define CHECK(X)                                                               \
+  do {                                                                         \
+    hipError_t E = (X);                                                        \
+    if (E != hipSuccess) {                                                     \
+      printf("FAILED: %s -> %s\n", #X, hipGetErrorString(E));                  \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+__global__ void run(const float *In, const double *InD, long long *Out,
+                    long *OutL) {
+  using std::llrint;
+  using std::llround;
+  using std::lround;
+  Out[0] = llround(In[0]);
+  Out[1] = llround(In[1]);
+  Out[2] = llrint(In[0]);
+  Out[3] = llround(InD[0]);
+  Out[4] = llrint(InD[0]);
+
+  // std::lrint(float) resolves to chipStar's devicelib overload rather than
+  // libstdc++'s, so reach llvm.lrint through the builtin instead.
+  OutL[0] = __builtin_lrintf(In[0]);
+  OutL[1] = __builtin_lrintf(In[2]);
+  OutL[2] = __builtin_lrint(InD[0]);
+  OutL[3] = lround(In[0]);
+  OutL[4] = lround(In[1]);
+}
+
+int main() {
+  float HostIn[3] = {2.5f, -2.5f, 3.5f};
+  double HostInD[1] = {7.5};
+
+  float *In;
+  double *InD;
+  long long *Out;
+  long *OutL;
+  CHECK(hipMalloc(&In, sizeof(HostIn)));
+  CHECK(hipMalloc(&InD, sizeof(HostInD)));
+  CHECK(hipMalloc(&Out, 5 * sizeof(long long)));
+  CHECK(hipMalloc(&OutL, 5 * sizeof(long)));
+  CHECK(hipMemcpy(In, HostIn, sizeof(HostIn), hipMemcpyHostToDevice));
+  CHECK(hipMemcpy(InD, HostInD, sizeof(HostInD), hipMemcpyHostToDevice));
+
+  hipLaunchKernelGGL(run, dim3(1), dim3(1), 0, 0, In, InD, Out, OutL);
+  CHECK(hipDeviceSynchronize());
+
+  long long HostOut[5];
+  long HostOutL[5];
+  CHECK(hipMemcpy(HostOut, Out, sizeof(HostOut), hipMemcpyDeviceToHost));
+  CHECK(hipMemcpy(HostOutL, OutL, sizeof(HostOutL), hipMemcpyDeviceToHost));
+
+  // llround and lround round half away from zero; llrint and lrint follow the
+  // rounding mode, which is round to nearest even by default.
+  const long long Expected[5] = {3, -3, 2, 8, 8};
+  const char *Names[5] = {"llround(2.5f)", "llround(-2.5f)", "llrint(2.5f)",
+                          "llround(7.5)", "llrint(7.5)"};
+  const long ExpectedL[5] = {2, 4, 8, 3, -3};
+  const char *NamesL[5] = {"lrint(2.5f)", "lrint(3.5f)", "lrint(7.5)",
+                           "lround(2.5f)", "lround(-2.5f)"};
+
+  int Errors = 0;
+  for (int I = 0; I < 5; ++I)
+    if (HostOut[I] != Expected[I]) {
+      printf("%s: got %lld expected %lld\n", Names[I], HostOut[I], Expected[I]);
+      ++Errors;
+    }
+  for (int I = 0; I < 5; ++I)
+    if (HostOutL[I] != ExpectedL[I]) {
+      printf("%s: got %ld expected %ld\n", NamesL[I], HostOutL[I],
+             ExpectedL[I]);
+      ++Errors;
+    }
+
+  CHECK(hipFree(In));
+  CHECK(hipFree(InD));
+  CHECK(hipFree(Out));
+  CHECK(hipFree(OutL));
+
+  if (Errors) {
+    printf("FAILED\n");
+    return 1;
+  }
+  printf("PASSED\n");
+  return 0;
+}


### PR DESCRIPTION
Fixes #1404

libstdc++ declares std::llround and std::llrint for float as constexpr, which HIP turns into implicitly __host__ __device__ functions. They win overload resolution in device code over anything chipStar can declare (a plain __device__ overload with the same signature is rejected outright, see the analysis in #1404) and expand to __builtin_llroundf, so the module ends up with an llvm.llround intrinsic that llvm-spirv has no translation for. The failure surfaces at hipspv-link with no source location.

The new pass rounds in floating point with llvm.round or llvm.rint, which the translator maps to the OpenCL round and rint ExtInsts, then converts.

Calling the devicelib entry points (__chip_llround_f32 and friends) was the first attempt and does not work: devicelib is linked in before the post-link passes run, so a symbol first referenced by a post-link pass is never pulled in and the program build fails with `unresolved external symbol __chip_llround_f32`.

New test tests/devicelib/TestStdLlroundFloat.cpp, verified on Intel Arc B570 (OpenCL): does not link before, PASSED after. It pins down both rounding modes (llround(2.5f) is 3, llrint(2.5f) is 2) for float and double.

Found while getting the Kokkos HIP backend running on chipStar; this is what blocks Kokkos_CoreUnitTest_HIP from linking.

This pass is a bridge, not the real fix. The real fix belongs in the SPIR-V producers, and both are open upstream: llvm/llvm-project#217618 https://github.com/llvm/llvm-project/pull/217618 for the in tree backend, and KhronosGroup/SPIRV-LLVM-Translator#3987 https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/3987 for the translator. Neither reaches chipStar automatically, and the LLVM 21 lanes never receive either, so the pass is still required. Removal is tracked in #1476.
