### PR TITLE
Detach debug info from globals before erasing them

### DIFF
--- a/llvm_passes/HipAbort.cpp
+++ b/llvm_passes/HipAbort.cpp
@@ -45,6 +45,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "HipAbort.h"
+#include "HipDebugInfoUtils.h"
 
 #include "../src/common.hh"
 
@@ -332,6 +333,7 @@ static bool eraseAbortFlag(Module &M) {
   GlobalVariable *AbortFlag = M.getGlobalVariable(ChipDeviceAbortFlagName);
   if (AbortFlag != nullptr) {
     AbortFlag->replaceAllUsesWith(Constant::getNullValue(AbortFlag->getType()));
+    chipstar::dropGlobalDebugInfo(AbortFlag);
     AbortFlag->eraseFromParent();
     return true;
   }

--- a/llvm_passes/HipCleanup.cpp
+++ b/llvm_passes/HipCleanup.cpp
@@ -18,6 +18,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "HipCleanup.h"
+#include "HipDebugInfoUtils.h"
 
 #include "../src/common.hh"
 
@@ -179,12 +180,13 @@ PreservedAnalyses HipCleanupPass::run(Module &M, ModuleAnalysisManager &AM) {
       I->eraseFromParent();
     }
     GV->removeDeadConstantUsers();
-    if (GV->use_empty())
-      GV->eraseFromParent();
-    else {
+    if (!GV->use_empty())
       GV->replaceAllUsesWith(PoisonValue::get(GV->getType()));
-      GV->eraseFromParent();
-    }
+    // Detach debug info first: erasing the global leaves its
+    // DIGlobalVariableExpression in the compile unit, which the SPIR-V
+    // producers then emit as a DebugGlobalVariable with no storage.
+    chipstar::dropGlobalDebugInfo(GV);
+    GV->eraseFromParent();
     ModuleChanged = true;
   }
 

--- a/llvm_passes/HipDebugInfoUtils.h
+++ b/llvm_passes/HipDebugInfoUtils.h
@@ -1,0 +1,75 @@
+//===- HipDebugInfoUtils.h ------------------------------------------------===//
+//
+// Part of the chipStar Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Helper for erasing a global variable without leaving its debug info behind.
+//
+// (c) 2026 chipStar developers
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_PASSES_HIP_DEBUG_INFO_UTILS_H
+#define LLVM_PASSES_HIP_DEBUG_INFO_UTILS_H
+
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/DebugInfoMetadata.h"
+#include "llvm/IR/GlobalVariable.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/IR/Module.h"
+
+namespace chipstar {
+
+/// Detach the debug info describing \p GV, which is about to be erased.
+///
+/// GlobalVariable::eraseFromParent() does not remove the variable's
+/// DIGlobalVariableExpression from the DICompileUnit's `globals:` list. The
+/// SPIR-V producers walk that list, so a stale entry is emitted as a
+/// DebugGlobalVariable whose Variable operand is a DebugExpression instead of
+/// an OpVariable, describing storage that no longer exists.
+///
+/// Consumers are not obliged to cope with that. Intel's CPU OpenCL runtime
+/// segfaults on it in SPIRVToLLVMDbgTran::transGlobalVariable, taking down
+/// every kernel in the module. See
+/// reproducers/cpu-opencl-debug-global-variable-segfault/.
+///
+/// Call this immediately before erasing a global.
+inline void dropGlobalDebugInfo(llvm::GlobalVariable *GV) {
+  llvm::SmallVector<llvm::DIGlobalVariableExpression *, 1> GVEs;
+  GV->getDebugInfo(GVEs);
+  if (GVEs.empty())
+    return;
+
+  llvm::SmallPtrSet<const llvm::Metadata *, 4> Dead;
+  for (auto *GVE : GVEs)
+    Dead.insert(GVE);
+
+  llvm::Module &M = *GV->getParent();
+  if (auto *CUs = M.getNamedMetadata("llvm.dbg.cu")) {
+    for (auto *Op : CUs->operands()) {
+      auto *CU = llvm::dyn_cast<llvm::DICompileUnit>(Op);
+      if (!CU)
+        continue;
+      llvm::SmallVector<llvm::Metadata *, 8> Keep;
+      bool Changed = false;
+      for (auto *G : CU->getGlobalVariables()) {
+        if (Dead.count(G)) {
+          Changed = true;
+          continue;
+        }
+        Keep.push_back(G);
+      }
+      if (Changed)
+        CU->replaceGlobalVariables(llvm::MDTuple::get(M.getContext(), Keep));
+    }
+  }
+
+  GV->eraseMetadata(llvm::LLVMContext::MD_dbg);
+}
+
+} // namespace chipstar
+
+#endif

--- a/llvm_passes/HipPasses.cpp
+++ b/llvm_passes/HipPasses.cpp
@@ -247,6 +247,12 @@ llvmGetPassPluginInfo() {
                     MPM.addPass(HipVerifyPass());
                     return true;
                   }
+                  // Register the global cleanup as standalone, which makes the
+                  // debug-info detaching directly testable with opt.
+                  if (Name == "hip-cleanup") {
+                    MPM.addPass(HipCleanupPass());
+                    return true;
+                  }
                   return false;
                 });
           }};

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -195,3 +195,6 @@ add_subdirectory(promoteInt)
 
 # Add the IR verification tests
 add_subdirectory(irVerification)
