### PR TITLE
List the pass plugin sources one per line

### DIFF
--- a/llvm_passes/CMakeLists.txt
+++ b/llvm_passes/CMakeLists.txt
@@ -97,15 +97,38 @@ endif()
 
 add_library(LLVMHipStripUsedIntrinsics MODULE HipStripUsedIntrinsics.cpp)
 add_library(LLVMHipDefrost MODULE HipDefrost.cpp)
-add_library(LLVMHipPasses MODULE HipPasses.cpp
-    HipDynMem.cpp HipStripUsedIntrinsics.cpp HipStripDebugInfo.cpp HipDefrost.cpp
-    HipPrintf.cpp HipGlobalVariables.cpp HipCleanup.cpp HipTextureLowering.cpp HipAbort.cpp
-    HipEmitLoweredNames.cpp HipWarps.cpp HipKernelArgSpiller.cpp
-    HipLowerZeroLengthArrays.cpp HipSanityChecks.cpp HipLowerSwitch.cpp
-    HipLowerMemset.cpp HipLowerFPAtomicMinMax.cpp HipIGBADetector.cpp HipPromoteInts.cpp
+# One source per line, alphabetically sorted, so that two branches each adding
+# a pass insert at different anchors and merge without a conflict.
+#
+# HipPasses.cpp must stay first: fifteen of these sources define
+# llvmGetPassPluginInfo, which LLVM declares LLVM_ATTRIBUTE_WEAK, so the link
+# keeps whichever object comes first instead of reporting a duplicate, and only
+# HipPasses.cpp registers the hip-post-link-passes pipeline.
+add_library(LLVMHipPasses MODULE
+    HipPasses.cpp
+    HipAbort.cpp
+    HipCanonicalizeGEP.cpp
+    HipCleanup.cpp
+    HipDefrost.cpp
+    HipDynMem.cpp
+    HipEmitLoweredNames.cpp
+    HipGlobalVariables.cpp
+    HipIGBADetector.cpp
+    HipKernelArgSpiller.cpp
+    HipLowerFPAtomicMinMax.cpp
+    HipLowerMemset.cpp
     HipLowerOverflowIntrinsics.cpp
+    HipLowerSwitch.cpp
+    HipLowerZeroLengthArrays.cpp
+    HipPrintf.cpp
+    HipPromoteInts.cpp
+    HipSanityChecks.cpp
     HipSpirvFunctionReorderPass.cpp
-    HipVerify.cpp HipCanonicalizeGEP.cpp
+    HipStripDebugInfo.cpp
+    HipStripUsedIntrinsics.cpp
+    HipTextureLowering.cpp
+    HipVerify.cpp
+    HipWarps.cpp
     ${EXTRA_OBJS})
 
 # macOS Linking Requirements:


### PR DESCRIPTION
Lists the `LLVMHipPasses` sources one per line, alphabetically sorted, instead of packing several per line.

Adding a pass previously meant editing a line shared with three unrelated passes:

    HipLowerMemset.cpp HipLowerFPAtomicMinMax.cpp HipIGBADetector.cpp HipPromoteInts.cpp

so two branches that each add a pass conflict even though the changes are independent. #1395 hit exactly that against the `HipLowerFPAtomicMinMax.cpp` addition. One source per line gives each new pass its own anchor and a three-way merge resolves them without help.

`HipPasses.cpp` stays first, with the reason written down above the target. Fifteen sources in this directory define `llvmGetPassPluginInfo`, which LLVM declares `LLVM_ATTRIBUTE_WEAK`, so the link keeps whichever object comes first instead of reporting a duplicate symbol, and only `HipPasses.cpp` registers the `hip-post-link-passes` pipeline. Sorting it into the middle yields a plugin that compiles and links cleanly, exports the symbol, and still fails every `hipcc` invocation with `opt: unknown pass name 'hip-post-link-passes'`.

No build change, verified three ways: the ninja object list for `LLVMHipPasses.dir` is unchanged, the built plugin still answers to `opt -load-pass-plugin ... -passes=hip-post-link-passes`, and so does a standalone pass name.

`file(GLOB)` was considered and rejected. CMake's documentation advises against globbing source trees, since nothing tells the generated build system to re-run cmake when a source appears or disappears, which misbuilds for anyone switching between a branch that adds a pass and one that does not. It would also drop only half the friction, as a new pass still has to be registered in `HipPasses.cpp`.