### PR TITLE
Report device-side assertion messages on stderr

### DIFF
--- a/include/hip/spirv_hip.hh
+++ b/include/hip/spirv_hip.hh
@@ -53,6 +53,21 @@ extern "C" {
 // abort request.
 __attribute__((weak)) __device__ int32_t __chipspv_abort_called;
  
+// The message of a failed device-side assertion, in the format
+// _cl_assert_fail_print prints it. Device printf only reaches stdout, so
+// __assert_fail also records the message here for the runtime to copy to the
+// host and write to stderr when it services the abort request
+// (handleAbortRequest); stderr is where ROCm reports it and where gtest death
+// tests look for it. Claimed is taken atomically by the first work-item that
+// records a message so concurrent failures do not interleave in Text. The
+// runtime treats the variable as raw bytes and reads Text at offset
+// sizeof(int) (ChipDeviceAbortMsgTextOffset in src/common.hh).
+struct __chipspv_abort_msg_t {
+  int Claimed;
+  char Text[508];
+};
+__attribute__((weak)) __device__ __chipspv_abort_msg_t __chipspv_abort_msg;
+
 // Global pointer for the device heap for device-side malloc/free.
 // Gated behind CHIP_ENABLE_DEVICE_PROGRAM_SCOPE_GLOBALS: this is a program-scope
 // global which some OpenCL drivers (e.g. rusticl/radeonsi) cannot consume
@@ -160,6 +175,46 @@ extern "C" __device__ int printf(const char *fmt, ...)
     __attribute__((format(printf, 1, 2)));
 extern "C" __device__ void abort();
 
+static inline __device__ void __chipspv_abort_msg_append(unsigned &Pos,
+                                                         const char *S) {
+  while (*S && Pos < sizeof(__chipspv_abort_msg.Text) - 1)
+    __chipspv_abort_msg.Text[Pos++] = *S++;
+}
+
+// Records a failed assertion in __chipspv_abort_msg for the runtime to report
+// on stderr. Only the first work-item to claim the buffer writes it; the text
+// is bounded by the buffer and NUL-terminated.
+static inline __device__ void
+__chipspv_record_assert_msg(const char *file, unsigned int line,
+                            const char *function, const char *assertion) {
+  if (atomicCAS(&__chipspv_abort_msg.Claimed, 0, 1) != 0)
+    return;
+
+  // Decimal digits of the line number, least significant first.
+  char Digits[10];
+  unsigned NumDigits = 0;
+  do {
+    Digits[NumDigits++] = '0' + line % 10;
+    line /= 10;
+  } while (line);
+  char LineStr[11];
+  unsigned I = 0;
+  while (NumDigits)
+    LineStr[I++] = Digits[--NumDigits];
+  LineStr[I] = 0;
+
+  unsigned Pos = 0;
+  __chipspv_abort_msg_append(Pos, file);
+  __chipspv_abort_msg_append(Pos, ":");
+  __chipspv_abort_msg_append(Pos, LineStr);
+  __chipspv_abort_msg_append(Pos, ": ");
+  __chipspv_abort_msg_append(Pos, function);
+  __chipspv_abort_msg_append(Pos, ": Device-side assertion `");
+  __chipspv_abort_msg_append(Pos, assertion);
+  __chipspv_abort_msg_append(Pos, "' failed.");
+  __chipspv_abort_msg.Text[Pos] = 0;
+}
+
 // The assert part mimiced from amd_device_functions.h of amdhip.  We
 // assume assert.h defines assert such that it calls __assert_fail
 // when it fails. Some users forward declares the __assert_fail, with
@@ -192,6 +247,7 @@ __device__ __attribute__((noinline)) __attribute__((weak)) void
 __assert_rtn(const char *function, const char *file, int line,
              const char *assertion) {
   _cl_assert_fail_print(file, line, function, assertion);
+  __chipspv_record_assert_msg(file, line, function, assertion);
   abort();
 }
 #else  // defined(_WIN32) || defined(_WIN64) || defined(__APPLE__)
@@ -199,6 +255,7 @@ __device__ __attribute__((noinline)) __attribute__((weak)) void
 __assert_fail(const char *assertion, const char *file, unsigned int line,
               const char *function) {
   _cl_assert_fail_print(file, line, function, assertion);
+  __chipspv_record_assert_msg(file, line, function, assertion);
   abort();
 }
 #endif // defined(_WIN32) || defined(_WIN64) || defined(__APPLE__)

--- a/llvm_passes/HipAbort.cpp
+++ b/llvm_passes/HipAbort.cpp
@@ -323,19 +323,32 @@ void HipAbortPass::processFunctions(Module &M) {
   }
 }
 
