### PR TITLE
ci: trigger the LLVM patch tests only on files that build LLVM

### DIFF
--- a/.github/workflows/test-llvm-patches.yml
+++ b/.github/workflows/test-llvm-patches.yml
@@ -10,13 +10,15 @@ on:
     paths:
       - 'llvm-patches/**'
       - 'scripts/configure_llvm.sh'
-      - 'scripts/cross-aarch64/**'
+      - 'scripts/cross-aarch64/Dockerfile'
+      - 'scripts/cross-aarch64/cross-build.sh'
       - '.github/workflows/test-llvm-patches.yml'
   pull_request:
     paths:
       - 'llvm-patches/**'
       - 'scripts/configure_llvm.sh'
-      - 'scripts/cross-aarch64/**'
+      - 'scripts/cross-aarch64/Dockerfile'
+      - 'scripts/cross-aarch64/cross-build.sh'
       - '.github/workflows/test-llvm-patches.yml'
   workflow_dispatch:
 
@@ -73,9 +75,13 @@ jobs:
             git diff --quiet "$BASE"...HEAD -- llvm-patches/llvm-21 || v21=true
             git diff --quiet "$BASE"...HEAD -- llvm-patches/llvm-22 || v22=true
             git diff --quiet "$BASE"...HEAD -- llvm-patches/llvm-23 || v23=true
-            # The aarch64 cross-build scripts only feed the LLVM 23 salami
-            # lane, so a change there rebuilds 23 alone, not 21/22.
-            git diff --quiet "$BASE"...HEAD -- scripts/cross-aarch64 || v23=true
+            # Only the two files that determine the aarch64 LLVM itself: the
+            # base image it builds in, and the script that builds it. The rest
+            # of scripts/cross-aarch64 cross-builds chipStar, not LLVM, and
+            # must not cost a toolchain rebuild. Feeds the 23 lane alone.
+            git diff --quiet "$BASE"...HEAD -- \
+                scripts/cross-aarch64/Dockerfile \
+                scripts/cross-aarch64/cross-build.sh || v23=true
           fi
           any=false
           { $v21 || $v22 || $v23; } && any=true

--- a/.github/workflows/test-llvm-patches.yml
+++ b/.github/workflows/test-llvm-patches.yml
@@ -12,6 +12,7 @@ on:
       - 'scripts/configure_llvm.sh'
       - 'scripts/cross-aarch64/Dockerfile'
       - 'scripts/cross-aarch64/cross-build.sh'
+      - 'scripts/cross-aarch64/aarch64-toolchain.cmake'
       - '.github/workflows/test-llvm-patches.yml'
   pull_request:
     paths:
@@ -19,6 +20,7 @@ on:
       - 'scripts/configure_llvm.sh'
       - 'scripts/cross-aarch64/Dockerfile'
       - 'scripts/cross-aarch64/cross-build.sh'
+      - 'scripts/cross-aarch64/aarch64-toolchain.cmake'
       - '.github/workflows/test-llvm-patches.yml'
   workflow_dispatch:
 
@@ -81,7 +83,8 @@ jobs:
             # must not cost a toolchain rebuild. Feeds the 23 lane alone.
             git diff --quiet "$BASE"...HEAD -- \
                 scripts/cross-aarch64/Dockerfile \
-                scripts/cross-aarch64/cross-build.sh || v23=true
+                scripts/cross-aarch64/cross-build.sh \
+                scripts/cross-aarch64/aarch64-toolchain.cmake || v23=true
           fi
           any=false
           { $v21 || $v22 || $v23; } && any=true


### PR DESCRIPTION
scripts/cross-aarch64 held one file when this filter was written, and that file built the aarch64 LLVM 23, so gating a toolchain rebuild on the whole directory was accurate. The directory has since grown a chipStar cross build, an rsync step, an OpenCL stub and a README, none of which affect the toolchain.

The cost is not one rebuild per push: detect diffs the branch against its base, so any PR touching that directory pays a full LLVM 23 rebuild on every push for the life of the PR. PR #1460 (https://github.com/CHIP-SPV/chipStar/pull/1460) has been paying roughly 116 min per push for this.

Narrows both the workflow trigger and the detect check to scripts/cross-aarch64/Dockerfile and scripts/cross-aarch64/cross-build.sh, which are what actually determine the toolchain.

Note on merging: this edits test-llvm-patches.yml itself, which the detect job treats as rebuild everything, so merging runs install-llvm-on-main for LLVM 21, 22-translator, 22-native and 23. Best merged when the self-hosted runners are otherwise idle.