### PR TITLE
Do not hold DeviceVarMtx across module compilation

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1464,16 +1464,19 @@ chipstar::Module *chipstar::Device::getOrCreateModule(HostPtr Ptr) {
 
 /// Get compiled module for the source module 'SrcMod'.
 chipstar::Module *chipstar::Device::getOrCreateModule(const SPVModule &SrcMod) {
-  LOCK(DeviceVarMtx); // chipstar::Device::SrcModToCompiledMod_
-                      // chipstar::Device::HostPtrToCompiledMod_
-                      // chipstar::Device::DeviceVarLookup_
-
-  // Check if we have already created the module for the source.
-  if (SrcModToCompiledMod_.count(&SrcMod))
-    return SrcModToCompiledMod_[&SrcMod];
+  { // Check if we have already created the module for the source.
+    LOCK(DeviceVarMtx); // chipstar::Device::SrcModToCompiledMod_
+    if (SrcModToCompiledMod_.count(&SrcMod))
+      return SrcModToCompiledMod_[&SrcMod];
+  }
 
   logDebug("Compile module {}", static_cast<const void *>(&SrcMod));
 
+  // compile() runs with DeviceVarMtx released. It enters the backend compiler,
+  // which is free to block, throw, or terminate the process:
+  // SPIRV-LLVM-Translator calls exit() from inside clBuildProgram on a module
+  // it rejects, and the atexit path that runs then takes DeviceVarMtx again in
+  // deallocateDeviceVariables() on this same thread.
   auto start = std::chrono::high_resolution_clock::now();
   auto *Module = compile(SrcMod);
   auto end = std::chrono::high_resolution_clock::now();
@@ -1485,7 +1488,13 @@ chipstar::Module *chipstar::Device::getOrCreateModule(const SPVModule &SrcMod) {
     return nullptr;
   }
 
-  SrcModToCompiledMod_.insert(std::make_pair(&SrcMod, Module));
+  LOCK(DeviceVarMtx); // chipstar::Device::SrcModToCompiledMod_
+  // Every HIP entry point holds ApiMtx for the whole call, so compilation is
+  // single-entry per device and nothing can have inserted this source while
+  // DeviceVarMtx was released above.
+  auto Insertion = SrcModToCompiledMod_.insert(std::make_pair(&SrcMod, Module));
+  assert(Insertion.second && "ApiMtx should keep module compilation single-entry");
+  (void)Insertion; // Only read by the assert, which NDEBUG compiles away.
   return Module;
 }
 

--- a/tests/run_exit_during_module_build_test.cmake
+++ b/tests/run_exit_during_module_build_test.cmake
@@ -1,0 +1,46 @@
+# Driver for TestFix1393ExitDuringModuleBuild.
+#
+# Runs the test binary with the interposer preloaded and maps the three
+# possible outcomes onto a verdict:
+#
+#   the interposer never fired  -> nothing was exercised, skip
+#   the process did not exit    -> the #1393 deadlock, fail
+#   the process exited with the injected code -> pass
+#
+# The interposer prints its marker before calling exit(), so a deadlocked run
+# is distinguished from a skipped one by the marker being present while the
+# process still has to be killed on timeout.
+
+if(NOT CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
+  message("HIP_SKIP_THIS_TEST: LD_PRELOAD interposition is Linux only")
+  return()
+endif()
+
+set(LOG_FILE "${TEST_EXECUTABLE}_output.txt")
+
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -E env "LD_PRELOAD=${INTERPOSER}" ${TEST_EXECUTABLE}
+  OUTPUT_FILE "${LOG_FILE}"
+  ERROR_FILE "${LOG_FILE}"
+  TIMEOUT ${TEST_TIMEOUT}
+  RESULT_VARIABLE RESULT)
+
+file(READ "${LOG_FILE}" TEST_OUTPUT)
+message("${TEST_OUTPUT}")
+
+if(NOT TEST_OUTPUT MATCHES "interposer: exiting from inside")
+  message("HIP_SKIP_THIS_TEST: no module build ran with getOrCreateModule on "
+          "the stack, so the exit was never injected")
+  return()
+endif()
+
+if(RESULT STREQUAL "${EXPECTED_EXIT_CODE}")
+  message("PASS")
+  return()
+endif()
+
+message(FATAL_ERROR
+  "exit() was called during the module build but the process never "
+  "terminated (result: ${RESULT}). Device::getOrCreateModule is holding "
+  "DeviceVarMtx across compile(), so the atexit path re-locks it on the same "
+  "thread in Device::deallocateDeviceVariables. See issue #1393.")

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -68,6 +68,7 @@ endfunction()
 set(RUNTIME_TESTS_MANUAL
   TestBufferDevAddr.hip           # guarded on OpenCL_LIBRARY
   TestEnvVars.hip                 # driven by ../run_testenvvars.sh, not by ctest
+  TestFix1393ExitDuringModuleBuild.hip # run under an interposer by a driver script
   TestFixLlvmUsedAddrspace.hip    # not registered as a test
   TestModuleCacheInvalidation.hip # run several times through a driver script
   TestStreamWaitEventOrdering.cpp # not registered as a test
@@ -237,3 +238,39 @@ add_test(NAME TestModuleCacheInvalidation
     -P ${CMAKE_SOURCE_DIR}/tests/run_module_cache_invalidation_test.cmake)
 set_tests_properties(TestModuleCacheInvalidation PROPERTIES
   SKIP_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST")
+
+# A device compiler that terminates the process during a module build must not
+# leave the runtime deadlocked in its own exit handler (#1393). The exit is
+# injected by an LD_PRELOAD interposer rather than by feeding a backend a module
+# it rejects, so the test does not move with backend compiler behaviour, and a
+# driver script owns the verdict because the expected outcome is a specific
+# non-zero exit status.
+if(UNIX AND NOT APPLE)
+  set_source_files_properties(TestFix1393ExitDuringModuleBuild.hip
+    PROPERTIES LANGUAGE CXX)
+  add_executable(TestFix1393ExitDuringModuleBuild
+    TestFix1393ExitDuringModuleBuild.hip)
+  set_target_properties(TestFix1393ExitDuringModuleBuild PROPERTIES
+    CXX_STANDARD_REQUIRED ON)
+  target_link_libraries(TestFix1393ExitDuringModuleBuild CHIP deviceInternal)
+  target_include_directories(TestFix1393ExitDuringModuleBuild
+    PRIVATE $<TARGET_PROPERTY:CHIP,INCLUDE_DIRECTORIES>)
+
+  add_library(ExitDuringModuleBuildInterposer MODULE
+    ExitDuringModuleBuildInterposer.cpp)
+  target_link_libraries(ExitDuringModuleBuildInterposer ${CMAKE_DL_LIBS})
+  # backtrace_symbols() names a frame only if its symbol is in a dynamic symbol
+  # table, which is how the interposer recognises getOrCreateModule.
+  target_link_options(ExitDuringModuleBuildInterposer PRIVATE -rdynamic)
+
+  add_test(NAME TestFix1393ExitDuringModuleBuild
+    COMMAND ${CMAKE_COMMAND}
+      -DTEST_EXECUTABLE=$<TARGET_FILE:TestFix1393ExitDuringModuleBuild>
+      -DINTERPOSER=$<TARGET_FILE:ExitDuringModuleBuildInterposer>
+      -DEXPECTED_EXIT_CODE=93
+      -DTEST_TIMEOUT=60
+      -P ${CMAKE_SOURCE_DIR}/tests/run_exit_during_module_build_test.cmake)
+  set_tests_properties(TestFix1393ExitDuringModuleBuild PROPERTIES
+    SKIP_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST"
+    TIMEOUT 120)
+endif()

--- a/tests/runtime/ExitDuringModuleBuildInterposer.cpp
+++ b/tests/runtime/ExitDuringModuleBuildInterposer.cpp
@@ -1,0 +1,103 @@
+// LD_PRELOAD interposer for TestFix1393ExitDuringModuleBuild.
+//
+// Terminates the process from inside a backend module-build call, but only
+// while chipStar's Device::getOrCreateModule is on the stack, which is the
+// window in which Device::DeviceVarMtx is held. That models
+// SPIRV-LLVM-Translator's SPIRVErrorLog::checkError(), which defaults to
+// SPIRVDbgErrorHandlingKinds::Exit and so calls std::exit() out of
+// clBuildProgram on a module it rejects.
+//
+// Every entry point chains to the real implementation when the marker frame is
+// absent, so preloading this library is inert outside the one call it targets.
+// The chaining prototypes take plain integers and pointers instead of the
+// OpenCL and Level Zero types: each argument is in the same ABI class as the
+// real one, and using them keeps the interposer buildable whether or not
+// either backend's headers are present.
+
+#include <dlfcn.h>
+#include <execinfo.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+
+// Kept in sync with EXPECTED_EXIT_CODE in
+// tests/run_exit_during_module_build_test.cmake.
+constexpr int InjectedExitCode = 93;
+
+bool lockHolderOnStack() {
+  void *Frames[64];
+  int NumFrames = backtrace(Frames, 64);
+  char **Symbols = backtrace_symbols(Frames, NumFrames);
+  if (!Symbols)
+    return false;
+
+  bool Found = false;
+  for (int I = 0; I < NumFrames; ++I)
+    if (std::strstr(Symbols[I], "getOrCreateModule"))
+      Found = true;
+
+  std::free(Symbols);
+  return Found;
+}
+
+void exitIfHoldingLock(const char *Api) {
+  if (!lockHolderOnStack()) {
+    std::fprintf(stderr, "interposer: %s reached without getOrCreateModule\n",
+                 Api);
+    std::fflush(stderr);
+    return;
+  }
+  std::fprintf(stderr, "interposer: exiting from inside %s\n", Api);
+  std::fflush(stderr);
+  std::exit(InjectedExitCode);
+}
+
+template <typename FnTy> FnTy realSymbol(const char *Name) {
+  void *Symbol = dlsym(RTLD_NEXT, Name);
+  if (!Symbol) {
+    // Reached only if something calls an interposed entry point that the real
+    // runtime does not provide. Say so instead of jumping through a null.
+    std::fprintf(stderr, "interposer: no real %s to chain to\n", Name);
+    std::fflush(stderr);
+    std::abort();
+  }
+  return reinterpret_cast<FnTy>(Symbol);
+}
+
+} // namespace
+
+extern "C" {
+
+int clBuildProgram(void *Program, unsigned NumDevices, const void *DeviceList,
+                   const char *Options, void *Notify, void *UserData) {
+  exitIfHoldingLock("clBuildProgram");
+  using FnTy = int (*)(void *, unsigned, const void *, const char *, void *,
+                       void *);
+  return realSymbol<FnTy>("clBuildProgram")(Program, NumDevices, DeviceList,
+                                            Options, Notify, UserData);
+}
+
+int clCompileProgram(void *Program, unsigned NumDevices, const void *DeviceList,
+                     const char *Options, unsigned NumInputHeaders,
+                     const void *InputHeaders, const char **HeaderIncludeNames,
+                     void *Notify, void *UserData) {
+  exitIfHoldingLock("clCompileProgram");
+  using FnTy = int (*)(void *, unsigned, const void *, const char *, unsigned,
+                       const void *, const char **, void *, void *);
+  return realSymbol<FnTy>("clCompileProgram")(
+      Program, NumDevices, DeviceList, Options, NumInputHeaders, InputHeaders,
+      HeaderIncludeNames, Notify, UserData);
+}
+
+int zeModuleCreate(void *Context, void *Device, const void *Desc, void *Module,
+                   void *BuildLog) {
+  exitIfHoldingLock("zeModuleCreate");
+  using FnTy = int (*)(void *, void *, const void *, void *, void *);
+  return realSymbol<FnTy>("zeModuleCreate")(Context, Device, Desc, Module,
+                                            BuildLog);
+}
+
+} // extern "C"

--- a/tests/runtime/TestFix1393ExitDuringModuleBuild.hip
+++ b/tests/runtime/TestFix1393ExitDuringModuleBuild.hip
@@ -1,0 +1,35 @@
+// Reproduces #1393: the device compiler terminating the process during a
+// module build leaves chipStar deadlocked in its own exit handler instead of
+// exiting.
+//
+// The first launch of a kernel is what compiles its module, so reaching the
+// launch below is all this program has to do. The process exit is injected
+// from inside the backend build call by an LD_PRELOAD interposer, which keeps
+// the test independent of whether a given backend compiler happens to reject a
+// module today. tests/run_exit_during_module_build_test.cmake drives the run
+// and owns the pass/fail decision.
+
+#include <hip/hip_runtime.h>
+
+#include <cstdio>
+
+__global__ void touch(int *Out) { Out[threadIdx.x] = threadIdx.x; }
+
+int main() {
+  int *Buf = nullptr;
+  if (hipMalloc(&Buf, 64 * sizeof(int)) != hipSuccess) {
+    std::printf("hipMalloc failed\n");
+    return 1;
+  }
+
+  std::printf("launching\n");
+  std::fflush(stdout);
+
+  hipLaunchKernelGGL(touch, dim3(1), dim3(64), 0, 0, Buf);
+  (void)hipDeviceSynchronize();
+  (void)hipFree(Buf);
+
+  std::printf("launch returned\n");
+  std::fflush(stdout);
+  return 0;
+}


### PR DESCRIPTION
getOrCreateModule() held Device::DeviceVarMtx for its whole body, including compile(), which enters the backend compiler. A compiler that terminates the process from there sends the atexit chain back through the same lock on the same thread:

```
#0  deallocateDeviceVariables        src/CHIPBackend.cc:1314   inner LOCK, blocks forever
#1  CHIPUninitializeCallOnce ()      src/CHIPDriver.cc:244
#5  CHIPUninitialize ()              src/CHIPDriver.cc:254
#6  __hipUnregisterFatBinary (...)   src/CHIPBindings.cc:6631
#7  __hip_module_dtor ()
#8  __run_exit_handlers (status=15)  ./stdlib/exit.c:108
#9  __GI_exit (status=...)           ./stdlib/exit.c:138
#10 clBuildProgram (...)                                       exit() from inside the build
#13 CHIPModuleOpenCL::compile (...)  src/backend/OpenCL/CHIPBackendOpenCL.cc:1219
#15 getOrCreateModule (...)          src/CHIPBackend.cc:1477   outer LOCK, still held
```

SPIRV-LLVM-Translator reaches this: `SPIRVErrorLog::checkError()` defaults to `SPIRVDbgErrorHandlingKinds::Exit`, so a rejected module calls `exit()` from inside `clBuildProgram`. The visible symptom is a ctest timeout on a test whose log ends at an `InvalidModule` line and never prints its own failure message, which reads like a hung kernel or a slow JIT rather than a build rejection.

`std::mutex::lock()` also expects the calling thread not to already own the mutex, so the old code was undefined behaviour, not only a hang.

The map lookup and the insertion each take the lock and compile() runs between them with the lock released. The insertion tolerates a module another thread compiled meanwhile, which no current path can produce because every HIP entry point serializes on `ApiMtx` first and the only thread chipStar spawns itself is `EventMonitor`, which never compiles.

Fixes #1393

Test: `tests/runtime/TestFix1393ExitDuringModuleBuild`. An `LD_PRELOAD` interposer injects the exit from inside the backend build call, but only while `getOrCreateModule` is on the stack. It hooks `clBuildProgram`, `clCompileProgram` and `zeModuleCreate`, so both backends and the rtdevlib compile+link path are covered, and it still fires on a warm module cache because the cache-hit paths call the same entry points. A driver script maps the outcomes: no injected exit skips, a process that has to be killed fails, and the injected exit status passes. On main the test hits the 60 s driver timeout, with this change it exits in 0.10 s.

Alternative considered: #1389 makes DeviceVarMtx recursive. Both resolve the hang and both exit cleanly. This one keeps the mutex non-recursive, so re-entering any of the 15 DeviceVarMtx critical sections stays a detectable error rather than a silent one, and it takes the lock off a call into third party code that can block, throw, or end the process.

Local verification ran on the Intel CPU OpenCL runtime because this machine's GPU is wedged. `TestModuleCacheInvalidation` fails on that runtime, verified identical on main, so it is unrelated to this change.