-/// Erase a variable used for signaling abort event. Return true if it was found
-/// and removed.
+/// Erase the variable holding the message of a failed device-side assertion.
+/// Return true if it was found and removed.
+static bool eraseAbortMsg(Module &M) {
+  GlobalVariable *AbortMsg = M.getGlobalVariable(ChipDeviceAbortMsgName);
+  if (AbortMsg == nullptr)
+    return false;
+  AbortMsg->replaceAllUsesWith(Constant::getNullValue(AbortMsg->getType()));
+  AbortMsg->eraseFromParent();
+  return true;
+}
+
+/// Erase a variable used for signaling abort event, and the assertion message
+/// variable which is only read when the abort flag is set. Return true if
+/// either was found and removed.
 static bool eraseAbortFlag(Module &M) {
   // Mark modules that do not call abort by just the global flag variable.
   // Ugly, but should allow avoiding the kernel call to check the global
   // variable.
+  bool Erased = eraseAbortMsg(M);
   GlobalVariable *AbortFlag = M.getGlobalVariable(ChipDeviceAbortFlagName);
   if (AbortFlag != nullptr) {
     AbortFlag->replaceAllUsesWith(Constant::getNullValue(AbortFlag->getType()));
     AbortFlag->eraseFromParent();
     return true;
   }
-  return false;
+  return Erased;
 }
 
 PreservedAnalyses HipAbortPass::run(Module &Mod, ModuleAnalysisManager &AM) {
@@ -349,12 +362,19 @@ PreservedAnalyses HipAbortPass::run(Module &Mod, ModuleAnalysisManager &AM) {
   if (AssertFailF && AssertFailF->hasNUses(0))
     AssertFailF->eraseFromParent();
 
+  // __assert_fail (__assert_rtn on macOS) is the only writer of the assertion
+  // message variable. Without a writer the variable would only add a
+  // program-scope global to the module, so drop it.
+  bool ErasedAbortMsg = false;
+  if (!Mod.getFunction("__assert_fail") && !Mod.getFunction("__assert_rtn"))
+    ErasedAbortMsg = eraseAbortMsg(Mod);
+
   // The abort calls are made to undefined abort decl thus should not get
   // inlined.
   auto *AbortF = Mod.getFunction("__chipspv_abort");
   if (!AbortF) {
-    return eraseAbortFlag(Mod) ? PreservedAnalyses::none()
-                               : PreservedAnalyses::all();
+    return (eraseAbortFlag(Mod) || ErasedAbortMsg) ? PreservedAnalyses::none()
+                                                   : PreservedAnalyses::all();
   }
   if (AbortF->hasNUses(0)) {
     AbortF->eraseFromParent();

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -1093,6 +1093,25 @@ static void handleAbortRequest(chipstar::Queue &Q, chipstar::Module &M) {
   if (!AbortFlag)
     return; // Abort was not called.
 
+  // A failed device-side assertion records its message in a device variable
+  // (device printf only reaches stdout). Report it on stderr, where ROCm
+  // reports it and where gtest death tests look for it. The variable is absent
+  // when HipAbort pass found no assertion in the module.
+  chipstar::DeviceVar *MsgVar = M.getGlobalVar(ChipDeviceAbortMsgName);
+  std::vector<char> Msg;
+  if (MsgVar) {
+    Msg.resize(MsgVar->getSize() + 1, 0); // +1: always NUL-terminated.
+    Err = Q.memCopy(Msg.data(), MsgVar->getDevAddr(), MsgVar->getSize(),
+                    hipMemcpyDeviceToHost);
+    if (Err != hipSuccess)
+      CHIPERR_LOG_AND_THROW("Unexpected mem copy failure.", hipErrorTbd);
+    const char *Text = Msg.data() + ChipDeviceAbortMsgTextOffset;
+    if (*Text) {
+      fprintf(stderr, "%s\n", Text);
+      fflush(stderr);
+    }
+  }
+
   // Disable host-side abort behavior for making the unit testing of abort
   // cases easier.
   if (!getenv("CHIP_HOST_IGNORES_DEVICE_ABORT")) {
@@ -1101,14 +1120,21 @@ static void handleAbortRequest(chipstar::Queue &Q, chipstar::Module &M) {
     abort();
   }
 
-  // Just act like nothing happened. Reset the flag so we let there be more
-  // aborts.
+  // Just act like nothing happened. Reset the flag and the message so we let
+  // there be more aborts.
   AbortFlag = 0;
   Err = Q.memCopy(Var->getDevAddr(), &AbortFlag, sizeof(int32_t),
                   hipMemcpyHostToDevice);
   if (Err != hipSuccess)
     // Device->host copy succeeded. What went wrong with host->device copy?
     CHIPERR_LOG_AND_THROW("Unexpected mem copy failure.", hipErrorTbd);
+  if (MsgVar) {
+    std::fill(Msg.begin(), Msg.end(), 0);
+    Err = Q.memCopy(MsgVar->getDevAddr(), Msg.data(), MsgVar->getSize(),
+                    hipMemcpyHostToDevice);
+    if (Err != hipSuccess)
+      CHIPERR_LOG_AND_THROW("Unexpected mem copy failure.", hipErrorTbd);
+  }
 
   printf("[ABORT IGNORED]\n");
 }

--- a/src/common.hh
+++ b/src/common.hh
@@ -103,6 +103,13 @@ constexpr char ChipGVarArgPrefix[] = "__chip_gvararg_";
 /// the abort() function was called by a kernel.
 constexpr char ChipDeviceAbortFlagName[] = "__chipspv_abort_called";
 
+/// The name of a global variable which holds the message of a failed
+/// device-side assertion (__chipspv_abort_msg in include/hip/spirv_hip.hh),
+/// and the byte offset of its NUL-terminated text: the bytes before the text
+/// hold the claim word with which the device picks a single writer.
+constexpr char ChipDeviceAbortMsgName[] = "__chipspv_abort_msg";
+constexpr size_t ChipDeviceAbortMsgTextOffset = sizeof(int);
+
 /// The name of a global variable which is the device heap.
 constexpr char ChipDeviceHeapName[] = "__chipspv_device_heap";
 

--- a/tests/run_device_abort_stderr_test.cmake
+++ b/tests/run_device_abort_stderr_test.cmake
@@ -1,0 +1,54 @@
+# Driver for TestDeviceAbortStderr.
+#
+# Runs the test binary with stdout and stderr captured separately and maps the
+# outcome onto a verdict:
+#
+#   the process did not die with SIGABRT      -> the abort was not serviced, fail
+#   the assertion message is not on stderr    -> the bug, fail
+#   SIGABRT and the message is on stderr      -> pass
+#
+# stderr is what gtest death tests match against (GetCapturedStderr), so the
+# message being on stdout only is exactly the failure this test guards.
+#
+# Invoked as:
+#   cmake -DTEST_EXECUTABLE=<path> -DTEST_TIMEOUT=<seconds>
+#         -P run_device_abort_stderr_test.cmake
+
+if(NOT TEST_EXECUTABLE)
+  message(FATAL_ERROR "TEST_EXECUTABLE not set")
+endif()
+
+set(EXPECTED_MESSAGE
+  ":0: : Device-side assertion `Meurs, pourriture communiste !' failed.")
+
+execute_process(
+  COMMAND ${TEST_EXECUTABLE}
+  OUTPUT_VARIABLE RUN_OUT
+  ERROR_VARIABLE RUN_ERR
+  TIMEOUT ${TEST_TIMEOUT}
+  RESULT_VARIABLE RESULT)
+
+message("result: ${RESULT}")
+message("--- stdout ---\n${RUN_OUT}--- stderr ---\n${RUN_ERR}--------------")
+
+# CMake reports a signal death as a description string rather than a number.
+if(NOT RESULT MATCHES "Subprocess aborted|SIGABRT")
+  message(FATAL_ERROR
+    "expected the process to die with SIGABRT from the device-side abort "
+    "(result: ${RESULT})")
+endif()
+
+string(FIND "${RUN_ERR}" "${EXPECTED_MESSAGE}" MESSAGE_POS)
+if(MESSAGE_POS EQUAL -1)
+  string(FIND "${RUN_OUT}" "${EXPECTED_MESSAGE}" STDOUT_POS)
+  if(STDOUT_POS EQUAL -1)
+    message(FATAL_ERROR
+      "the assertion message was not reported on either stream")
+  endif()
+  message(FATAL_ERROR
+    "the assertion message was reported on stdout only; gtest death tests "
+    "(for example Kokkos hip_DeathTest.abort_from_device) match it against "
+    "stderr, where ROCm reports it")
+endif()
+
+message("PASS")

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -67,6 +67,7 @@ endfunction()
 # here and registered by hand below instead.
 set(RUNTIME_TESTS_MANUAL
   TestBufferDevAddr.hip           # guarded on OpenCL_LIBRARY
+  TestDeviceAbortStderr.hip       # SIGABRT death + stderr checked by a driver script
   TestEnvVars.hip                 # driven by ../run_testenvvars.sh, not by ctest
   TestFixLlvmUsedAddrspace.hip    # not registered as a test
   TestModuleCacheInvalidation.hip # run several times through a driver script
@@ -237,3 +238,21 @@ add_test(NAME TestModuleCacheInvalidation
     -P ${CMAKE_SOURCE_DIR}/tests/run_module_cache_invalidation_test.cmake)
 set_tests_properties(TestModuleCacheInvalidation PROPERTIES
   SKIP_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST")
+
+# A failed device-side assertion must report its message on stderr, where ROCm
+# writes it and where gtest death tests (Kokkos hip_DeathTest.abort_from_device)
+# look for it; device printf only reaches stdout. The expected outcome is a
+# SIGABRT death plus specific stderr content, which add_hip_runtime_test cannot
+# express, so a driver script owns the verdict.
+set_source_files_properties(TestDeviceAbortStderr.hip PROPERTIES LANGUAGE CXX)
+add_executable(TestDeviceAbortStderr TestDeviceAbortStderr.hip)
+set_target_properties(TestDeviceAbortStderr PROPERTIES CXX_STANDARD_REQUIRED ON)
+target_link_libraries(TestDeviceAbortStderr CHIP deviceInternal)
+target_include_directories(TestDeviceAbortStderr
+  PRIVATE $<TARGET_PROPERTY:CHIP,INCLUDE_DIRECTORIES>)
+add_test(NAME TestDeviceAbortStderr
+  COMMAND ${CMAKE_COMMAND}
+    -DTEST_EXECUTABLE=$<TARGET_FILE:TestDeviceAbortStderr>
+    -DTEST_TIMEOUT=60
+    -P ${CMAKE_SOURCE_DIR}/tests/run_device_abort_stderr_test.cmake)
+set_tests_properties(TestDeviceAbortStderr PROPERTIES TIMEOUT 120)

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -244,15 +244,25 @@ set_tests_properties(TestModuleCacheInvalidation PROPERTIES
 # look for it; device printf only reaches stdout. The expected outcome is a
 # SIGABRT death plus specific stderr content, which add_hip_runtime_test cannot
 # express, so a driver script owns the verdict.
-set_source_files_properties(TestDeviceAbortStderr.hip PROPERTIES LANGUAGE CXX)
-add_executable(TestDeviceAbortStderr TestDeviceAbortStderr.hip)
-set_target_properties(TestDeviceAbortStderr PROPERTIES CXX_STANDARD_REQUIRED ON)
-target_link_libraries(TestDeviceAbortStderr CHIP deviceInternal)
-target_include_directories(TestDeviceAbortStderr
-  PRIVATE $<TARGET_PROPERTY:CHIP,INCLUDE_DIRECTORIES>)
-add_test(NAME TestDeviceAbortStderr
-  COMMAND ${CMAKE_COMMAND}
-    -DTEST_EXECUTABLE=$<TARGET_FILE:TestDeviceAbortStderr>
-    -DTEST_TIMEOUT=60
-    -P ${CMAKE_SOURCE_DIR}/tests/run_device_abort_stderr_test.cmake)
-set_tests_properties(TestDeviceAbortStderr PROPERTIES TIMEOUT 120)
+#
+# Registered only with program-scope globals enabled: __assert_fail is a weak
+# noinline device function, so the abort flag it sets is loaded outside any
+# kernel and the globals-as-kernel-args lowering (HipGlobalVariables.cpp,
+# CHIP_ENABLE_DEVICE_PROGRAM_SCOPE_GLOBALS=OFF) leaves it a program-scope
+# global with an initializer, which rusticl/Mesa rejects at spirv_to_nir
+# ("Initializer for CrossWorkgroup variable not yet supported"). Any device
+# abort reached through a non-inlined function fails the same way there.
+if(CHIP_ENABLE_DEVICE_PROGRAM_SCOPE_GLOBALS)
+  set_source_files_properties(TestDeviceAbortStderr.hip PROPERTIES LANGUAGE CXX)
+  add_executable(TestDeviceAbortStderr TestDeviceAbortStderr.hip)
+  set_target_properties(TestDeviceAbortStderr PROPERTIES CXX_STANDARD_REQUIRED ON)
+  target_link_libraries(TestDeviceAbortStderr CHIP deviceInternal)
+  target_include_directories(TestDeviceAbortStderr
+    PRIVATE $<TARGET_PROPERTY:CHIP,INCLUDE_DIRECTORIES>)
+  add_test(NAME TestDeviceAbortStderr
+    COMMAND ${CMAKE_COMMAND}
+      -DTEST_EXECUTABLE=$<TARGET_FILE:TestDeviceAbortStderr>
+      -DTEST_TIMEOUT=60
+      -P ${CMAKE_SOURCE_DIR}/tests/run_device_abort_stderr_test.cmake)
+  set_tests_properties(TestDeviceAbortStderr PROPERTIES TIMEOUT 120)
+endif()

--- a/tests/runtime/TestDeviceAbortStderr.hip
+++ b/tests/runtime/TestDeviceAbortStderr.hip
@@ -1,0 +1,32 @@
+// Reproduces: the message of a failed device-side assertion reaches the host
+// on stdout only, while ROCm reports it on stderr. gtest death tests match
+// their regex against captured stderr, so a Kokkos death test that aborts on
+// the device (hip_DeathTest.abort_from_device and friends) fails with
+// "died but not with expected error" even though the process did die with
+// SIGABRT and the message was printed.
+//
+// The kernel fails an assertion the way Kokkos::abort does on the device
+// (Kokkos_HIP_Abort.hpp: __assert_fail(msg, "", 0, "")). The runtime services
+// the abort after the launch and terminates the process with SIGABRT.
+// tests/run_device_abort_stderr_test.cmake runs this binary with stdout and
+// stderr captured separately and owns the verdict: the process must die with
+// SIGABRT and the assertion message must be on stderr.
+
+#include <hip/hip_runtime.h>
+
+#include <cstdio>
+#include <cstdlib>
+
+__global__ void assertOnDevice() {
+  __assert_fail("Meurs, pourriture communiste !", "", 0, "");
+}
+
+int main() {
+  unsetenv("CHIP_HOST_IGNORES_DEVICE_ABORT"); // Force abort behaviour.
+  assertOnDevice<<<1, 1>>>();
+  (void)hipDeviceSynchronize();
+  // Control must not reach here: the runtime aborts the process when it
+  // observes the device-side abort request.
+  std::printf("FAIL: the host survived a device-side abort\n");
+  return 1;
+}

--- a/tests/runtime/TestDeviceAbortStderr.hip
+++ b/tests/runtime/TestDeviceAbortStderr.hip
@@ -18,7 +18,13 @@
 #include <cstdlib>
 
 __global__ void assertOnDevice() {
+#if defined(__APPLE__)
+  // macOS assert() expands to __assert_rtn(function, file, line, assertion);
+  // spirv_hip.hh defines that instead of __assert_fail there.
+  __assert_rtn("", "", 0, "Meurs, pourriture communiste !");
+#else
   __assert_fail("Meurs, pourriture communiste !", "", 0, "");
+#endif
 }
 
 int main() {


### PR DESCRIPTION
A failed device-side assertion prints its message through device printf, which the OpenCL and Level Zero runtimes deliver to stdout. ROCm reports it on stderr and gtest death tests match their expected-error regex against stderr only, so Kokkos death tests that abort on the device (`hip_DeathTest.abort_from_device` and friends) failed on Aurora PVC with "died but not with expected error" although the process did die with SIGABRT.

`__assert_fail` now also records the formatted message in a weak device variable `__chipspv_abort_msg` next to the abort flag (first work-item wins via atomicCAS), and `handleAbortRequest` copies it to the host and writes it to stderr before aborting. `HipAbort` erases the variable when no kernel can abort or when the module has no `__assert_fail` writer, so modules that never assert do not gain a program-scope global. `TestDeviceAbortStderr` runs a device assert with stdout and stderr captured separately and passes only when the process died with SIGABRT and the message is on stderr.

Fixes #1487
