### PR TITLE
Key the module cache on everything that shapes the device binary

### DIFF
--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -278,35 +278,56 @@ bool startsWith(std::string_view Str, std::string_view WithStr) {
          Str.substr(0, WithStr.size()) == WithStr;
 }
 
-std::string collectIGCEnvironmentVariables() {
-  std::vector<std::string> igcVars;
-  logDebug("Collecting IGC environment variables...");
-  
+uint64_t fnv1a64(const std::string &S) {
+  uint64_t Hash = UINT64_C(14695981039346656037);
+  for (unsigned char C : S) {
+    Hash ^= C;
+    Hash *= UINT64_C(1099511628211);
+  }
+  return Hash;
+}
+
+std::string collectCompilerEnvironmentVariables() {
+  // Prefixes of variables that reach the device compiler. IGC_ covers IGC's
+  // own knobs; the rest are Compute Runtime / Level Zero loader settings that
+  // change codegen without carrying that prefix.
+  // OverrideDefaultFP64Settings is the motivating case: it switches on fp64
+  // emulation and the x86 CI exports it on every job, so leaving it out lets
+  // an emulated-fp64 binary be served to a run that did not ask for it.
+  static constexpr const char *CompilerEnvPrefixes[] = {
+      "IGC_", "NEO", "Override", "ZE_", "ZET_", "cl_cache_dir"};
+
+  std::vector<std::string> Vars;
+  logDebug("Collecting device compiler environment variables...");
+
   // Access the environment variables through the global environ variable
   extern char **environ;
-  
-  for (char **env = environ; *env != nullptr; ++env) {
-    std::string envVar(*env);
-    if (startsWith(envVar, "IGC_")) {
-      logDebug("Found IGC variable: {}", envVar);
-      igcVars.push_back(envVar);
+
+  for (char **Env = environ; *Env != nullptr; ++Env) {
+    std::string EnvVar(*Env);
+    for (const char *Prefix : CompilerEnvPrefixes) {
+      if (startsWith(EnvVar, Prefix)) {
+        logDebug("Found compiler variable: {}", EnvVar);
+        Vars.push_back(EnvVar);
+        break;
+      }
     }
   }
-  
-  // Sort to ensure consistent ordering for cache key generation
-  std::sort(igcVars.begin(), igcVars.end());
-  
-  // Concatenate all IGC_ variables into a single string
-  std::string result;
-  for (const auto& var : igcVars) {
-    if (!result.empty()) {
-      result += ";";
+
+  // Sort so the key does not depend on the order the environment happens to be
+  // laid out in.
+  std::sort(Vars.begin(), Vars.end());
+
+  std::string Result;
+  for (const auto &Var : Vars) {
+    if (!Result.empty()) {
+      Result += ";";
     }
-    result += var;
+    Result += Var;
   }
-  
-  logDebug("Collected IGC variables string: '{}'", result);
-  return result;
+
+  logDebug("Collected compiler variables string: '{}'", Result);
+  return Result;
 }
 
 /// Deep copies kernel arguments pointed by 'CopyArg'. Bytes of the

--- a/src/Utils.hh
+++ b/src/Utils.hh
@@ -169,8 +169,19 @@ template <class T> struct PointerCmp {
 void copyKernelArgs(std::vector<void *> &ArgList, std::vector<char> &ArgData,
                     void **CopyFrom, const SPVFuncInfo &FuncInfo);
 
-/// Collect all environment variables that start with "IGC_" and return them as a string
-/// for use in cache key generation
-std::string collectIGCEnvironmentVariables();
+/// FNV-1a 64-bit hash — portable and deterministic across runs, platforms and
+/// stdlib versions. std::hash<std::string> is implementation-defined and may be
+/// randomized per run or change between compiler/stdlib versions, which makes
+/// any on-disk cache keyed with it effectively write-only on those platforms.
+uint64_t fnv1a64(const std::string &S);
+
+/// Collect the environment variables that can change what the device compiler
+/// emits, as a sorted, ";"-joined "NAME=VALUE" string for cache key generation.
+///
+/// Matching is by name prefix. Beyond IGC's own knobs this has to cover the
+/// Compute Runtime and Level Zero loader ones: OverrideDefaultFP64Settings=1,
+/// for example, changes fp64 codegen and is set by the x86 CI on every job, yet
+/// carries no IGC_ prefix.
+std::string collectCompilerEnvironmentVariables();
 
 #endif

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -3172,6 +3172,65 @@ static std::string dumpBuildLog(ze_module_build_log_handle_t &&Log) {
   return LogStr;
 }
 
+/// Compute the Level Zero module cache key.
+///
+/// Unlike the OpenCL path this hashes every input module handed to
+/// zeModuleCreate, so the runtime device library modules are already covered:
+/// they are passed in as additional ILs rather than linked in afterwards.
+///
+/// The device driver is the compiler here, so its version has to be part of the
+/// key -- without it an IGC or Level Zero upgrade keeps serving binaries built
+/// by the previous compiler. The device name alone does not change across such
+/// an upgrade.
+static std::string
+computeLevel0CacheKey(const ze_module_program_exp_desc_t *ProgramDesc,
+                      CHIPDeviceLevel0 *device) {
+  std::string Combined;
+  for (int i = 0; i < static_cast<int>(ProgramDesc->count); i++) {
+    Combined.append(
+        reinterpret_cast<const char *>(ProgramDesc->pInputModules[i]),
+        ProgramDesc->inputSizes[i]);
+    if (ProgramDesc->pBuildFlags && ProgramDesc->pBuildFlags[i])
+      Combined.append(ProgramDesc->pBuildFlags[i]);
+    Combined.append(std::to_string(ProgramDesc->inputSizes[i]));
+  }
+
+  Combined.append("\n---device---\n");
+  Combined.append(device->getName());
+
+  ze_device_properties_t DeviceProperties{};
+  DeviceProperties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
+  DeviceProperties.pNext = nullptr;
+  if (zeDeviceGetProperties(device->get(), &DeviceProperties) ==
+      ZE_RESULT_SUCCESS) {
+    Combined.append("\n");
+    Combined.append(std::to_string(DeviceProperties.deviceId));
+    Combined.append("\n");
+    Combined.append(std::to_string(DeviceProperties.vendorId));
+  }
+
+  if (auto *CtxLz = static_cast<CHIPContextLevel0 *>(device->getContext())) {
+    ze_driver_properties_t DriverProperties{};
+    DriverProperties.stype = ZE_STRUCTURE_TYPE_DRIVER_PROPERTIES;
+    DriverProperties.pNext = nullptr;
+    if (zeDriverGetProperties(CtxLz->ZeDriver, &DriverProperties) ==
+        ZE_RESULT_SUCCESS) {
+      Combined.append("\n");
+      Combined.append(std::to_string(DriverProperties.driverVersion));
+    }
+  }
+
+  Combined.append("\n---env---\n");
+  std::string EnvVars = collectCompilerEnvironmentVariables();
+  logDebug("Level0: compiler env vars for cache key: '{}'", EnvVars);
+  Combined.append(EnvVars);
+
+  // fnv1a64 rather than std::hash: std::hash<std::string> is
+  // implementation-defined and may differ between stdlib versions or even runs,
+  // which would make these on-disk entries unreadable after a toolchain change.
+  return std::to_string(fnv1a64(Combined));
+}
+
 void save(const ze_module_desc_t &desc, const ze_module_handle_t &module,
           CHIPDeviceLevel0 *device) {
   const void *pNextConst = desc.pNext;
@@ -3184,29 +3243,8 @@ void save(const ze_module_desc_t &desc, const ze_module_handle_t &module,
           reinterpret_cast<const ze_module_program_exp_desc_t *>(pNextConst));
   int numILs = ProgramDesc->count;
 
-  std::hash<std::string> hasher;
-  std::string combinedInput;
-  for (int i = 0; i < numILs; i++) {
-    combinedInput.append(
-        reinterpret_cast<const char *>(ProgramDesc->pInputModules[i]),
-        ProgramDesc->inputSizes[i]);
-    combinedInput.append(ProgramDesc->pBuildFlags[i]);
-    combinedInput.append(std::to_string(ProgramDesc->inputSizes[i]));
-  }
-
-  // Add device name to the hash input
-  combinedInput.append(device->getName());
-
-  // Include IGC_ environment variables in cache key
-  std::string igcVars = collectIGCEnvironmentVariables();
-  logDebug("Level0: IGC variables for cache key: '{}'", igcVars);
-  if (!igcVars.empty()) {
-    combinedInput.append(";");
-    combinedInput.append(igcVars);
-  }
-
-  size_t hash = hasher(combinedInput);
-  logDebug("Level0: Generated cache hash: '{}'", std::to_string(hash));
+  std::string hash = computeLevel0CacheKey(ProgramDesc, device);
+  logDebug("Level0: Generated cache hash: '{}'", hash);
 
   if (!ChipEnvVars.getModuleCacheDir().has_value()) {
     logTrace("Module caching is disabled");
@@ -3216,8 +3254,8 @@ void save(const ze_module_desc_t &desc, const ze_module_handle_t &module,
   std::string cacheDir = ChipEnvVars.getModuleCacheDir().value();
   // Create the cache directory if it doesn't exist
   std::filesystem::create_directories(cacheDir);
-  std::string fullPath = cacheDir + "/" + std::to_string(hash);
-  std::string fullPath_tmp = cacheDir + "/" + std::to_string(hash) +"_tmp";
+  std::string fullPath = cacheDir + "/" + hash;
+  std::string fullPath_tmp = cacheDir + "/" + hash +"_tmp";
 
   size_t binarySize;
   zeStatus = zeModuleGetNativeBinary(module, &binarySize, nullptr);
@@ -3280,36 +3318,15 @@ bool load(ze_module_desc_t &desc, CHIPDeviceLevel0 *device) {
           reinterpret_cast<const ze_module_program_exp_desc_t *>(pNextConst));
   int numILs = ProgramDesc->count;
 
-  std::hash<std::string> hasher;
-  std::string combinedInput;
-  for (int i = 0; i < numILs; i++) {
-    combinedInput.append(
-        reinterpret_cast<const char *>(ProgramDesc->pInputModules[i]),
-        ProgramDesc->inputSizes[i]);
-    combinedInput.append(ProgramDesc->pBuildFlags[i]);
-    combinedInput.append(std::to_string(ProgramDesc->inputSizes[i]));
-  }
-
-  // Add device name to the hash input
-  combinedInput.append(device->getName());
-
-  // Include IGC_ environment variables in cache key
-  std::string igcVars = collectIGCEnvironmentVariables();
-  logDebug("Level0 load: IGC variables for cache key: '{}'", igcVars);
-  if (!igcVars.empty()) {
-    combinedInput.append(";");
-    combinedInput.append(igcVars);
-  }
-
-  size_t hash = hasher(combinedInput);
-  logDebug("Level0 load: Generated cache hash: '{}'", std::to_string(hash));
+  std::string hash = computeLevel0CacheKey(ProgramDesc, device);
+  logDebug("Level0 load: Generated cache hash: '{}'", hash);
 
   if (!ChipEnvVars.getModuleCacheDir().has_value()) {
     return false;
   }
 
   std::string cacheDir = ChipEnvVars.getModuleCacheDir().value();
-  std::string fullPath = cacheDir + "/" + std::to_string(hash);
+  std::string fullPath = cacheDir + "/" + hash;
 
   logTrace("Loading kernel binary from cache at {}", fullPath);
   std::ifstream inFile(fullPath, std::ios::in | std::ios::binary);

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -27,9 +27,12 @@
 #include <sstream>
 
 #include "Utils.hh"
+#include <algorithm>
 #include <chrono>
+#include <map>
 #include <thread>
 #include <fstream>
+#include <unistd.h>
 
 // Auto-generated header that lives in <build-dir>/bitcode.
 #include "rtdevlib-modules.h"
@@ -938,6 +941,50 @@ static cl::Program compileIL(cl::Context Ctx, CHIPDeviceOpenCL &ChipDev,
   return compileIL(Ctx, ChipDev, IL.data(), IL.size());
 }
 
+/// One rtdevlib module selected for linking into a device program.
+struct RtDevLibModule {
+  const char *Name;
+  const unsigned char *Data;
+  size_t Size;
+};
+
+/// Pick the rtdevlib modules to link into a program on this device.
+///
+/// Which implementation is chosen depends on device capabilities (native vs
+/// emulated atomics, fp64 support, ballot), so the selection is part of what
+/// determines the final binary. The cache key hashes the modules this returns,
+/// which is why selection lives here rather than inline in the link path: the
+/// key and the link have to agree, and duplicating the capability checks would
+/// let them drift apart silently.
+static std::vector<RtDevLibModule>
+selectRuntimeObjects(CHIPDeviceOpenCL &ChipDev) {
+  std::vector<RtDevLibModule> Modules;
+  auto Add = [&](auto &Source, const char *Name) -> void {
+    Modules.push_back({Name, Source.data(), Source.size()});
+  };
+
+  if (ChipDev.hasFP32AtomicAdd())
+    Add(chipstar::atomicAddFloat_native, "atomicAddFloat_native");
+  else
+    Add(chipstar::atomicAddFloat_emulation, "atomicAddFloat_emulation");
+
+  if (ChipDev.hasDoubles()) {
+    if (ChipDev.hasFP64AtomicAdd())
+      Add(chipstar::atomicAddDouble_native, "atomicAddDouble_native");
+    else
+      Add(chipstar::atomicAddDouble_emulation, "atomicAddDouble_emulation");
+  }
+
+  Add(chipstar::atomicMinMaxFloat_emulation, "atomicMinMaxFloat_emulation");
+
+  if (ChipDev.hasBallot())
+    Add(chipstar::ballot_native, "ballot_native");
+
+  // No fall-back implementation for ballot - let linker raise an error.
+
+  return Modules;
+}
+
 static void appendRuntimeObjects(cl::Context Ctx, CHIPDeviceOpenCL &ChipDev,
                                  std::vector<cl::Program> &Objects) {
 
@@ -946,36 +993,69 @@ static void appendRuntimeObjects(cl::Context Ctx, CHIPDeviceOpenCL &ChipDev,
 
   // TODO: Reuse already compiled modules.
 
-  auto AppendSource = [&](auto &Source, const std::string &Name) -> void {
+  for (const auto &Module : selectRuntimeObjects(ChipDev)) {
     if (ChipEnvVars.getDumpSpirv()) {
-      auto Str = std::string_view(reinterpret_cast<const char *>(Source.data()),
-                                  Source.size());
-      if (auto DumpPath = dumpSpirv(Str, Name))
-        logDebug("Dumped runtime object '{}' SPIR-V binary to '{}'", Name,
-                 fs::absolute(*DumpPath).c_str());
+      auto Str = std::string_view(reinterpret_cast<const char *>(Module.Data),
+                                  Module.Size);
+      if (auto DumpPath = dumpSpirv(Str, Module.Name))
+        logDebug("Dumped runtime object '{}' SPIR-V binary to '{}'",
+                 Module.Name, fs::absolute(*DumpPath).c_str());
     }
-    Objects.push_back(compileIL(Ctx, ChipDev, Source));
-  };
-
-  if (ChipDev.hasFP32AtomicAdd())
-    AppendSource(chipstar::atomicAddFloat_native, "atomicAddFloat_native");
-  else
-    AppendSource(chipstar::atomicAddFloat_emulation, "atomicAddFloat_emulation");
-
-  if (ChipDev.hasDoubles()) {
-    if (ChipDev.hasFP64AtomicAdd())
-      AppendSource(chipstar::atomicAddDouble_native, "atomicAddDouble_native");
-    else
-      AppendSource(chipstar::atomicAddDouble_emulation, "atomicAddDouble_emulation");
+    Objects.push_back(compileIL(Ctx, ChipDev, Module.Data, Module.Size));
   }
-
-  AppendSource(chipstar::atomicMinMaxFloat_emulation, "atomicMinMaxFloat_emulation");
-
-  if (ChipDev.hasBallot())
-    AppendSource(chipstar::ballot_native, "ballot_native");
-
-  // No fall-back implementation for ballot - let linker raise an error.
 }
+
+/// Flags passed to clLinkProgram for the rtdevlib link step.
+///
+/// Intel's driver is the only one given optimization flags here, so the value
+/// depends on the device as well as the environment. Computed in one place so
+/// the cache key and the actual link cannot disagree.
+static std::string computeLinkFlags(CHIPDeviceOpenCL &ChipDev) {
+  std::string Vendor = ChipDev.get()->getInfo<CL_DEVICE_VENDOR>();
+  bool IsIntelGPU = (Vendor.find("Intel") != std::string::npos) &&
+                    (ChipDev.get()->getInfo<CL_DEVICE_TYPE>() &
+                     CL_DEVICE_TYPE_GPU);
+  if (!IsIntelGPU)
+    return "";
+  return ChipEnvVars.hasJitOverride()
+             ? ChipEnvVars.getJitFlagsOverride()
+             : ChipEnvVars.getJitFlags() + " " + Backend->getDefaultJitFlags();
+}
+
+// Module cache file format (binary, host byte order):
+//
+//   magic[4]        = 'C','H','M','1'
+//   device_count    = uint32_t
+//   per device:
+//     name_len      = uint32_t
+//     name          = name_len bytes   (CL_DEVICE_NAME)
+//     binary_size   = uint64_t
+//     binary        = binary_size bytes
+//
+// The previous format concatenated every device's binary with no header and no
+// sizes, and the reader handed the whole blob back as device 0's binary. That
+// silently produced a corrupt program for any multi-device context. Framing the
+// entries and tagging them with the device name makes the file self describing,
+// and the magic lets an old or truncated file be rejected as a miss instead of
+// being fed to the driver.
+namespace {
+constexpr char ModuleCacheMagic[4] = {'C', 'H', 'M', '1'};
+
+template <typename T> void appendPod(std::vector<char> &Out, const T &Value) {
+  const char *Bytes = reinterpret_cast<const char *>(&Value);
+  Out.insert(Out.end(), Bytes, Bytes + sizeof(T));
+}
+
+/// Read a POD from Data at Offset, advancing it. False if the file is too short.
+template <typename T>
+bool readPod(const std::vector<char> &Data, size_t &Offset, T &Value) {
+  if (Offset + sizeof(T) > Data.size())
+    return false;
+  std::memcpy(&Value, Data.data() + Offset, sizeof(T));
+  Offset += sizeof(T);
+  return true;
+}
+} // namespace
 
 static void save(const cl::Program &program, const std::string &cacheName) {
   if (!ChipEnvVars.getModuleCacheDir().has_value()) {
@@ -988,101 +1068,91 @@ static void save(const cl::Program &program, const std::string &cacheName) {
   std::filesystem::create_directories(cacheDir);
   std::string fullPath = cacheDir + "/" + cacheName;
 
-  // Step 1: Get the sizes of the binaries for each device
   std::vector<size_t> binarySizes;
   program.getInfo(CL_PROGRAM_BINARY_SIZES, &binarySizes);
-
   size_t numDevices = binarySizes.size();
-
   if (numDevices == 0) {
     logError("No devices associated with the program.");
     return;
   }
 
-  // Step 2: Allocate memory for each binary
+  std::vector<cl::Device> devices;
+  program.getInfo(CL_PROGRAM_DEVICES, &devices);
+  if (devices.size() != numDevices) {
+    logError("Program reports {} binaries but {} devices; not caching.",
+             numDevices, devices.size());
+    return;
+  }
+
+  // Owning storage, so an early return cannot leak (the previous version hand
+  // rolled new[]/delete[] across six exit paths).
+  std::vector<std::vector<unsigned char>> binaryStorage(numDevices);
   std::vector<unsigned char *> binaries(numDevices, nullptr);
   for (size_t i = 0; i < numDevices; ++i) {
-    if (binarySizes[i] > 0) {
-      binaries[i] = new unsigned char[binarySizes[i]];
-    } else {
+    if (binarySizes[i] == 0) {
       logError("Binary size for device {} is zero.", i);
       return;
     }
+    binaryStorage[i].resize(binarySizes[i]);
+    binaries[i] = binaryStorage[i].data();
   }
 
-  // Step 3: Retrieve the binaries
   cl_int err = clGetProgramInfo(program(), CL_PROGRAM_BINARIES,
                                 numDevices * sizeof(unsigned char *),
                                 binaries.data(), nullptr);
   if (err != CL_SUCCESS) {
     logError("clGetProgramInfo(CL_PROGRAM_BINARIES) failed with error {}", err);
-    // Clean up allocated memory
-    for (auto ptr : binaries) {
-      delete[] ptr;
-    }
     return;
   }
 
-  // Step 4: Write the binaries to the output file
-  std::ofstream outFile(fullPath, std::ios::out | std::ios::binary);
-  if (!outFile) {
-    logError("Failed to open file for writing kernel binary");
-    // Clean up allocated memory
-    for (auto ptr : binaries) {
-      delete[] ptr;
-    }
-    return;
-  }
-
-  size_t totalBinarySize = 0;
+  std::vector<char> Out;
+  Out.insert(Out.end(), std::begin(ModuleCacheMagic),
+             std::end(ModuleCacheMagic));
+  appendPod(Out, static_cast<uint32_t>(numDevices));
   for (size_t i = 0; i < numDevices; ++i) {
-    logTrace("Writing binary for device {}: {} bytes", i, binarySizes[i]);
-    outFile.write(reinterpret_cast<const char *>(binaries[i]), binarySizes[i]);
-    if (!outFile) {
-      logError("Failed to write binary data to file");
-      outFile.close();
-      // Clean up allocated memory
-      for (auto ptr : binaries) {
-        delete[] ptr;
-      }
+    std::string Name;
+    if (devices[i].getInfo(CL_DEVICE_NAME, &Name) != CL_SUCCESS) {
+      logError("Failed to query device name while caching; not caching.");
       return;
     }
-    totalBinarySize += binarySizes[i];
+    appendPod(Out, static_cast<uint32_t>(Name.size()));
+    Out.insert(Out.end(), Name.begin(), Name.end());
+    appendPod(Out, static_cast<uint64_t>(binarySizes[i]));
+    Out.insert(Out.end(), binaryStorage[i].begin(), binaryStorage[i].end());
+    logTrace("Caching binary for device '{}': {} bytes", Name, binarySizes[i]);
   }
 
-  outFile.close();
-
-  // Step 5: Verify the file size
-  std::ifstream inFile(fullPath,
-                       std::ios::in | std::ios::binary | std::ios::ate);
-  if (!inFile) {
-    logError("Failed to open file for reading to verify size");
-    // Clean up allocated memory
-    for (auto ptr : binaries) {
-      delete[] ptr;
+  // Write to a private temp file and rename into place. rename(2) is atomic, so
+  // a concurrent reader sees either no file or a complete one. The library test
+  // suites run ctest with -j, so several processes can be compiling the same
+  // module at once; writing straight to the final path let one of them read a
+  // half written file.
+  std::string tmpPath =
+      fullPath + ".tmp." + std::to_string(static_cast<long>(::getpid()));
+  {
+    std::ofstream outFile(tmpPath, std::ios::out | std::ios::binary);
+    if (!outFile) {
+      logError("Failed to open {} for writing kernel binary", tmpPath);
+      return;
     }
+    outFile.write(Out.data(), Out.size());
+    if (!outFile) {
+      logError("Failed to write binary data to {}", tmpPath);
+      outFile.close();
+      std::remove(tmpPath.c_str());
+      return;
+    }
+  }
+
+  std::error_code EC;
+  std::filesystem::rename(tmpPath, fullPath, EC);
+  if (EC) {
+    logError("Failed to rename {} into place: {}", tmpPath, EC.message());
+    std::remove(tmpPath.c_str());
     return;
   }
-  std::streampos fileSize = inFile.tellg();
-  inFile.close();
 
-  if (fileSize != static_cast<std::streampos>(totalBinarySize)) {
-    logError("File size mismatch. Expected: {}, Actual: {}", totalBinarySize,
-             fileSize);
-    // Clean up allocated memory
-    for (auto ptr : binaries) {
-      delete[] ptr;
-    }
-    return;
-  }
-
-  logTrace("Kernel binary cached as {}", fullPath);
-  logTrace("Number of binaries: {}", numDevices);
-
-  // Step 6: Clean up allocated memory
-  for (auto ptr : binaries) {
-    delete[] ptr;
-  }
+  logTrace("Kernel binary cached as {} ({} devices)", fullPath, numDevices);
 }
 
 static bool load(cl::Context &context, const std::vector<cl::Device> &devices,
@@ -1107,30 +1177,75 @@ static bool load(cl::Context &context, const std::vector<cl::Device> &devices,
 
   inFile.seekg(0, std::ios::beg);
 
-  std::vector<char> binary(size);
-  inFile.read(binary.data(), size);
+  std::vector<char> fileData(size);
+  inFile.read(fileData.data(), size);
 
   if (inFile.fail()) {
     logError("Failed to read file. Error: {}", strerror(errno));
     return false;
   }
 
-  size_t bytesRead = inFile.gcount();
-  logTrace("Bytes actually read: {}", bytesRead);
-
   inFile.close();
 
-  try {
-    cl::Program::Binaries binaries(
-        1, std::vector<unsigned char>(binary.begin(), binary.end()));
-    logTrace("loading Binary size: {}", binary.size());
+  // Any malformed, truncated or old-format file is treated as a miss rather
+  // than an error: the caller just recompiles and overwrites it.
+  if (fileData.size() < sizeof(ModuleCacheMagic) ||
+      !std::equal(std::begin(ModuleCacheMagic), std::end(ModuleCacheMagic),
+                  fileData.begin())) {
+    logTrace("Cache file {} has no recognised header; ignoring", fullPath);
+    return false;
+  }
 
-    if (binary.empty()) {
-      logError("Binary data is empty. Deleting the cache file.");
-      std::remove(fullPath.c_str());
+  size_t Offset = sizeof(ModuleCacheMagic);
+  uint32_t DeviceCount = 0;
+  if (!readPod(fileData, Offset, DeviceCount)) {
+    logTrace("Cache file {} is truncated; ignoring", fullPath);
+    return false;
+  }
+
+  std::map<std::string, std::vector<unsigned char>> BinariesByDevice;
+  for (uint32_t i = 0; i < DeviceCount; ++i) {
+    uint32_t NameLen = 0;
+    if (!readPod(fileData, Offset, NameLen) ||
+        Offset + NameLen > fileData.size()) {
+      logTrace("Cache file {} is truncated; ignoring", fullPath);
       return false;
     }
+    std::string Name(fileData.data() + Offset, NameLen);
+    Offset += NameLen;
 
+    uint64_t BinarySize = 0;
+    if (!readPod(fileData, Offset, BinarySize) ||
+        Offset + BinarySize > fileData.size()) {
+      logTrace("Cache file {} is truncated; ignoring", fullPath);
+      return false;
+    }
+    const unsigned char *Start =
+        reinterpret_cast<const unsigned char *>(fileData.data() + Offset);
+    BinariesByDevice.emplace(std::move(Name),
+                             std::vector<unsigned char>(Start, Start + BinarySize));
+    Offset += BinarySize;
+  }
+
+  // Hand each device the binary that was compiled for it. Matching by name
+  // keeps this correct when the cached program covered a different device set
+  // or a different device order than the one being loaded now.
+  cl::Program::Binaries binaries;
+  binaries.reserve(devices.size());
+  for (const auto &Dev : devices) {
+    std::string Name;
+    if (Dev.getInfo(CL_DEVICE_NAME, &Name) != CL_SUCCESS)
+      return false;
+    auto It = BinariesByDevice.find(Name);
+    if (It == BinariesByDevice.end() || It->second.empty()) {
+      logTrace("Cache file {} has no binary for device '{}'; ignoring",
+               fullPath, Name);
+      return false;
+    }
+    binaries.push_back(It->second);
+  }
+
+  try {
     cl_int err;
     program = cl::Program(context, devices, binaries, nullptr, &err);
     assert(err == CL_SUCCESS);
@@ -1177,24 +1292,84 @@ static bool load(cl::Context &context, const std::vector<cl::Device> &devices,
   return true;
 }
 
-std::string generateCacheName(const std::string &strIn,
-                              const std::string &deviceName) {
-  std::hash<std::string> hasher;
-  std::string combinedStr = strIn + deviceName;
+/// Compute the module cache key.
+///
+/// The cached artifact is the device binary the driver produces, which is a
+/// pure function of the inputs handed to it: the IL, the flags, the rtdevlib
+/// modules linked alongside it, which driver compiled it, and the environment
+/// that driver reads. Every one of those is hashed here, so the key changes if
+/// and only if the resulting binary would.
+///
+/// Deliberately NOT a chipStar version or build id. Such a token changes on
+/// every commit and would evict the whole cache for changes that cannot affect
+/// a single kernel -- the common case, since most chipStar work is host side
+/// and leaves the SPIR-V byte identical. Keying the real inputs keeps those
+/// entries valid while still invalidating exactly when the output moves.
+///
+/// Fields are separated by markers so that no concatenation of one field can
+/// be mistaken for a different split across two.
+static std::string
+generateCacheName(const std::string &IL, const std::string &BuildOptions,
+                  const std::string &LinkFlags, bool NeedsRtDevLib,
+                  const std::vector<RtDevLibModule> &RtDevLibModules,
+                  CHIPDeviceOpenCL &ChipDev) {
+  std::string Combined;
 
-  // Include IGC_ environment variables in cache key
-  std::string igcVars = collectIGCEnvironmentVariables();
-  logDebug("IGC variables for cache key: '{}'", igcVars);
-  if (!igcVars.empty()) {
-    combinedStr += ";" + igcVars;
+  Combined += "---il---\n";
+  Combined += IL;
+
+  Combined += "\n---build-options---\n";
+  Combined += BuildOptions;
+
+  // Applied by the link step below and previously unkeyed: setting
+  // CHIP_JIT_FLAGS_OVERRIDE changed the produced binary without changing the
+  // key. The x86 CI sets it for the Zero-RK stage.
+  Combined += "\n---link-flags---\n";
+  Combined += LinkFlags;
+
+  // The override also feeds clBuildProgram on the direct (no rtdevlib) path,
+  // which is taken on every vendor, whereas LinkFlags above is empty off Intel.
+  // Keyed separately so the override is covered on both paths and all devices.
+  Combined += "\n---jit-override---\n";
+  if (ChipEnvVars.hasJitOverride())
+    Combined += ChipEnvVars.getJitFlagsOverride();
+
+  // compile+link and a direct clCreateProgramWithIL+clBuildProgram do not
+  // produce the same binary, so which path ran is part of the key.
+  Combined += "\n---needs-rtdevlib---\n";
+  Combined += NeedsRtDevLib ? "1" : "0";
+
+  // The rtdevlib modules are linked in after the cache lookup, so without this
+  // an edit to e.g. bitcode/atomicAddFloat_emulation.cl would keep serving the
+  // kernel built against the old one. Hashing the selected bytes also captures
+  // the capability-driven choice between the native and emulated variants.
+  Combined += "\n---rtdevlib---\n";
+  for (const auto &Module : RtDevLibModules) {
+    Combined += Module.Name;
+    Combined += ":";
+    Combined.append(reinterpret_cast<const char *>(Module.Data), Module.Size);
+    Combined += "\n";
   }
 
-  logDebug("Combined string for cache key: '{}'",
-           combinedStr.substr(0, 200) + "...");
-  size_t hash = hasher(combinedStr);
-  std::string cacheKey = std::to_string(hash);
-  logDebug("Generated cache key: '{}'", cacheKey);
-  return cacheKey;
+  // The device compiler is the JIT here, so its version belongs in the key just
+  // as the LLVM version belongs in the HIPRTC one. Without the driver version
+  // an IGC or Compute Runtime upgrade silently reuses binaries built by the
+  // previous compiler.
+  Combined += "\n---device---\n";
+  Combined += ChipDev.get()->getInfo<CL_DEVICE_NAME>();
+  Combined += "\n";
+  Combined += ChipDev.get()->getInfo<CL_DRIVER_VERSION>();
+  Combined += "\n";
+  Combined += ChipDev.get()->getInfo<CL_DEVICE_VERSION>();
+
+  Combined += "\n---env---\n";
+  std::string EnvVars = collectCompilerEnvironmentVariables();
+  logDebug("Compiler env vars for cache key: '{}'", EnvVars);
+  Combined += EnvVars;
+
+  std::string CacheKey = std::to_string(fnv1a64(Combined));
+  logDebug("Generated cache key: '{}'", CacheKey);
+  return CacheKey;
 }
 
 void CHIPModuleOpenCL::compile(chipstar::Device *ChipDev) {
@@ -1210,16 +1385,24 @@ void CHIPModuleOpenCL::compile(chipstar::Device *ChipDev) {
       Backend->getDefaultJitFlags() + " " + ChipEnvVars.getJitFlags();
   std::string binAsStr = std::string(SrcBin.begin(), SrcBin.end());
 
-  // Include device name in cache key
-  std::string deviceName = ChipDevOcl->getName();
+  // Everything the driver will be given has to be known before the lookup, so
+  // that the key covers it. These were previously computed inside the miss path
+  // and therefore could not be keyed.
+  bool NeedsRtDevLib = spirvNeedsRtdevlib(SrcBin);
+  std::vector<RtDevLibModule> RtDevLibModules;
+  if (NeedsRtDevLib)
+    RtDevLibModules = selectRuntimeObjects(*ChipDevOcl);
+  std::string Flags = computeLinkFlags(*ChipDevOcl);
+
   std::string cacheName =
-      generateCacheName(binAsStr + buildOptions, deviceName);
+      generateCacheName(binAsStr, buildOptions, Flags, NeedsRtDevLib,
+                        RtDevLibModules, *ChipDevOcl);
 
   bool cached =
       load(*ChipCtxOcl->get(), {*ChipDevOcl->get()}, cacheName, Program_);
 
   if (!cached) {
-    if (spirvNeedsRtdevlib(Src_->getBinary())) {
+    if (NeedsRtDevLib) {
       // Compile + link: compile main module, append rtdevlib, link together.
       cl::Program ClMainObj =
           compileIL(*ChipCtxOcl->get(), *ChipDevOcl, SrcBin.data(),
@@ -1228,15 +1411,6 @@ void CHIPModuleOpenCL::compile(chipstar::Device *ChipDev) {
       ClObjects.push_back(ClMainObj);
       appendRuntimeObjects(*ChipCtxOcl->get(), *ChipDevOcl, ClObjects);
 
-      std::string Flags = "";
-      std::string vendor = ChipDevOcl->get()->getInfo<CL_DEVICE_VENDOR>();
-      bool isIntelGPU =
-          (vendor.find("Intel") != std::string::npos) &&
-          (ChipDevOcl->get()->getInfo<CL_DEVICE_TYPE>() & CL_DEVICE_TYPE_GPU);
-      if (isIntelGPU)
-        Flags = ChipEnvVars.hasJitOverride() ? ChipEnvVars.getJitFlagsOverride()
-                                             : ChipEnvVars.getJitFlags() + " " +
-                                                   Backend->getDefaultJitFlags();
       logInfo("Linking {} program objects", ClObjects.size());
       Program_ =
           cl::linkProgram(ClObjects, Flags.c_str(), nullptr, nullptr, &Err);

--- a/src/spirv_hiprtc.cc
+++ b/src/spirv_hiprtc.cc
@@ -460,20 +460,8 @@ hiprtcResult hiprtcAddNameExpression(hiprtcProgram Prog,
   return HIPRTC_SUCCESS;
 }
 
-/// FNV-1a 64-bit hash — portable, deterministic across runs and platforms.
-/// std::hash<std::string> is implementation-defined and may produce different
-/// values across program runs (some libc++ randomize it) or across different
-/// compiler/stdlib versions, making the cache effectively write-only on those
-/// platforms. A stable on-disk hash is required for the versioned cache file
-/// format ('CHC1' magic) to be useful.
-static uint64_t fnv1a64(const std::string &s) {
-  uint64_t hash = UINT64_C(14695981039346656037);
-  for (unsigned char c : s) {
-    hash ^= c;
-    hash *= UINT64_C(1099511628211);
-  }
-  return hash;
-}
+// fnv1a64 lives in Utils.hh: the module cache needs the same stable hash, and
+// two copies would be free to drift.
 
 /// Compute a cache key for HIPRTC output based on source, headers, options,
 /// and registered name expressions.

--- a/tests/run_module_cache_invalidation_test.cmake
+++ b/tests/run_module_cache_invalidation_test.cmake
@@ -1,0 +1,141 @@
+# Module cache invalidation test.
+#
+# The module cache maps a compiled device binary to a key. If that key misses an
+# input that changes what the driver emits, a warm cache serves a kernel built
+# from different inputs -- silently, and with no way to tell from the results.
+# This drives one test binary repeatedly under a fresh cache directory and
+# checks the cache entry count after each run, which is an observable proxy for
+# "did the key change":
+#
+#   same inputs      -> no new entry (hit)   ... the key must be stable
+#   changed inputs   -> a new entry (miss)   ... the key must invalidate
+#
+# Both directions matter. A key that never invalidates serves stale kernels; a
+# key that always invalidates (e.g. one keyed on a build id or timestamp) makes
+# the cache useless without failing any correctness test.
+#
+# libCHIP reads CHIP_MODULE_CACHE_DIR at static-init time, so it has to be set
+# before the process starts; hence a script wrapper rather than a test fixture.
+#
+# Invoked as:
+#   cmake -DTEST_EXECUTABLE=<path> -P run_module_cache_invalidation_test.cmake
+
+if(NOT TEST_EXECUTABLE)
+  message(FATAL_ERROR "TEST_EXECUTABLE not set")
+endif()
+
+# Lowercase-only directory name, deliberately not mktemp -d. This test looks at
+# the cache directory from the outside to count entries, and the runtime
+# currently lowercases CHIP_MODULE_CACHE_DIR (issue #1396), so a path containing
+# uppercase characters -- which mktemp names routinely do -- would have its
+# entries written somewhere else and every run would look like a miss. Staying
+# lowercase makes the test agree with the runtime either way, before or after
+# that bug is fixed.
+string(RANDOM LENGTH 12 ALPHABET "abcdefghijklmnopqrstuvwxyz0123456789" SUFFIX)
+set(CACHE_DIR "$ENV{TMPDIR}")
+if(NOT CACHE_DIR)
+  set(CACHE_DIR "/tmp")
+endif()
+string(TOLOWER "${CACHE_DIR}/chipstar-cache-test-${SUFFIX}" CACHE_DIR)
+file(REMOVE_RECURSE "${CACHE_DIR}")
+file(MAKE_DIRECTORY "${CACHE_DIR}")
+
+set(FAILURES "")
+
+# Run TEST_EXECUTABLE with CHIP_MODULE_CACHE_DIR set plus any extra NAME=VALUE
+# entries, and report how many entries the cache holds afterwards.
+function(run_and_count LABEL OUT_COUNT)
+  # Clear the variables this test toggles before applying the one under test, so
+  # each run is a known delta from the baseline rather than from whatever the
+  # caller's environment happened to hold. This is not hypothetical: the x86 CI
+  # exports OverrideDefaultFP64Settings=1 for every job, which would make the
+  # step that adds it a no-op and fail the test for the wrong reason.
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E env
+      --unset=CHIP_JIT_FLAGS_OVERRIDE
+      --unset=OverrideDefaultFP64Settings
+      --unset=NEOReadDebugKeys
+      "CHIP_MODULE_CACHE_DIR=${CACHE_DIR}"
+      ${ARGN}
+      "${TEST_EXECUTABLE}"
+    RESULT_VARIABLE RUN_RC
+    OUTPUT_VARIABLE RUN_OUT
+    ERROR_VARIABLE RUN_ERR)
+  if(NOT RUN_RC EQUAL 0)
+    message(FATAL_ERROR
+      "${LABEL}: test executable failed (exit ${RUN_RC})\n${RUN_OUT}\n${RUN_ERR}")
+  endif()
+  # Count only cache entries; a crashed writer could leave a *.tmp.<pid> behind
+  # and those are not cache hits.
+  file(GLOB ENTRIES "${CACHE_DIR}/*")
+  set(REAL_ENTRIES "")
+  foreach(ENTRY IN LISTS ENTRIES)
+    if(NOT ENTRY MATCHES "\\.tmp\\.[0-9]+$")
+      list(APPEND REAL_ENTRIES "${ENTRY}")
+    endif()
+  endforeach()
+  list(LENGTH REAL_ENTRIES COUNT)
+  message(STATUS "${LABEL}: ${COUNT} cache entr(y/ies)")
+  set(${OUT_COUNT} ${COUNT} PARENT_SCOPE)
+endfunction()
+
+function(expect LABEL ACTUAL EXPECTED)
+  if(NOT ACTUAL EQUAL EXPECTED)
+    set(FAILURES "${FAILURES}  ${LABEL}: expected ${EXPECTED} entries, got ${ACTUAL}\n"
+        PARENT_SCOPE)
+  endif()
+endfunction()
+
+# 1. Cold: the first compile must populate the cache.
+run_and_count("cold run" N1)
+if(N1 LESS 1)
+  file(REMOVE_RECURSE "${CACHE_DIR}")
+  message(FATAL_ERROR
+    "cold run produced no cache entries; caching is not active, so this test "
+    "cannot detect anything")
+endif()
+
+# 2. Identical inputs must hit. If this grows, the key depends on something that
+#    varies run to run (a timestamp, a randomized std::hash, an unsorted
+#    environment) and the cache would never be reused.
+run_and_count("repeat run (expect hit)" N2)
+expect("repeat run" ${N2} ${N1})
+
+# 3. CHIP_JIT_FLAGS_OVERRIDE changes the flags handed to the driver, so it must
+#    invalidate. It was previously absent from the key even though the x86 CI
+#    sets it.
+math(EXPR N3_EXPECTED "${N1} + ${N1}")
+run_and_count("with CHIP_JIT_FLAGS_OVERRIDE (expect miss)" N3
+  "CHIP_JIT_FLAGS_OVERRIDE=-cl-opt-disable")
+expect("CHIP_JIT_FLAGS_OVERRIDE" ${N3} ${N3_EXPECTED})
+
+# 4. OverrideDefaultFP64Settings switches on fp64 emulation, which changes the
+#    device's reported fp64 capability and therefore which rtdevlib modules get
+#    linked. This covers the rtdevlib half of the key: the selected modules are
+#    hashed, so a different selection must produce a different key.
+math(EXPR N4_EXPECTED "${N3} + ${N1}")
+run_and_count("with OverrideDefaultFP64Settings (expect miss)" N4
+  "OverrideDefaultFP64Settings=1")
+expect("OverrideDefaultFP64Settings" ${N4} ${N4_EXPECTED})
+
+# 5. A compiler environment variable that does NOT change device capabilities
+#    must still invalidate, because it still reaches the device compiler. This
+#    is the one that pins the environment half of the key: it can only be caught
+#    by collecting the variable itself, and the collector used to match IGC_*
+#    only, so anything from the Compute Runtime or the Level Zero loader was
+#    invisible to the key.
+math(EXPR N5_EXPECTED "${N4} + ${N1}")
+run_and_count("with NEOReadDebugKeys (expect miss)" N5 "NEOReadDebugKeys=1")
+expect("NEOReadDebugKeys" ${N5} ${N5_EXPECTED})
+
+# 6. Back to the original inputs: must hit the entry from step 1, proving the
+#    key invalidates on real changes rather than simply always changing.
+run_and_count("back to baseline (expect hit)" N6)
+expect("baseline revisit" ${N6} ${N5})
+
+file(REMOVE_RECURSE "${CACHE_DIR}")
+
+if(NOT FAILURES STREQUAL "")
+  message(FATAL_ERROR "module cache invalidation test failed:\n${FAILURES}")
+endif()
+message(STATUS "module cache invalidation test passed")

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -247,3 +247,20 @@ add_hip_runtime_test(TestSyncthreadsAndOrCount.hip)
 # __clz(0)-poison miscompile only manifests at -O1 and above.
 add_hip_runtime_test(TestSnakeMiscompileO2.hip)
 target_compile_options(TestSnakeMiscompileO2 PRIVATE -O2)
+
+# Module cache invalidation. The executable is built like any other runtime
+# test, but it has to be run several times with different compilation inputs
+# under one fresh cache directory, so it is registered through a driver script
+# instead of add_hip_runtime_test's single invocation.
+set_source_files_properties(TestModuleCacheInvalidation.hip PROPERTIES LANGUAGE CXX)
+add_executable(TestModuleCacheInvalidation TestModuleCacheInvalidation.hip)
+set_target_properties(TestModuleCacheInvalidation PROPERTIES CXX_STANDARD_REQUIRED ON)
+target_link_libraries(TestModuleCacheInvalidation CHIP deviceInternal)
+target_include_directories(TestModuleCacheInvalidation
+  PRIVATE $<TARGET_PROPERTY:CHIP,INCLUDE_DIRECTORIES>)
+add_test(NAME TestModuleCacheInvalidation
+  COMMAND ${CMAKE_COMMAND}
+    -DTEST_EXECUTABLE=$<TARGET_FILE:TestModuleCacheInvalidation>
+    -P ${CMAKE_SOURCE_DIR}/tests/run_module_cache_invalidation_test.cmake)
+set_tests_properties(TestModuleCacheInvalidation PROPERTIES
+  SKIP_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST")

--- a/tests/runtime/TestModuleCacheInvalidation.hip
+++ b/tests/runtime/TestModuleCacheInvalidation.hip
@@ -1,0 +1,49 @@
+// Payload for the module cache invalidation test.
+//
+// Driven repeatedly by tests/run_module_cache_invalidation_test.cmake, which
+// varies the compilation inputs between runs and checks whether the module
+// cache key changed. This program only has to compile a device module and
+// produce a correct result; the assertions about caching live in that script.
+//
+// atomicAdd on a float is deliberate: it makes the module import a symbol from
+// the runtime device library, so the compile takes the compile+link path that
+// links an rtdevlib module in after the cache is consulted. Those modules are
+// part of what the key must cover, and a module that needs none of them would
+// take the direct clBuildProgram path and never exercise it.
+
+#include <hip/hip_runtime.h>
+#include <cstdio>
+
+__global__ void accumulate(float *Out) { atomicAdd(Out, 1.0f); }
+
+int main() {
+  constexpr int NumThreads = 64;
+
+  float *DevOut = nullptr;
+  if (hipMalloc(&DevOut, sizeof(float)) != hipSuccess) {
+    printf("FAILED: hipMalloc\n");
+    return 1;
+  }
+  if (hipMemset(DevOut, 0, sizeof(float)) != hipSuccess) {
+    printf("FAILED: hipMemset\n");
+    return 1;
+  }
+
+  accumulate<<<1, NumThreads>>>(DevOut);
+
+  float HostOut = 0.0f;
+  if (hipMemcpy(&HostOut, DevOut, sizeof(float), hipMemcpyDeviceToHost) !=
+      hipSuccess) {
+    printf("FAILED: hipMemcpy\n");
+    return 1;
+  }
+  (void)hipFree(DevOut);
+
+  if (HostOut != static_cast<float>(NumThreads)) {
+    printf("FAILED: expected %d, got %f\n", NumThreads, HostOut);
+    return 1;
+  }
+
+  printf("PASSED\n");
+  return 0;
+}


### PR DESCRIPTION
The module cache key misses several things that change what the driver emits, so a warm cache can serve a kernel built from different inputs. That is why CI disables caching entirely.

Missing from the OpenCL key:

- the runtime device library, linked by appendRuntimeObjects() after the cache is consulted, so editing bitcode/atomicAddFloat_emulation.cl kept serving the kernel built against the old one
- CHIP_JIT_FLAGS_OVERRIDE, which the x86 CI sets for the Zero-RK stage
- the Intel-conditional link step flags
- whether the compile took the compile+link or direct clBuildProgram path
- the driver version; the device compiler is the JIT here, and CL_DRIVER_VERSION was queried nowhere, so an IGC upgrade invalidated nothing
- compiler environment variables without an IGC_ prefix, notably OverrideDefaultFP64Settings which the x86 CI exports on every job

Not keyed on a chipStar version or build id on purpose. That changes every commit and would evict entries for changes that cannot affect a kernel, which is the common case since most chipStar work is host side and leaves the SPIR-V byte identical. Keying the real inputs invalidates exactly when the output moves.

Also fixes two things that made caching unsafe regardless of the key: the cache file concatenated every device's binary with no sizes and the reader handed the whole blob back as device 0's, corrupting multi-device programs; and the writer wrote straight to the final path so a concurrent reader could see a partial file. Entries are now framed behind a 'CHM1' magic and written via temp plus rename.

Level Zero gains the driver version and widened environment, and its two copies of the key computation are merged. Both backends move off std::hash<std::string>, which is implementation-defined, onto the fnv1a64 the HIPRTC cache already uses.

Adds TestModuleCacheInvalidation, which varies compilation inputs across runs under a fresh cache and asserts both directions: unchanged inputs must hit, changed inputs must miss. Verified it fails against the unfixed collector and passes once fixed.

This does not enable caching in CI. That is a separate decision and wants the measured hit rate first.
