### PR TITLE
Guard the duplicate plugin entry, test plugin registration, and two doc/test fixes

### DIFF
--- a/llvm_passes/CMakeLists.txt
+++ b/llvm_passes/CMakeLists.txt
@@ -132,6 +132,23 @@ add_library(LLVMHipPasses MODULE
     HipWarps.cpp
     ${EXTRA_OBJS})
 
+# The plugin registers its pipeline through llvmGetPassPluginInfo, and the
+# ordering note above explains how easily that registration is lost: the link
+# still succeeds, the symbol is still exported, and only an actual opt run
+# notices. Without this test the failure surfaces as every hipcc invocation
+# reporting "unknown pass name" with no build error anywhere.
+find_program(LLVM_OPT NAMES opt-${LLVM_VERSION_MAJOR} opt
+  NO_DEFAULT_PATH PATHS ${CLANG_ROOT_PATH_BIN} ENV PATH)
+if(LLVM_OPT)
+  set(PLUGIN_PROBE_IR ${CMAKE_CURRENT_BINARY_DIR}/plugin-probe.ll)
+  file(WRITE ${PLUGIN_PROBE_IR} "define void @probe() { ret void }\n")
+  add_test(NAME PassPluginRegistersPipeline
+    COMMAND ${LLVM_OPT} -load-pass-plugin $<TARGET_FILE:LLVMHipPasses>
+            -passes=hip-post-link-passes ${PLUGIN_PROBE_IR} -o /dev/null)
+else()
+  message(STATUS "opt not found; skipping the pass plugin registration test")
+endif()
+
 # macOS Linking Requirements:
 # On macOS, the linker requires all symbols to be resolved at link time for
 # MODULE (plugin) libraries, unlike Linux where unresolved symbols can be

--- a/llvm_passes/CMakeLists.txt
+++ b/llvm_passes/CMakeLists.txt
@@ -100,12 +100,12 @@ add_library(LLVMHipDefrost MODULE HipDefrost.cpp)
 # One source per line, alphabetically sorted, so that two branches each adding
 # a pass insert at different anchors and merge without a conflict.
 #
-# HipPasses.cpp must stay first: fifteen of these sources define
-# llvmGetPassPluginInfo, which LLVM declares LLVM_ATTRIBUTE_WEAK, so the link
-# keeps whichever object comes first instead of reporting a duplicate, and only
-# HipPasses.cpp registers the hip-post-link-passes pipeline.
+# Order is not load-bearing, but only because every pass guards its standalone
+# llvmGetPassPluginInfo with CHIP_COMBINED_PASS_PLUGIN, leaving HipPasses.cpp
+# as the single definition here. A pass that forgets the guard adds a second
+# LLVM_ATTRIBUTE_WEAK definition, which the link resolves silently by position
+# rather than rejecting; PassPluginRegistersPipeline below catches that.
 add_library(LLVMHipPasses MODULE
-    HipPasses.cpp
     HipAbort.cpp
     HipCanonicalizeGEP.cpp
     HipCleanup.cpp
@@ -120,6 +120,7 @@ add_library(LLVMHipPasses MODULE
     HipLowerOverflowIntrinsics.cpp
     HipLowerSwitch.cpp
     HipLowerZeroLengthArrays.cpp
+    HipPasses.cpp
     HipPrintf.cpp
     HipPromoteInts.cpp
     HipSanityChecks.cpp

--- a/llvm_passes/HipLowerFPAtomicMinMax.cpp
+++ b/llvm_passes/HipLowerFPAtomicMinMax.cpp
@@ -125,6 +125,7 @@ PreservedAnalyses HipLowerFPAtomicMinMaxPass::run(Function &F,
                                 : PreservedAnalyses::all();
 }
 
+#ifndef CHIP_COMBINED_PASS_PLUGIN
 extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
 llvmGetPassPluginInfo() {
   return {LLVM_PLUGIN_API_VERSION, PASS_NAME, LLVM_VERSION_STRING,
@@ -140,3 +141,4 @@ llvmGetPassPluginInfo() {
                 });
           }};
 }
+#endif // CHIP_COMBINED_PASS_PLUGIN

--- a/llvm_passes/HipLowerOverflowIntrinsics.cpp
+++ b/llvm_passes/HipLowerOverflowIntrinsics.cpp
@@ -26,14 +26,18 @@
 // llvm.smul.with.overflow has no lowering at all and translation aborts with
 // "InvalidFunctionCall: Unexpected llvm intrinsic". Since chipStar puts all of
 // a binary's device code in one module, either failure takes down every kernel
-// in the program.
+// in the program. Issue #1475 tracks both upstream gaps and the conditions
+// under which this pass can be dropped again.
 //
 // Expanding both intrinsics here means neither construct reaches SPIR-V.
 // The overflow predicate is computed with a division rather than a 128-bit
