### PR TITLE
Update .gitlab-ci.yml to use LLVM21 instead of LLVM19

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,8 +23,8 @@ stages:
     - build_chipstar
     - builds_chipstar_install_script_llvm22
     - runs_tests_chipstar_install_script_llvm22
-    - builds_chipstar_aurora_script_llvm19
-    - runs_chipstar_aurora_script_llvm19
+    - builds_chipstar_aurora_script_llvm21
+    - runs_chipstar_aurora_script_llvm21
     - builds_chipstar_aurora_script_llvm22
     - runs_chipstar_aurora_script_llvm22
     - builds_hoMusic
@@ -71,7 +71,7 @@ aurora_build_test:
     - cd ${WRK_DIR}/chipStar
     # first test with already installed clang. will update to patch and build
     - module use /soft/modulefiles
-    - module load cmake chipStar/.llvm19/20251107-19/release
+    - module load cmake chipStar/.llvm21/20260808-21/release
     - rm -rf build
     - mkdir build
     - cd build
@@ -110,27 +110,27 @@ chipStar_script_test_llvm22:
 
 # testing with install script
 chipStar_aurora_script_test:
-  stage: builds_chipstar_aurora_script_llvm19
+  stage: builds_chipstar_aurora_script_llvm21
   resource_group: aurora_pipeline  
   extends: .aurora-shell-runner
   script:
     - hostname
     - echo "Running on $(hostname) with setuid shell runner"
-    - mkdir ${WRK_DIR}/script_llvm19
-    - cp -r ${WRK_DIR}/chipStar ${WRK_DIR}/script_llvm19
-    - NO_FRESH_CHIPSTAR_PULL=true temp=${WRK_DIR}/script_llvm19 MODULE_INSTALL_DIR=${WRK_DIR}/modulefiles CHIPSTAR_INSTALL_DIR=${WRK_DIR}/latest_llvm19/ /lus/flare/projects/Aurora_deployment/bertoni/projects/p02.chipStar/chip-star-patch.sh release chipStar/.llvm19/20251107-19/release
+    - mkdir ${WRK_DIR}/script_llvm21
+    - cp -r ${WRK_DIR}/chipStar ${WRK_DIR}/script_llvm21
+    - NO_FRESH_CHIPSTAR_PULL=true temp=${WRK_DIR}/script_llvm21 MODULE_INSTALL_DIR=${WRK_DIR}/modulefiles CHIPSTAR_INSTALL_DIR=${WRK_DIR}/latest_llvm21/ /lus/flare/projects/Aurora_deployment/bertoni/projects/p02.chipStar/chip-star-patch.sh release chipStar/.llvm21/20260808-21/release
     - cd ${WRK_DIR}/modulefiles/chipStar
-    - echo 'module_version("llvm19", "default")' > .modulerc.lua
+    - echo 'module_version("llvm21", "default")' > .modulerc.lua
   allow_failure: true
   
 chipStar_aurora_script_test_run:
-  stage: runs_chipstar_aurora_script_llvm19
+  stage: runs_chipstar_aurora_script_llvm21
   resource_group: aurora_pipeline  
   extends: .aurora-batch-runner
   script:
     - hostname
     - echo "Running on $(hostname) with setuid shell runner"
-    - cd ${WRK_DIR}/script_llvm19/chipStar/build
+    - cd ${WRK_DIR}/script_llvm21/chipStar/build
     - rm -rf $HOME/.cache/chipStar
     - CHIP_BE=level0 make build_tests -j
     - module load cmake
@@ -169,7 +169,7 @@ hoMusic_build:
   resource_group: aurora_pipeline  
   extends: .aurora-shell-runner
   script:
-    - ${GENESIS_CI_PROJECT_DIR}/hoMusic_ci.sh build chipStar/llvm19
+    - ${GENESIS_CI_PROJECT_DIR}/hoMusic_ci.sh build chipStar/llvm21
   
 hoMusic_run:
   stage: runs_hoMusic
@@ -178,7 +178,7 @@ hoMusic_run:
   script:
     - set -o pipefail
     - rm -f ${GENESIS_CI_PROJECT_DIR}/output
-    - ${GENESIS_CI_PROJECT_DIR}/hoMusic_ci.sh run chipStar/llvm19 |& tee -a ${GENESIS_CI_PROJECT_DIR}/output
+    - ${GENESIS_CI_PROJECT_DIR}/hoMusic_ci.sh run chipStar/llvm21 |& tee -a ${GENESIS_CI_PROJECT_DIR}/output
 
 performance_hoMusic:
   stage: performance_hoMusic
@@ -221,7 +221,7 @@ zeroRK_build:
    - cd zero-rk
    - module use /soft/modulefiles
    - module use ${WRK_DIR}/modulefiles
-   - module load chipStar/llvm19 cmake
+   - module load chipStar/llvm21 cmake
    - mkdir -p build_aurora
    - cd build_aurora
    - sh ../scripts/build_aurora.sh  --no-module-loads
@@ -237,7 +237,7 @@ zeroRK_run:
   - chmod a+x ./submit_job.sh
   - module use /soft/modulefiles
   - module use ${WRK_DIR}/modulefiles
-  - module load chipStar/llvm19
+  - module load chipStar/llvm21
   - rm -f output
   - set -o pipefail
   - ./submit_job.sh |& tee -a output
@@ -282,7 +282,7 @@ opensn_build:
    - export ONEAPI_DEVICE_SELECTOR=level_zero:gpu
    - module use /soft/modulefiles
    - module use ${WRK_DIR}/modulefiles
-   - module load chipStar/llvm19 cmake
+   - module load chipStar/llvm21 cmake
    - export BASE=$PWD
    - git clone git@github.com:Open-Sn/opensn.git
    - cd opensn
@@ -310,7 +310,7 @@ opensn_run:
    - cp ${WRK_DIR}/chipStar/tests/apps/OpenSn/xs_168g.xs .
    - module use ${WRK_DIR}/modulefiles
    - module use /soft/modulefiles
-   - module load chipStar/llvm19
+   - module load chipStar/llvm21
    - module load hdf5
    - rm -rf ~/.cache/chipStar/
    - rm -f output


### PR DESCRIPTION
This is a test of LLVM21 instead of LLVM19 for gitlab testing.