### PR TITLE
llvm_passes: adapt to LLVM 24 API removals

### DIFF
--- a/llvm_passes/HipDynMem.cpp
+++ b/llvm_passes/HipDynMem.cpp
@@ -134,7 +134,7 @@ private:
 
       if (llvm::AddrSpaceCastInst *ASCI = dyn_cast<AddrSpaceCastInst>(U)) {
         B.SetInsertPoint(ASCI);
-        PointerType *PT = PointerType::get(ElemType, ASCI->getDestAddressSpace());
+        PointerType *PT = PointerType::get(ElemType->getContext(), ASCI->getDestAddressSpace());
         Value *NewASCI = B.CreateAddrSpaceCast(DestV, PT);
 
         recursivelyReplaceArrayWithPointer(NewASCI, ASCI, ElemType, B);
@@ -291,7 +291,7 @@ private:
     Type *ElemT = GVTy->getArrayElementType();
 
     // float addrspace(3)*
-    PointerType *AS3_PTR = PointerType::get(ElemT, GV->getAddressSpace());
+    PointerType *AS3_PTR = PointerType::get(ElemT->getContext(), GV->getAddressSpace());
 
     for (Function::const_arg_iterator i = F->arg_begin(), e = F->arg_end();
          i != e; ++i) {
@@ -323,7 +323,7 @@ CloneFunctionInto(NewF, F, VV, CloneFunctionChangeType::GlobalChanges, RI);
     IRBuilder<> B(M.getContext());
 
     // float* (without AS, for MDNode)
-    PointerType *AS0_PTR = PointerType::get(ElemT, 0);
+    PointerType *AS0_PTR = PointerType::get(ElemT->getContext(), 0);
     updateFunctionMD(NewF, M, AS0_PTR);
 
     // insert new function with dynamic mem = last argument

--- a/llvm_passes/HipKernelArgSpiller.cpp
+++ b/llvm_passes/HipKernelArgSpiller.cpp
@@ -211,7 +211,7 @@ static ArgSet getSpillPlan(Function *F) {
 /// Get type presentation for the argument. Always returns a pointer type.
 static Type *getSpillType(const Argument &Arg) {
   auto *ArgTy = Arg.hasByValAttr() ? Arg.getParamByValType() : Arg.getType();
-  return ArgTy->getPointerTo(SPIRV_CROSSWORKGROUP_AS);
+  return PointerType::get(ArgTy->getContext(), SPIRV_CROSSWORKGROUP_AS);
 }
 
 /// Create an alloca placed in function's entry block.

--- a/llvm_passes/HipLowerSwitch.cpp
+++ b/llvm_passes/HipLowerSwitch.cpp
@@ -73,7 +73,8 @@ static bool lowerSwitch(SwitchInst *SI,
   // TODO: Consult computeKnownBits() for optimizing the mask instruction away.
   auto *Mask =
       ConstantInt::get(NewCondTy, cast<IntegerType>(OldType)->getBitMask());
-  NewCond = BinaryOperator::CreateAnd(NewCond, Mask, "switch.mask", SI);
+  NewCond = BinaryOperator::CreateAnd(NewCond, Mask, "switch.mask",
+                                      SI->getIterator());
 
   SI->setCondition(NewCond);
   for (auto Case : SI->cases()) {

--- a/llvm_passes/HipLowerZeroLengthArrays.cpp
+++ b/llvm_passes/HipLowerZeroLengthArrays.cpp
@@ -39,7 +39,8 @@ static Type* getLoweredTypeOrNull(Type *Ty) {
   // Delve into the pointer element
   if (Ty->isPointerTy())
     if (auto *LoweredEltTy = getLoweredTypeOrNull(Ty->getPointerElementType()))
-      return LoweredEltTy->getPointerTo(Ty->getPointerAddressSpace());
+      return PointerType::get(LoweredEltTy->getContext(),
+                              Ty->getPointerAddressSpace());
 #endif
 
   // SPIRV-LLVM translator does not accept zero length arrays. Lower such
@@ -150,7 +151,8 @@ static bool lowerZeroLengthArrayTypes(Function &F) {
         for (auto I = GEP->idx_begin(), E = GEP->idx_end(); I != E; I++)
           NewIndices.push_back(*I);
         GetElementPtrInst *NewGEP =
-            GetElementPtrInst::Create(NewSrcTy, NewPtr, NewIndices, "", GEP);
+            GetElementPtrInst::Create(NewSrcTy, NewPtr, NewIndices, "",
+                                      GEP->getIterator());
         if (hasUnsupportedType(GEP->getType()))
           recordLoweredValue(GEP, NewGEP);
         else

--- a/llvm_passes/HipPrintf.cpp
+++ b/llvm_passes/HipPrintf.cpp
@@ -334,9 +334,9 @@ Function *HipPrintfToOpenCLPrintfPass::getOrCreatePrintStringF() {
   auto *Int32Ty = IntegerType::get(Ctx, 32);
   auto *VoidTy = Type::getVoidTy(Ctx);
   PointerType *GenericCStrArgT =
-      PointerType::get(Int8Ty, SPIRV_OPENCL_GENERIC_AS);
+      PointerType::get(Int8Ty->getContext(), SPIRV_OPENCL_GENERIC_AS);
   PointerType *ConstStrPtrT =
-      PointerType::get(Int8Ty, SPIRV_OPENCL_CONSTANT_AS);
+      PointerType::get(Int8Ty->getContext(), SPIRV_OPENCL_CONSTANT_AS);
 
   FunctionType *PrintStrFTy =
       FunctionType::get(VoidTy, {GenericCStrArgT}, false);
@@ -452,7 +452,7 @@ PreservedAnalyses HipPrintfToOpenCLPrintfPass::run(Module &Mod,
   auto *Int32Ty = IntegerType::get(Ctx, 32);
 
   PointerType *ConstStrPtrT =
-      PointerType::get(Int8Ty, SPIRV_OPENCL_CONSTANT_AS);
+      PointerType::get(Int8Ty->getContext(), SPIRV_OPENCL_CONSTANT_AS);
 
   PointerType *OCLPrintfFmtArgT = ConstStrPtrT;
 
@@ -508,7 +508,8 @@ PreservedAnalyses HipPrintfToOpenCLPrintfPass::run(Module &Mod,
                      << "  Invalid format string or missing arguments?\n");
           Value *ErrorFmt = getOrCreateStrLiteralArg(
               "Error: Invalid printf format string\n", B);
-          CallInst::Create(OpenCLPrintfF, ArrayRef(ErrorFmt), "", &OrigCall);
+          CallInst::Create(OpenCLPrintfF.getFunctionType(), OpenCLPrintfF.getCallee(),
+                           ArrayRef(ErrorFmt), "", OrigCall.getIterator());
           auto *PoisonInt = PoisonValue::get(Type::getInt32Ty(Ctx));
           OrigCall.replaceAllUsesWith(PoisonInt);
           EraseList.insert(&OrigCall);
@@ -590,7 +591,9 @@ PreservedAnalyses HipPrintfToOpenCLPrintfPass::run(Module &Mod,
             if (!toAdd.empty()) {
               Args.insert(Args.begin(), getOrCreateStrLiteralArg(toAdd, B));
               toAdd.clear();
-              CallInst::Create(OpenCLPrintfF, Args, "", &OrigCall);
+              CallInst::Create(OpenCLPrintfF.getFunctionType(),
+                           OpenCLPrintfF.getCallee(), Args, "",
+                           OrigCall.getIterator());
               Args.clear();
             }
 
@@ -600,12 +603,14 @@ PreservedAnalyses HipPrintfToOpenCLPrintfPass::run(Module &Mod,
             // _cl_print_str expects a generic address space pointer
             auto *Int8Ty = IntegerType::get(M_->getContext(), 8);
             PointerType *GenericPtrTy =
-                PointerType::get(Int8Ty, SPIRV_OPENCL_GENERIC_AS);
+                PointerType::get(Int8Ty->getContext(), SPIRV_OPENCL_GENERIC_AS);
             Value *GenericPtr =
                 B.CreateAddrSpaceCast(OrigArg, GenericPtrTy, "str.generic");
 
             Args.push_back(GenericPtr);
-            CallInst::Create(getOrCreatePrintStringF(), Args, "", &OrigCall);
+            Function *PrintStrF = getOrCreatePrintStringF();
+            CallInst::Create(PrintStrF->getFunctionType(), PrintStrF, Args, "",
+                             OrigCall.getIterator());
             Args.clear();
             continue;
           }
@@ -621,7 +626,9 @@ PreservedAnalyses HipPrintfToOpenCLPrintfPass::run(Module &Mod,
         if (!toAdd.empty()) {
           Args.insert(Args.begin(), getOrCreateStrLiteralArg(toAdd, B));
           toAdd.clear();
-          CallInst::Create(OpenCLPrintfF, Args, "", &OrigCall);
+          CallInst::Create(OpenCLPrintfF.getFunctionType(),
+                           OpenCLPrintfF.getCallee(), Args, "",
+                           OrigCall.getIterator());
           Args.clear();
         }
 

--- a/llvm_passes/HipPrintf.cpp
+++ b/llvm_passes/HipPrintf.cpp
@@ -338,9 +338,9 @@ Function *HipPrintfToOpenCLPrintfPass::getOrCreatePrintStringF() {
   auto *Int32Ty = IntegerType::get(Ctx, 32);
   auto *VoidTy = Type::getVoidTy(Ctx);
   PointerType *GenericCStrArgT =
-      PointerType::get(Int8Ty, SPIRV_OPENCL_GENERIC_AS);
+      PointerType::get(Int8Ty->getContext(), SPIRV_OPENCL_GENERIC_AS);
   PointerType *ConstStrPtrT =
-      PointerType::get(Int8Ty, SPIRV_OPENCL_CONSTANT_AS);
+      PointerType::get(Int8Ty->getContext(), SPIRV_OPENCL_CONSTANT_AS);
 
   FunctionType *PrintStrFTy =
       FunctionType::get(VoidTy, {GenericCStrArgT}, false);
@@ -443,7 +443,7 @@ PreservedAnalyses HipPrintfToOpenCLPrintfPass::run(Module &Mod,
   auto *Int32Ty = IntegerType::get(Ctx, 32);
 
   PointerType *ConstStrPtrT =
-      PointerType::get(Int8Ty, SPIRV_OPENCL_CONSTANT_AS);
+      PointerType::get(Int8Ty->getContext(), SPIRV_OPENCL_CONSTANT_AS);
 
   PointerType *OCLPrintfFmtArgT = ConstStrPtrT;
 
@@ -499,7 +499,8 @@ PreservedAnalyses HipPrintfToOpenCLPrintfPass::run(Module &Mod,
                      << "  Invalid format string or missing arguments?\n");
           Value *ErrorFmt = getOrCreateStrLiteralArg(
               "Error: Invalid printf format string\n", B);
-          CallInst::Create(OpenCLPrintfF, ArrayRef(ErrorFmt), "", &OrigCall);
+          CallInst::Create(OpenCLPrintfF.getFunctionType(), OpenCLPrintfF.getCallee(),
+                           ArrayRef(ErrorFmt), "", OrigCall.getIterator());
           auto *PoisonInt = PoisonValue::get(Type::getInt32Ty(Ctx));
           OrigCall.replaceAllUsesWith(PoisonInt);
           EraseList.insert(&OrigCall);
@@ -581,7 +582,9 @@ PreservedAnalyses HipPrintfToOpenCLPrintfPass::run(Module &Mod,
             if (!toAdd.empty()) {
               Args.insert(Args.begin(), getOrCreateStrLiteralArg(toAdd, B));
               toAdd.clear();
-              CallInst::Create(OpenCLPrintfF, Args, "", &OrigCall);
+              CallInst::Create(OpenCLPrintfF.getFunctionType(),
+                           OpenCLPrintfF.getCallee(), Args, "",
+                           OrigCall.getIterator());
               Args.clear();
             }
 
@@ -591,12 +594,14 @@ PreservedAnalyses HipPrintfToOpenCLPrintfPass::run(Module &Mod,
             // _cl_print_str expects a generic address space pointer
             auto *Int8Ty = IntegerType::get(M_->getContext(), 8);
             PointerType *GenericPtrTy =
-                PointerType::get(Int8Ty, SPIRV_OPENCL_GENERIC_AS);
+                PointerType::get(Int8Ty->getContext(), SPIRV_OPENCL_GENERIC_AS);
             Value *GenericPtr =
                 B.CreateAddrSpaceCast(OrigArg, GenericPtrTy, "str.generic");
 
             Args.push_back(GenericPtr);
-            CallInst::Create(getOrCreatePrintStringF(), Args, "", &OrigCall);
+            Function *PrintStrF = getOrCreatePrintStringF();
+            CallInst::Create(PrintStrF->getFunctionType(), PrintStrF, Args, "",
+                             OrigCall.getIterator());
             Args.clear();
             continue;
           }
@@ -612,7 +617,9 @@ PreservedAnalyses HipPrintfToOpenCLPrintfPass::run(Module &Mod,
         if (!toAdd.empty()) {
           Args.insert(Args.begin(), getOrCreateStrLiteralArg(toAdd, B));
           toAdd.clear();
-          CallInst::Create(OpenCLPrintfF, Args, "", &OrigCall);
+          CallInst::Create(OpenCLPrintfF.getFunctionType(),
+                           OpenCLPrintfF.getCallee(), Args, "",
+                           OrigCall.getIterator());
           Args.clear();
         }
 

--- a/llvm_passes/HipPromoteInts.cpp
+++ b/llvm_passes/HipPromoteInts.cpp
@@ -404,7 +404,8 @@ static Value *processPhiNode(PHINode *Phi, Type *NonStdType, Type *PromotedTy,
 
       
   // Process incoming values
-  PHINode *NewPhi = PHINode::Create(PromotedType, Phi->getNumIncomingValues(), "", Phi);
+  PHINode *NewPhi = PHINode::Create(PromotedType, Phi->getNumIncomingValues(), "",
+                                    Phi->getIterator());
   unsigned PendingCount = 0;
   for (unsigned i = 0; i < Phi->getNumIncomingValues(); ++i) {
       Value *OriginalValue = Phi->getIncomingValue(i);
@@ -810,7 +811,8 @@ static Value *processCallInst(CallInst *OldCall, Type *NonStdType, Type *Promote
 
   CallInst *NewCall = CallInst::Create(OldCall->getFunctionType(),
                                        OldCall->getCalledOperand(), NewArgs,
-                                       OldCall->getName(), OldCall);
+                                       OldCall->getName(),
+                                       OldCall->getIterator());
   NewCall->setCallingConv(OldCall->getCallingConv());
   NewCall->setAttributes(OldCall->getAttributes());
 
@@ -837,7 +839,7 @@ static Value *processStoreInst(StoreInst *Store, Type *NonStdType, Type *Promote
       LLVMContext &Ctx = Store->getContext();
       Type *PromTy = Type::getIntNTy(Ctx, NewBW);
       unsigned AS = OrigPtr->getType()->getPointerAddressSpace();
-      PointerType *NewPtrTy = PointerType::get(PromTy, AS);
+      PointerType *NewPtrTy = PointerType::get(PromTy->getContext(), AS);
       // Bitcast the pointer to the promoted pointer type
       Value *CastPtr = Builder.CreateBitCast(OrigPtr, NewPtrTy, Store->getName() + ".promote_ptr");
       // Obtain the promoted value (zero/sign extension handled by getPromotedValue)
@@ -911,7 +913,7 @@ static Value *processLoadInst(LoadInst *Load, Type *NonStdType, Type *PromotedTy
       unsigned NewBW = HipPromoteIntsPass::getPromotedBitWidth(BW);
       Type *NewIntTy = Type::getIntNTy(Ctx, NewBW);
       // Bitcast the pointer to point to the promoted integer type
-      PointerType *NewPtrTy = PointerType::get(NewIntTy, 
+      PointerType *NewPtrTy = PointerType::get(NewIntTy->getContext(),
                                   Ptr->getType()->getPointerAddressSpace());
       Value *CastPtr = Builder.CreateBitCast(Ptr, NewPtrTy, Load->getName() + ".promote_ptr");
       // Create the promoted load

--- a/llvm_passes/HipTextureLowering.cpp
+++ b/llvm_passes/HipTextureLowering.cpp
@@ -292,7 +292,7 @@ static Type *getPointerTypeToOpaqueStruct(LLVMContext &C, StringRef Name,
   Type *Ty = StructType::getTypeByName(C, Name);
   if (!Ty)
     Ty = StructType::create(C, Name);
-  return Ty->getPointerTo(AddrSpace);
+  return PointerType::get(Ty->getContext(), AddrSpace);
 }
 #endif
 
@@ -384,7 +384,8 @@ static void lowerTextureObjectUses(Function *F,
         for (unsigned I = 1, E = CI->arg_size(); I != E; I++)
           CallArgs.push_back(CI->getArgOperand(I));
         auto *NewCI =
-            CallInst::Create(ImplF->getFunctionType(), ImplF, CallArgs, "", CI);
+            CallInst::Create(ImplF->getFunctionType(), ImplF, CallArgs, "",
+                             CI->getIterator());
         // Calling convention is not inherited from the callee.
         NewCI->setCallingConv(CallingConv::SPIR_FUNC);
 


### PR DESCRIPTION
LLVM 24 removes four interfaces the passes still used:

- PointerType::get(Type *, unsigned), the typed-pointer form
- Type::getPointerTo()
- CallInst::Create(FunctionCallee, ...)
- the implicit conversion from Instruction * to InsertPosition

All four replacements exist in LLVM 21 through 23 as well, so there are no version guards and older toolchains are unaffected. Seven files, one migration family.

Verified by building chipStar against llvm/llvm-project main (24.0.0git): the tree configures, builds and installs cleanly with zero errors.

Independent of the LLVM 23 work in #1194; this only makes the passes compile against 24.