-// multiply because i128 is not portable across the SPIR-V consumers chipStar
-// targets. These intrinsics come from allocation-size checks, which are not
-// hot code. The pass must stay after any InstCombine run, which re-forms both
-// intrinsics from exactly the shapes emitted here.
+// multiply because 128-bit integers are outside the OpenCL SPIR-V environment,
+// which requires only the Int8, Int16 and Int64 capabilities: llvm-spirv
+// rejects them with "InvalidBitWidth: Invalid bit width in input: 128" and the
+// in-tree backend demands SPV_ALTERA_arbitrary_precision_integers, an
+// extension IGC does not know. These intrinsics come from allocation-size
+// checks, which are not hot code. The pass must stay after any InstCombine
+// run, which re-forms both intrinsics from exactly the shapes emitted here.
 //
 // Copyright (c) 2026 chipStar developers
 //===----------------------------------------------------------------------===//

--- a/tests/regression/TestFix1391UmulWithOverflow.hip
+++ b/tests/regression/TestFix1391UmulWithOverflow.hip
@@ -26,6 +26,15 @@
 #include <cstdio>
 #include <cstdint>
 
+#define CHECK(Expr)                                                            \
+  do {                                                                         \
+    hipError_t Err = (Expr);                                                   \
+    if (Err != hipSuccess) {                                                   \
+      printf("FAIL: %s returned %s\n", #Expr, hipGetErrorString(Err));         \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
 __global__ void testUmulOverflow(uint64_t *Lo, uint64_t *Ov) {
   uint64_t R = 0;
 
@@ -61,8 +70,8 @@ int main() {
     printf("SKIP: no GPU\n");
     return 0;
   }
-  hipMemset(DLo, 0, N * sizeof(uint64_t));
-  hipMemset(DOv, 0, N * sizeof(uint64_t));
+  CHECK(hipMemset(DLo, 0, N * sizeof(uint64_t)));
+  CHECK(hipMemset(DOv, 0, N * sizeof(uint64_t)));
 
   hipLaunchKernelGGL(testUmulOverflow, dim3(1), dim3(1), 0, 0, DLo, DOv);
   if (hipDeviceSynchronize() != hipSuccess) {
@@ -71,10 +80,10 @@ int main() {
   }
 
   uint64_t HLo[N] = {0}, HOv[N] = {0};
-  hipMemcpy(HLo, DLo, sizeof(HLo), hipMemcpyDeviceToHost);
-  hipMemcpy(HOv, DOv, sizeof(HOv), hipMemcpyDeviceToHost);
-  hipFree(DLo);
-  hipFree(DOv);
+  CHECK(hipMemcpy(HLo, DLo, sizeof(HLo), hipMemcpyDeviceToHost));
+  CHECK(hipMemcpy(HOv, DOv, sizeof(HOv), hipMemcpyDeviceToHost));
+  CHECK(hipFree(DLo));
+  CHECK(hipFree(DOv));
 
   const uint64_t WantLo[N] = {42, UINT64_MAX - 1, 0, 0};
   const uint64_t WantOv[N] = {0, 1, 0, 1};


### PR DESCRIPTION
Four follow-ups from #1395 and #1474, one commit each.

`llvm_passes/HipLowerFPAtomicMinMax.cpp` was missing the `CHIP_COMBINED_PASS_PLUGIN` guard that the other thirteen passes wrap their standalone `llvmGetPassPluginInfo` in, so `libLLVMHipSpvPasses.so` shipped two `LLVM_ATTRIBUTE_WEAK` definitions of it. The linker resolves that by position instead of rejecting it, which means source order in `add_library` silently decided whether `hip-post-link-passes` was registered at all. That is what broke #1474 on its first push, where every `hipcc` call failed with `opt: unknown pass name 'hip-post-link-passes'` while the build itself stayed green. With the guard in place `HipPasses.cpp` is again the only definition, the list is fully alphabetical, and order stops mattering:

    $ nm -C build/.../LLVMHipPasses.dir/*.o | grep llvmGetPassPluginInfo
    before: HipLowerFPAtomicMinMax.cpp.o [W], HipPasses.cpp.o [W]
    after:  HipPasses.cpp.o [W]

A `PassPluginRegistersPipeline` ctest now runs `opt -load-pass-plugin` against the built plugin, so the next occurrence fails a test instead of every HIP compile. Verified it catches the real thing: with the old duplicate definition and an alphabetical list it fails, and passes once the guard is in.

The `HipLowerOverflowIntrinsics.cpp` header claimed i128 "is not portable across the SPIR-V consumers chipStar targets". 128-bit integers are outside the OpenCL SPIR-V environment altogether, which requires only `Int8`, `Int16` and `Int64`; `llvm-spirv` answers `InvalidBitWidth: Invalid bit width in input: 128` and the in-tree backend demands `SPV_ALTERA_arbitrary_precision_integers`, which IGC rejects as unknown. The header now says that and points at #1475.

`TestFix1391UmulWithOverflow` discarded the `hipError_t` from `hipMemset`, `hipMemcpy` and `hipFree`, which tripped `-Wunused-value` six times and let a failed transfer reach the comparison as a silent zero. Those are checked now.