+
+# Add the HipCleanup debug-info tests
+add_subdirectory(cleanupDebugInfo)

--- a/tests/compiler/cleanupDebugInfo/CMakeLists.txt
+++ b/tests/compiler/cleanupDebugInfo/CMakeLists.txt
@@ -1,0 +1,40 @@
+#=============================================================================
+#  Copyright (c) 2026 chipStar developers
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+#
+#=============================================================================
+
+# HipCleanupPass must detach the debug info of the globals it erases, otherwise
+# the compile unit keeps advertising storage that no longer exists and the
+# SPIR-V producers emit a DebugGlobalVariable that crashes some consumers.
+add_test(
+  NAME hipCleanupDebugInfo-erased-global
+  COMMAND ${LLVM_TOOLS_BINARY_DIR}/opt
+    -load-pass-plugin ${CMAKE_BINARY_DIR}/lib/libLLVMHipSpvPasses.so
+    -passes=hip-cleanup
+    -S
+    ${CMAKE_CURRENT_SOURCE_DIR}/erased-global-debug-info.ll
+)
+
+# The erased global's DIGlobalVariable must be gone, while the retained one's
+# must survive (guards against stripping debug info wholesale).
+set_tests_properties(hipCleanupDebugInfo-erased-global PROPERTIES
+  FAIL_REGULAR_EXPRESSION "__hip_cuid_deadbeef"
+  PASS_REGULAR_EXPRESSION "kept_global")

--- a/tests/compiler/cleanupDebugInfo/erased-global-debug-info.ll
+++ b/tests/compiler/cleanupDebugInfo/erased-global-debug-info.ll
@@ -1,0 +1,39 @@
+; HipCleanupPass erases __hip_cuid* globals. It must also detach their debug
+; info: leaving a DIGlobalVariableExpression in the compile unit's globals list
+; makes the SPIR-V producers emit a DebugGlobalVariable describing storage that
+; no longer exists, which segfaults Intel's CPU OpenCL runtime.
+;
+; @kept_global is not removed by the pass, so its debug info must survive --
+; this guards against over-stripping.
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spirv64-unknown-unknown"
+
+@__hip_cuid_deadbeef = addrspace(1) global i8 0, align 1, !dbg !6
+@kept_global = addrspace(1) global i32 7, align 4, !dbg !10
+
+define spir_kernel void @k(ptr addrspace(1) %out) !dbg !14 {
+entry:
+  %v = load i32, ptr addrspace(1) @kept_global, align 4, !dbg !17
+  store i32 %v, ptr addrspace(1) %out, align 4, !dbg !17
+  ret void, !dbg !17
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "chipStar test", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !2)
+!1 = !DIFile(filename: "erased-global-debug-info.ll", directory: "/")
+!2 = !{!6, !10}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 2, !"Dwarf Version", i32 4}
+!6 = !DIGlobalVariableExpression(var: !7, expr: !DIExpression())
+!7 = distinct !DIGlobalVariable(name: "__hip_cuid_deadbeef", scope: !0, file: !1, line: 1, type: !8, isLocal: false, isDefinition: true)
+!8 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_signed_char)
+!10 = !DIGlobalVariableExpression(var: !11, expr: !DIExpression())
+!11 = distinct !DIGlobalVariable(name: "kept_global", scope: !0, file: !1, line: 2, type: !12, isLocal: false, isDefinition: true)
+!12 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!13 = !DISubroutineType(types: !16)
+!14 = distinct !DISubprogram(name: "k", scope: !1, file: !1, line: 4, type: !13, scopeLine: 4, spFlags: DISPFlagDefinition, unit: !0)
+!16 = !{null}
+!17 = !DILocation(line: 5, column: 3, scope: !14)


### PR DESCRIPTION
Device tests built with -g segfaulted on the Intel CPU OpenCL device, taking down every kernel in the module. Since CMakeLists.txt appends -gdwarf-4 unconditionally, this hit Release builds too.

HipAbortPass erases __chipspv_abort_called and HipCleanupPass erases __hip_cuid*, but eraseFromParent does not remove the variable's DIGlobalVariableExpression from the compile unit's globals list. The SPIR-V producers walk that list and emit a DebugGlobalVariable whose Variable operand is a DebugExpression instead of an OpVariable, describing storage that no longer exists. Intel's runtime segfaults reading it back in SPIRVToLLVMDbgTran::transGlobalVariable, which tries to build a LoadInst into a null BasicBlock.

Verified on meatloaf with a HIP reproducer compiled -g: cpu-opencl went from SIGSEGV to pass, all four GPU device/backend combinations unchanged. In the emitted SPIR-V, DebugGlobalVariable count drops from 2 to 1 (the surviving one is the global that still exists), while all 7 DebugFunction records and the non-semantic debug set are retained, so -g still works.

The crash also reproduces with no chipStar involved: a 40 line LLVM IR module whose compile unit advertises a deleted global, fed to a pure OpenCL host, segfaults in clBuildProgram on intel-opencl-rt 2024.0.0, 2025.0.4 and 2025.1.1 alike. Worth reporting upstream separately.