### PR TITLE
installer: add chipRCCL and chipStdPar components

### DIFF
--- a/install_chipstar.py
+++ b/install_chipstar.py
@@ -251,6 +251,22 @@ COMPONENTS = [
         test_cmake_flags=["-DBUILD_TESTS=ON"],
         with_hip_include_flag=True,
     ),
+    Component(
+        name="chiprccl",
+        display_name="chipRCCL",
+        repo="git@github.com:CHIP-SPV/chipRCCL.git",
+        depends_on=["chipstar"],
+        description=("Minimal single-process RCCL (NCCL API): nranks==1 "
+                     "collectives as local device operations"),
+    ),
+    Component(
+        name="chipstdpar",
+        display_name="chipStdPar",
+        repo="git@github.com:CHIP-SPV/chipStdPar.git",
+        depends_on=["chipstar", "rocprim", "rocthrust"],
+        description=("Header-only C++17 parallel-STL forwarding to rocThrust "
+                     "(no clang --hipstdpar needed)"),
+    ),
 ]
 
 


### PR DESCRIPTION
Adds two new suite components: chipRCCL (minimal single-process RCCL/NCCL API — github.com/CHIP-SPV/chipRCCL) and chipStdPar (header-only C++17 parallel-STL forwarding to rocThrust — github.com/CHIP-SPV/chipStdPar, depends on rocprim+rocthrust). Both extracted from the HeCBench sweep where they make ccl-hip and dp-hip build and pass (context: #1411, #1412); each repo carries its own GPU correctness test and CI.

Verified locally: ./install_chipstar.py -c chipstar,chiprccl,chipstdpar installs cleanly into a scratch prefix — librccl.a, rccl/rccl.h and stdpar_shim.h land in the suite prefix.