### PR TITLE
llvm_passes: lower 8 and 16 bit atomics onto their containing 32 bit word

### DIFF
--- a/llvm_passes/CMakeLists.txt
+++ b/llvm_passes/CMakeLists.txt
@@ -119,6 +119,7 @@ add_library(LLVMHipPasses MODULE
     HipLowerMemset.cpp
     HipLowerOverflowIntrinsics.cpp
     HipLowerRoundIntrinsics.cpp
+    HipLowerSubwordAtomics.cpp
     HipLowerSwitch.cpp
     HipLowerZeroLengthArrays.cpp
     HipPasses.cpp

--- a/llvm_passes/HipLowerSubwordAtomics.cpp
+++ b/llvm_passes/HipLowerSubwordAtomics.cpp
@@ -1,0 +1,456 @@
+//===- HipLowerSubwordAtomics.cpp -----------------------------------------===//
+//
+// Part of the chipStar Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Clang lowers __hip_atomic_load / store / exchange / fetch_* /
+// compare_exchange on char and short (and the atomic builtins on half and
+// bfloat16) to `load atomic i8`, `store atomic i16`, `atomicrmw ... i8` and
+// `cmpxchg i16`. Both SPIR-V producers pass those through as OpAtomicLoad,
+// OpAtomicStore, OpAtomicIAdd, OpAtomicCompareExchange ... on OpTypeInt 8 / 16,
+// and OpenCL SPIR-V consumers only implement 32 and 64 bit atomics: IGC fails
+// the module build with
+//
+//   error: undefined reference to `_Z18__spirv_AtomicLoadPU3AS4cii'
+//   error: backend compiler failed build.
+//
+// and the Intel CPU runtime with "JIT session error: Symbols not found:
+// [ _Z20atomic_load_explicitPU3AS1VU7_Atomicc12memory_order12memory_scope ...".
+// Either failure takes every kernel in the module down with it.
+//
+// Do what LLVM's AtomicExpand does for targets without narrow atomics: operate
+// on the aligned 32 bit word that contains the value and touch only its lane.
+//
+//   load     -> 32 bit atomic load, shift, truncate
+//   store    -> cmpxchg loop that replaces the lane and keeps the other bytes
+//   atomicrmw-> cmpxchg loop that applies the operation to the lane only
+//   cmpxchg  -> 32 bit cmpxchg with the expected and new values masked into
+//               the current word, retried while only the other lanes changed
+//
+// Every generated atomic keeps the original ordering and syncscope; the loops'
+// initial read is a monotonic atomic load in the same scope. Values are
+// assumed to be naturally aligned (which is what clang emits): a 16 bit value
+// at an odd address could straddle two words and is left untouched.
+//
+// (c) 2026 chipStar developers
+//===----------------------------------------------------------------------===//
+
+#include "HipLowerSubwordAtomics.h"
+
+#include <llvm/ADT/STLFunctionalExtras.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/DataLayout.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Intrinsics.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Passes/PassBuilder.h>
+#include <llvm/Support/ErrorHandling.h>
+#include <llvm/Support/raw_ostream.h>
+#include "PassPluginCompat.h"
+
+#define PASS_NAME "hip-lower-subword-atomics"
+#define DEBUG_TYPE PASS_NAME
+
+using namespace llvm;
+
+namespace {
+
+constexpr unsigned WordBytes = 4;
+
+/// Where the lane of one 8 or 16 bit value sits inside its containing word.
+struct LaneInWord {
+  Value *WordAddr = nullptr; // The aligned word, in the original address space.
+  Value *Shift = nullptr;    // i32: bit offset of the lane inside the word.
+  Value *Mask = nullptr;     // i32: ones over the lane.
+  Value *InvMask = nullptr;  // i32: ones over the other lanes.
+  Type *ValueTy = nullptr;   // i8, i16, half or bfloat.
+  Type *IntTy = nullptr;     // i8 or i16.
+};
+
+bool isSubwordType(Type *Ty) {
+  if (!Ty->isIntegerTy() && !Ty->isFloatingPointTy())
+    return false;
+  unsigned Bits = Ty->getPrimitiveSizeInBits();
+  return Bits == 8 || Bits == 16;
+}
+
+/// Emit the address of the word containing `Ptr` and the lane's position in
+/// it. The word address is formed with a GEP rather than ptrtoint / inttoptr so
+/// the pointer keeps its address space and provenance.
+LaneInWord locateLane(IRBuilder<> &B, Value *Ptr, Align PtrAlign,
+                      Type *ValueTy, const DataLayout &DL) {
+  LLVMContext &Ctx = B.getContext();
+  Type *Int32Ty = B.getInt32Ty();
+  LaneInWord L;
+  L.ValueTy = ValueTy;
+  unsigned ValueBits = ValueTy->getPrimitiveSizeInBits();
+  L.IntTy = Type::getIntNTy(Ctx, ValueBits);
+
+  if (PtrAlign >= Align(WordBytes)) {
+    L.WordAddr = Ptr;
+    L.Shift = ConstantInt::get(Int32Ty, 0);
+  } else {
+    Type *IdxTy = DL.getIndexType(Ptr->getType());
+    Value *AddrInt = B.CreatePtrToInt(Ptr, IdxTy);
+    Value *ByteInWord = B.CreateAnd(AddrInt, WordBytes - 1, "lane.byte");
+    L.WordAddr = B.CreateGEP(B.getInt8Ty(), Ptr, B.CreateNeg(ByteInWord),
+                             "word.addr");
+    if (!DL.isLittleEndian())
+      ByteInWord = B.CreateXor(ByteInWord, WordBytes - ValueBits / 8);
+    L.Shift = B.CreateTrunc(B.CreateShl(ByteInWord, 3), Int32Ty, "lane.shift");
+  }
+  L.Mask = B.CreateShl(ConstantInt::get(Int32Ty, (1u << ValueBits) - 1),
+                       L.Shift, "lane.mask");
+  L.InvMask = B.CreateNot(L.Mask, "lane.invmask");
+  return L;
+}
+
+/// The lane's value, as the original type, out of a whole word.
+Value *extractLane(IRBuilder<> &B, Value *Word, const LaneInWord &L) {
+  Value *Narrow = B.CreateTrunc(B.CreateLShr(Word, L.Shift), L.IntTy);
+  return B.CreateBitCast(Narrow, L.ValueTy);
+}
+
+/// `V` moved into the lane's position, with every other bit zero.
+Value *laneBits(IRBuilder<> &B, Value *V, const LaneInWord &L) {
+  Value *Int = B.CreateBitCast(V, L.IntTy);
+  return B.CreateShl(B.CreateZExt(Int, B.getInt32Ty()), L.Shift);
+}
+
+/// `Word` with its lane replaced by `V`.
+Value *insertLane(IRBuilder<> &B, Value *Word, Value *V, const LaneInWord &L) {
+  return B.CreateOr(B.CreateAnd(Word, L.InvMask), laneBits(B, V, L));
+}
+
+/// The value an atomicrmw leaves in memory, computed on the narrow type.
+Value *applyRMWOperation(IRBuilder<> &B, AtomicRMWInst::BinOp Op, Value *Old,
+                         Value *Val) {
+  switch (Op) {
+  case AtomicRMWInst::Add:
+    return B.CreateAdd(Old, Val);
+  case AtomicRMWInst::Sub:
+    return B.CreateSub(Old, Val);
+  case AtomicRMWInst::And:
+    return B.CreateAnd(Old, Val);
+  case AtomicRMWInst::Nand:
+    return B.CreateNot(B.CreateAnd(Old, Val));
+  case AtomicRMWInst::Or:
+    return B.CreateOr(Old, Val);
+  case AtomicRMWInst::Xor:
+    return B.CreateXor(Old, Val);
+  case AtomicRMWInst::Max:
+    return B.CreateSelect(B.CreateICmpSGT(Old, Val), Old, Val);
+  case AtomicRMWInst::Min:
+    return B.CreateSelect(B.CreateICmpSLE(Old, Val), Old, Val);
+  case AtomicRMWInst::UMax:
+    return B.CreateSelect(B.CreateICmpUGT(Old, Val), Old, Val);
+  case AtomicRMWInst::UMin:
+    return B.CreateSelect(B.CreateICmpULE(Old, Val), Old, Val);
+  case AtomicRMWInst::FAdd:
+    return B.CreateFAdd(Old, Val);
+  case AtomicRMWInst::FSub:
+    return B.CreateFSub(Old, Val);
+  case AtomicRMWInst::FMax:
+    return B.CreateBinaryIntrinsic(Intrinsic::maxnum, Old, Val);
+  case AtomicRMWInst::FMin:
+    return B.CreateBinaryIntrinsic(Intrinsic::minnum, Old, Val);
+#if LLVM_VERSION_MAJOR >= 16
+  case AtomicRMWInst::UIncWrap: {
+    Value *Inc = B.CreateAdd(Old, ConstantInt::get(Old->getType(), 1));
+    return B.CreateSelect(B.CreateICmpUGE(Old, Val),
+                          Constant::getNullValue(Old->getType()), Inc);
+  }
+  case AtomicRMWInst::UDecWrap: {
+    Value *Dec = B.CreateSub(Old, ConstantInt::get(Old->getType(), 1));
+    Value *Wrap = B.CreateOr(
+        B.CreateICmpEQ(Old, Constant::getNullValue(Old->getType())),
+        B.CreateICmpUGT(Old, Val));
+    return B.CreateSelect(Wrap, Val, Dec);
+  }
+#endif
+#if LLVM_VERSION_MAJOR >= 20
+  case AtomicRMWInst::USubCond:
+    return B.CreateSelect(B.CreateICmpUGE(Old, Val), B.CreateSub(Old, Val),
+                          Old);
+  case AtomicRMWInst::USubSat:
+    return B.CreateBinaryIntrinsic(Intrinsic::usub_sat, Old, Val);
+#endif
+#if LLVM_VERSION_MAJOR >= 21
+  case AtomicRMWInst::FMaximum:
+    return B.CreateBinaryIntrinsic(Intrinsic::maximum, Old, Val);
+  case AtomicRMWInst::FMinimum:
+    return B.CreateBinaryIntrinsic(Intrinsic::minimum, Old, Val);
+#endif
+  default:
+    report_fatal_error("HipLowerSubwordAtomics: unsupported atomicrmw "
+                       "operation on an 8 or 16 bit value");
+  }
+}
+
+AtomicOrdering cmpxchgSuccessOrdering(AtomicOrdering O) {
+  return O == AtomicOrdering::Unordered ? AtomicOrdering::Monotonic : O;
+}
+
+/// Turn the block holding `I` into
+///
+///   entry:  [lane setup already emitted]
+///           %word = load atomic i32, ptr %word.addr monotonic
+///           br %loop
+///   loop:   %loaded = phi [ %word, %entry ], [ %prev, %loop ]
+///           %new = Update(%loaded)
+///           %pair = cmpxchg ptr %word.addr, i32 %loaded, i32 %new
+///           %prev = extractvalue %pair, 0
+///           br (extractvalue %pair, 1), %end, %loop
+///   end:    I ...
+///
+/// and return %loaded, the word as it was right before the successful swap.
+/// The builder is left in front of `I`.
+Value *buildWordCmpXchgLoop(
+    Instruction *I, IRBuilder<> &B, const LaneInWord &L,
+    AtomicOrdering Ordering, SyncScope::ID SSID, bool IsVolatile,
+    function_ref<Value *(IRBuilder<> &, Value *)> Update) {
+  LLVMContext &Ctx = B.getContext();
+  Type *Int32Ty = B.getInt32Ty();
+  BasicBlock *EntryBB = I->getParent();
+  BasicBlock *EndBB =
+      EntryBB->splitBasicBlock(I->getIterator(), "subword.atomic.end");
+  BasicBlock *LoopBB = BasicBlock::Create(Ctx, "subword.atomic.loop",
+                                          EntryBB->getParent(), EndBB);
+
+  // splitBasicBlock left an unconditional branch to EndBB; retarget it.
+  EntryBB->getTerminator()->eraseFromParent();
+  B.SetInsertPoint(EntryBB);
+  LoadInst *Init =
+      B.CreateAlignedLoad(Int32Ty, L.WordAddr, Align(WordBytes), "word");
+  Init->setAtomic(AtomicOrdering::Monotonic, SSID);
+  Init->setVolatile(IsVolatile);
+  B.CreateBr(LoopBB);
+
+  B.SetInsertPoint(LoopBB);
+  PHINode *Loaded = B.CreatePHI(Int32Ty, 2, "word.loaded");
+  Loaded->addIncoming(Init, EntryBB);
+  Value *New = Update(B, Loaded);
+  AtomicOrdering Success = cmpxchgSuccessOrdering(Ordering);
+  AtomicCmpXchgInst *Pair = B.CreateAtomicCmpXchg(
+      L.WordAddr, Loaded, New, Align(WordBytes), Success,
+      AtomicCmpXchgInst::getStrongestFailureOrdering(Success), SSID);
+  Pair->setVolatile(IsVolatile);
+  Value *Prev = B.CreateExtractValue(Pair, 0, "word.prev");
+  Value *Done = B.CreateExtractValue(Pair, 1, "word.done");
+  Loaded->addIncoming(Prev, LoopBB);
+  B.CreateCondBr(Done, EndBB, LoopBB);
+
+  B.SetInsertPoint(I);
+  return Loaded;
+}
+
+void lowerLoad(LoadInst *LI, const DataLayout &DL) {
+  IRBuilder<> B(LI);
+  LaneInWord L = locateLane(B, LI->getPointerOperand(), LI->getAlign(),
+                            LI->getType(), DL);
+  LoadInst *Word =
+      B.CreateAlignedLoad(B.getInt32Ty(), L.WordAddr, Align(WordBytes), "word");
+  Word->setAtomic(LI->getOrdering(), LI->getSyncScopeID());
+  Word->setVolatile(LI->isVolatile());
+  LI->replaceAllUsesWith(extractLane(B, Word, L));
+  LI->eraseFromParent();
+}
+
+void lowerStore(StoreInst *SI, const DataLayout &DL) {
+  IRBuilder<> B(SI);
+  Value *Val = SI->getValueOperand();
+  LaneInWord L = locateLane(B, SI->getPointerOperand(), SI->getAlign(),
+                            Val->getType(), DL);
+  Value *ValBits = laneBits(B, Val, L);
+  buildWordCmpXchgLoop(SI, B, L, SI->getOrdering(), SI->getSyncScopeID(),
+                       SI->isVolatile(), [&](IRBuilder<> &B, Value *Loaded) {
+                         return B.CreateOr(B.CreateAnd(Loaded, L.InvMask),
+                                           ValBits);
+                       });
+  SI->eraseFromParent();
+}
+
+void lowerRMW(AtomicRMWInst *RMW, const DataLayout &DL) {
+  IRBuilder<> B(RMW);
+  AtomicRMWInst::BinOp Op = RMW->getOperation();
+  Value *Val = RMW->getValOperand();
+  LaneInWord L = locateLane(B, RMW->getPointerOperand(), RMW->getAlign(),
+                            RMW->getType(), DL);
+  Value *ValBits = Op == AtomicRMWInst::Xchg ? laneBits(B, Val, L) : nullptr;
+  Value *OldWord = buildWordCmpXchgLoop(
+      RMW, B, L, RMW->getOrdering(), RMW->getSyncScopeID(), RMW->isVolatile(),
+      [&](IRBuilder<> &B, Value *Loaded) -> Value * {
+        if (Op == AtomicRMWInst::Xchg)
+          return B.CreateOr(B.CreateAnd(Loaded, L.InvMask), ValBits);
+        Value *Old = extractLane(B, Loaded, L);
+        return insertLane(B, Loaded, applyRMWOperation(B, Op, Old, Val), L);
+      });
+  RMW->replaceAllUsesWith(extractLane(B, OldWord, L));
+  RMW->eraseFromParent();
+}
+
+/// The word-sized cmpxchg cannot tell a mismatch in the lane from a change in
+/// the other lanes, so a strong cmpxchg retries while only the other lanes
+/// moved:
+///
+///   entry:   %word = load atomic i32 %word.addr monotonic
+///            %init.others = and %word, %invmask
+///            br %loop
+///   loop:    %others = phi [ %init.others, %entry ], [ %old.others, %failure ]
+///            %pair = cmpxchg %word.addr, (%others | %cmp.bits),
+///                                        (%others | %new.bits)
+///            br (extractvalue %pair, 1), %end, %failure
+///   failure: %old.others = and (extractvalue %pair, 0), %invmask
+///            br (%others != %old.others), %loop, %end
+///   end:     { lane of (extractvalue %pair, 0), extractvalue %pair, 1 }
+///
+/// A weak cmpxchg may fail spuriously anyway, so it skips the retry.
+void lowerCmpXchg(AtomicCmpXchgInst *CI, const DataLayout &DL) {
+  IRBuilder<> B(CI);
+  LLVMContext &Ctx = B.getContext();
+  Type *Int32Ty = B.getInt32Ty();
+  Value *Cmp = CI->getCompareOperand();
+  LaneInWord L = locateLane(B, CI->getPointerOperand(), CI->getAlign(),
+                            Cmp->getType(), DL);
+  Value *CmpBits = laneBits(B, Cmp, L);
+  Value *NewBits = laneBits(B, CI->getNewValOperand(), L);
+
+  BasicBlock *EntryBB = CI->getParent();
+  Function *F = EntryBB->getParent();
+  BasicBlock *EndBB =
+      EntryBB->splitBasicBlock(CI->getIterator(), "subword.cmpxchg.end");
+  BasicBlock *FailureBB =
+      CI->isWeak() ? nullptr
+                   : BasicBlock::Create(Ctx, "subword.cmpxchg.failure", F,
+                                        EndBB);
+  BasicBlock *LoopBB = BasicBlock::Create(Ctx, "subword.cmpxchg.loop", F,
+                                          FailureBB ? FailureBB : EndBB);
+
+  EntryBB->getTerminator()->eraseFromParent();
+  B.SetInsertPoint(EntryBB);
+  LoadInst *Init =
+      B.CreateAlignedLoad(Int32Ty, L.WordAddr, Align(WordBytes), "word");
+  Init->setAtomic(AtomicOrdering::Monotonic, CI->getSyncScopeID());
+  Init->setVolatile(CI->isVolatile());
+  Value *InitOthers = B.CreateAnd(Init, L.InvMask, "word.others");
+  B.CreateBr(LoopBB);
+
+  B.SetInsertPoint(LoopBB);
+  PHINode *Others = B.CreatePHI(Int32Ty, 2, "others");
+  Others->addIncoming(InitOthers, EntryBB);
+  AtomicCmpXchgInst *Pair = B.CreateAtomicCmpXchg(
+      L.WordAddr, B.CreateOr(Others, CmpBits), B.CreateOr(Others, NewBits),
+      Align(WordBytes), CI->getSuccessOrdering(), CI->getFailureOrdering(),
+      CI->getSyncScopeID());
+  Pair->setVolatile(CI->isVolatile());
+  Pair->setWeak(CI->isWeak());
+  Value *OldWord = B.CreateExtractValue(Pair, 0, "word.prev");
+  Value *Success = B.CreateExtractValue(Pair, 1, "word.done");
+  if (FailureBB) {
+    B.CreateCondBr(Success, EndBB, FailureBB);
+    B.SetInsertPoint(FailureBB);
+    Value *OldOthers = B.CreateAnd(OldWord, L.InvMask, "word.prev.others");
+    Value *OnlyOthersMoved = B.CreateICmpNE(Others, OldOthers);
+    B.CreateCondBr(OnlyOthersMoved, LoopBB, EndBB);
+    Others->addIncoming(OldOthers, FailureBB);
+  } else {
+    B.CreateBr(EndBB);
+  }
+
+  B.SetInsertPoint(CI);
+  Value *Res = PoisonValue::get(CI->getType());
+  Res = B.CreateInsertValue(Res, extractLane(B, OldWord, L), 0);
+  Res = B.CreateInsertValue(Res, Success, 1);
+  CI->replaceAllUsesWith(Res);
+  CI->eraseFromParent();
+}
+
+/// A value narrower than its alignment allows can straddle two words, which
+/// no single-word operation can serve. Clang never emits such an atomic, so
+/// leave it to fail loudly downstream rather than lower it wrongly.
+bool isNaturallyAligned(Align A, Type *ValueTy) {
+  return A.value() * 8 >= ValueTy->getPrimitiveSizeInBits();
+}
+
+bool lowerSubwordAtomics(Function &F) {
+  const DataLayout &DL = F.getParent()->getDataLayout();
+  SmallVector<Instruction *, 16> WorkList;
+  for (auto &BB : F)
+    for (auto &I : BB) {
+      Type *Ty = nullptr;
+      Align A;
+      if (auto *LI = dyn_cast<LoadInst>(&I)) {
+        if (!LI->isAtomic())
+          continue;
+        Ty = LI->getType();
+        A = LI->getAlign();
+      } else if (auto *SI = dyn_cast<StoreInst>(&I)) {
+        if (!SI->isAtomic())
+          continue;
+        Ty = SI->getValueOperand()->getType();
+        A = SI->getAlign();
+      } else if (auto *RMW = dyn_cast<AtomicRMWInst>(&I)) {
+        Ty = RMW->getType();
+        A = RMW->getAlign();
+      } else if (auto *CX = dyn_cast<AtomicCmpXchgInst>(&I)) {
+        Ty = CX->getCompareOperand()->getType();
+        A = CX->getAlign();
+      } else {
+        continue;
+      }
+      if (!isSubwordType(Ty))
+        continue;
+      if (!isNaturallyAligned(A, Ty)) {
+        errs() << "warning: HipLowerSubwordAtomics: leaving under-aligned "
+                  "atomic alone in "
+               << F.getName() << ": " << I << "\n";
+        continue;
+      }
+      WorkList.push_back(&I);
+    }
+
+  for (Instruction *I : WorkList) {
+    if (auto *LI = dyn_cast<LoadInst>(I))
+      lowerLoad(LI, DL);
+    else if (auto *SI = dyn_cast<StoreInst>(I))
+      lowerStore(SI, DL);
+    else if (auto *RMW = dyn_cast<AtomicRMWInst>(I))
+      lowerRMW(RMW, DL);
+    else
+      lowerCmpXchg(cast<AtomicCmpXchgInst>(I), DL);
+  }
+  return !WorkList.empty();
+}
+
+} // namespace
+
+PreservedAnalyses HipLowerSubwordAtomicsPass::run(Function &F,
+                                                  FunctionAnalysisManager &AM) {
+  return lowerSubwordAtomics(F) ? PreservedAnalyses::none()
+                                : PreservedAnalyses::all();
+}
+
+#ifndef CHIP_COMBINED_PASS_PLUGIN
+extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
+llvmGetPassPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, PASS_NAME, LLVM_VERSION_STRING,
+          [](PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](StringRef Name, FunctionPassManager &FPM,
+                   ArrayRef<PassBuilder::PipelineElement>) {
+                  if (Name == PASS_NAME) {
+                    FPM.addPass(HipLowerSubwordAtomicsPass());
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}
+#endif // CHIP_COMBINED_PASS_PLUGIN

--- a/llvm_passes/HipLowerSubwordAtomics.h
+++ b/llvm_passes/HipLowerSubwordAtomics.h
@@ -1,0 +1,30 @@
+//===- HipLowerSubwordAtomics.h -------------------------------------------===//
+//
+// Part of the chipStar Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Rewrites 8 and 16 bit atomic load, store, atomicrmw and cmpxchg onto the
+// aligned 32 bit word that contains the value, because OpenCL SPIR-V consumers
+// only implement 32 and 64 bit atomics.
+//
+// (c) 2026 chipStar developers
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_PASSES_HIP_LOWER_SUBWORD_ATOMICS_H
+#define LLVM_PASSES_HIP_LOWER_SUBWORD_ATOMICS_H
+
+#include <llvm/IR/PassManager.h>
+
+using namespace llvm;
+
+class HipLowerSubwordAtomicsPass
+    : public PassInfoMixin<HipLowerSubwordAtomicsPass> {
+public:
+  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  static bool isRequired() { return true; }
+};
+
+#endif

--- a/llvm_passes/HipPasses.cpp
+++ b/llvm_passes/HipPasses.cpp
@@ -32,6 +32,7 @@
 #include "HipLowerMemset.h"
 #include "HipLowerFPAtomicMinMax.h"
 #include "HipLowerRoundIntrinsics.h"
+#include "HipLowerSubwordAtomics.h"
 #include "HipIGBADetector.h"
 #include "HipPromoteInts.h"
 #include "HipLowerOverflowIntrinsics.h"
@@ -186,6 +187,12 @@ static void addFullLinkTimePasses(ModulePassManager &MPM) {
   addPassWithVerification(MPM, createModuleToFunctionPassAdaptor(HipDefrostPass()), "HipDefrostPass");
   addPassWithVerification(MPM, createModuleToFunctionPassAdaptor(HipLowerMemsetPass()), "HipLowerMemsetPass");
   addPassWithVerification(MPM, createModuleToFunctionPassAdaptor(HipLowerFPAtomicMinMaxPass()), "HipLowerFPAtomicMinMaxPass");
+  // OpenCL SPIR-V consumers implement 32 and 64 bit atomics only; rewrite 8
+  // and 16 bit ones onto their containing word. Runs after the fmin / fmax
+  // expansion so the i16 cmpxchg it produces for half gets lowered too, and
+  // before InferAddressSpaces so the word address it forms with a GEP is
+  // still narrowed to the global or local address space.
+  addPassWithVerification(MPM, createModuleToFunctionPassAdaptor(HipLowerSubwordAtomicsPass()), "HipLowerSubwordAtomicsPass");
   addPassWithVerification(MPM, HipLowerRoundIntrinsicsPass(), "HipLowerRoundIntrinsicsPass");
   addPassWithVerification(MPM, HipAbortPass(), "HipAbortPass");
   // This pass must appear after HipDynMemExternReplaceNewPass.
@@ -271,6 +278,13 @@ llvmGetPassPluginInfo() {
                   // which makes it directly testable with opt.
                   if (Name == "hip-lower-overflow-intrinsics") {
                     MPM.addPass(HipLowerOverflowIntrinsicsPass());
+                    return true;
+                  }
+                  // Register the 8 and 16 bit atomic lowering as standalone,
+                  // which makes it directly testable with opt.
+                  if (Name == "hip-lower-subword-atomics") {
+                    MPM.addPass(createModuleToFunctionPassAdaptor(
+                        HipLowerSubwordAtomicsPass()));
                     return true;
                   }
                   // Register SPIR-V function reorder pass as standalone

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -197,3 +197,6 @@ add_subdirectory(promoteInt)
 
 # Add the IR verification tests
 add_subdirectory(irVerification)
+
+# Add the 8 and 16 bit atomic lowering pass tests
+add_subdirectory(subwordAtomics)

--- a/tests/compiler/subwordAtomics/CMakeLists.txt
+++ b/tests/compiler/subwordAtomics/CMakeLists.txt
@@ -1,0 +1,56 @@
+#=============================================================================
+#  Copyright (c) 2026 chipStar developers
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+#
+#=============================================================================
+
+configure_file(run_subword_atomics_pass.bash
+  ${CMAKE_CURRENT_BINARY_DIR}/run_subword_atomics_pass.bash @ONLY)
+
+# LLVM_SPIRV carries the sentinel "NOT_NEEDED" when chipStar targets LLVM's
+# integrated SPIR-V backend; this test still translates to SPIR-V to validate
+# the pass output, so fall back to a translator next to the other LLVM tools.
+set(SUBWORD_ATOMICS_LLVM_SPIRV "${LLVM_SPIRV}")
+if(NOT SUBWORD_ATOMICS_LLVM_SPIRV OR SUBWORD_ATOMICS_LLVM_SPIRV STREQUAL "NOT_NEEDED")
+  set(SUBWORD_ATOMICS_LLVM_SPIRV "${LLVM_TOOLS_BINARY_DIR}/llvm-spirv")
+endif()
+find_program(SPIRV_VAL spirv-val)
+
+# Every 8 and 16 bit atomic form clang emits for HIP device code, in the
+# global, local and generic address spaces (CHIP-SPV/chipStar#1497).
+list(APPEND TEST_IR_FILES ${CMAKE_CURRENT_SOURCE_DIR}/subword-atomics.ll)
+
+foreach(IR_FILE ${TEST_IR_FILES})
+  get_filename_component(FILENAME ${IR_FILE} NAME)
+  get_filename_component(BASENAME ${IR_FILE} NAME_WE)
+  configure_file(${IR_FILE} ${CMAKE_CURRENT_BINARY_DIR}/${FILENAME} COPYONLY)
+
+  add_test(
+    NAME hipSubwordAtomics-${BASENAME}
+    COMMAND env
+      LLVM_OPT=${LLVM_TOOLS_BINARY_DIR}/opt
+      LLVM_DIS=${LLVM_TOOLS_BINARY_DIR}/llvm-dis
+      LLVM_SPIRV=${SUBWORD_ATOMICS_LLVM_SPIRV}
+      SPIRV_VAL=${SPIRV_VAL}
+      HIP_SPV_PASSES_LIB=${CMAKE_BINARY_DIR}/lib/libLLVMHipSpvPasses.so
+      ${CMAKE_CURRENT_BINARY_DIR}/run_subword_atomics_pass.bash
+      ${CMAKE_CURRENT_BINARY_DIR}/${FILENAME}
+  )
+endforeach()

--- a/tests/compiler/subwordAtomics/run_subword_atomics_pass.bash
+++ b/tests/compiler/subwordAtomics/run_subword_atomics_pass.bash
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Check that the post-link pass pipeline leaves behind no 8 or 16 bit atomic
+# instruction, and that the result still translates to valid SPIR-V.
+#
+# Usage: run_subword_atomics_pass.bash <input.ll>
+#
+# OpenCL SPIR-V consumers implement 32 and 64 bit atomics only. An
+# OpAtomicLoad / OpAtomicStore / OpAtomicCompareExchange / OpAtomicIAdd ... on
+# OpTypeInt 8 or 16 passes spirv-val and only dies inside the driver's JIT
+# (IGC: "undefined reference to `_Z18__spirv_AtomicLoadPU3AS4cii'" followed by
+# "backend compiler failed build."), which takes every kernel in the module
+# down with it. HipLowerSubwordAtomicsPass rewrites those onto the containing
+# 32 bit word; this looks at the module after the pipeline to make sure none
+# survived. See CHIP-SPV/chipStar#1497.
+
+set -e
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <input.ll>"
+  exit 1
+fi
+
+INPUT_FILE="$1"
+BASE_NAME=$(basename "${INPUT_FILE}" .ll)
+OUTPUT_BC="${BASE_NAME}.lowered.bc"
+OUTPUT_LL="${BASE_NAME}.lowered.ll"
+OUTPUT_SPV="${BASE_NAME}.lowered.spv"
+SPIRV_OPTS="--spirv-max-version=1.2 --spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups"
+
+# CHIP_VERIFY_MODE=off: the in-pass IR->SPIR-V re-verification defaults to on
+# in Debug builds and is redundant here; the translation below is the check.
+CHIP_VERIFY_MODE=off "${LLVM_OPT}" -load-pass-plugin "${HIP_SPV_PASSES_LIB}" \
+  -passes=hip-post-link-passes "${INPUT_FILE}" -o "${OUTPUT_BC}"
+"${LLVM_DIS}" "${OUTPUT_BC}" -o "${OUTPUT_LL}"
+
+KERNELS=$(grep -c 'spir_kernel' "${OUTPUT_LL}" || true)
+if [ "${KERNELS}" -eq 0 ]; then
+  echo "ERROR: no spir_kernel survived the pass pipeline; test input is stale"
+  exit 1
+fi
+
+# load atomic i8 / store atomic i16 %v / atomicrmw add ptr %p, i8 %v /
+# cmpxchg weak ptr %p, i16 %c, i16 %n / atomicrmw fadd ptr %p, half %v
+LEFTOVER=$(grep -E -e 'load atomic (volatile )?(i8|i16|half|bfloat),' \
+                   -e 'store atomic (volatile )?(i8|i16|half|bfloat) ' \
+                   -e 'atomicrmw .*, (i8|i16|half|bfloat) ' \
+                   -e 'cmpxchg .*, (i8|i16) ' "${OUTPUT_LL}" || true)
+if [ -n "${LEFTOVER}" ]; then
+  echo "ERROR: 8/16 bit atomic instruction(s) survived the pass pipeline:"
+  echo "${LEFTOVER}"
+  echo "See ${OUTPUT_LL} for details"
+  exit 1
+fi
+
+# The lowering must land on 32 bit atomics, not delete the operations.
+WORD_CAS=$(grep -c -E 'cmpxchg .*, i32 ' "${OUTPUT_LL}" || true)
+WORD_LOAD=$(grep -c -E 'load atomic (volatile )?i32,' "${OUTPUT_LL}" || true)
+if [ "${WORD_CAS}" -eq 0 ] || [ "${WORD_LOAD}" -eq 0 ]; then
+  echo "ERROR: expected 32 bit cmpxchg and atomic loads after lowering" \
+       "(cmpxchg=${WORD_CAS} loads=${WORD_LOAD})"
+  echo "See ${OUTPUT_LL} for details"
+  exit 1
+fi
+
+# The rewrite is only useful if the result is valid SPIR-V.
+"${LLVM_SPIRV}" "${OUTPUT_BC}" ${SPIRV_OPTS} -o "${OUTPUT_SPV}"
+if [ -n "${SPIRV_VAL}" ] && [ -x "${SPIRV_VAL}" ]; then
+  "${SPIRV_VAL}" --target-env opencl2.2 "${OUTPUT_SPV}"
+  VALIDATED="spirv-val ok"
+else
+  VALIDATED="spirv-val not available"
+fi
+
+echo "kernels=${KERNELS} no 8/16 bit atomics, word cmpxchg=${WORD_CAS}" \
+     "word loads=${WORD_LOAD}, SPIR-V ok, ${VALIDATED}"
+exit 0

--- a/tests/compiler/subwordAtomics/subword-atomics.ll
+++ b/tests/compiler/subwordAtomics/subword-atomics.ll
@@ -1,0 +1,116 @@
+; Every 8 and 16 bit atomic form clang can emit for a HIP device module, in the
+; global, local and generic address spaces. OpenCL SPIR-V consumers only
+; implement 32 and 64 bit atomics, so HipLowerSubwordAtomicsPass must rewrite
+; all of these onto the aligned containing 32 bit word before SPIR-V emission.
+;
+; See CHIP-SPV/chipStar#1497.
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spirv64"
+
+@lmem = internal addrspace(3) global [64 x i8] undef, align 4
+
+define spir_kernel void @subword_atomics(ptr addrspace(1) %P8,
+                                         ptr addrspace(1) %P16,
+                                         ptr addrspace(1) %PH,
+                                         ptr addrspace(1) %P32,
+                                         ptr addrspace(1) %Out8,
+                                         ptr addrspace(1) %Out16,
+                                         i8 %V8, i16 %V16, half %VH, i32 %V32) {
+entry:
+  %G8 = addrspacecast ptr addrspace(1) %P8 to ptr addrspace(4)
+  %L8 = getelementptr inbounds [64 x i8], ptr addrspace(3) @lmem, i64 0, i64 5
+
+  ; load / store, every ordering clang emits for them
+  %ld.mono = load atomic i8, ptr addrspace(1) %P8 syncscope("device") monotonic, align 1
+  %ld.acq = load atomic i8, ptr addrspace(4) %G8 syncscope("device") acquire, align 1
+  %ld.seq = load atomic i16, ptr addrspace(1) %P16 seq_cst, align 2
+  %ld.local = load atomic i8, ptr addrspace(3) %L8 syncscope("workgroup") monotonic, align 1
+  store atomic i8 %V8, ptr addrspace(1) %P8 syncscope("device") monotonic, align 1
+  store atomic i8 %V8, ptr addrspace(4) %G8 syncscope("device") release, align 1
+  store atomic i16 %V16, ptr addrspace(1) %P16 seq_cst, align 2
+  store atomic i8 %V8, ptr addrspace(3) %L8 syncscope("workgroup") monotonic, align 1
+
+  ; atomicrmw, every integer operation, on i8
+  %xchg = atomicrmw xchg ptr addrspace(1) %P8, i8 %V8 syncscope("device") monotonic, align 1
+  %add = atomicrmw add ptr addrspace(4) %G8, i8 %V8 syncscope("device") monotonic, align 1
+  %sub = atomicrmw sub ptr addrspace(1) %P8, i8 %V8 syncscope("device") acq_rel, align 1
+  %and = atomicrmw and ptr addrspace(1) %P8, i8 %V8 syncscope("device") monotonic, align 1
+  %or = atomicrmw or ptr addrspace(1) %P8, i8 %V8 syncscope("device") monotonic, align 1
+  %xor = atomicrmw xor ptr addrspace(3) %L8, i8 %V8 syncscope("workgroup") monotonic, align 1
+  %min = atomicrmw min ptr addrspace(1) %P8, i8 %V8 syncscope("device") monotonic, align 1
+  %max = atomicrmw max ptr addrspace(1) %P8, i8 %V8 syncscope("device") monotonic, align 1
+  %umin = atomicrmw umin ptr addrspace(1) %P8, i8 %V8 syncscope("device") monotonic, align 1
+  %umax = atomicrmw umax ptr addrspace(1) %P8, i8 %V8 syncscope("device") monotonic, align 1
+  %nand = atomicrmw nand ptr addrspace(1) %P8, i8 %V8 syncscope("device") monotonic, align 1
+
+  ; the same on i16, plus a 16 bit float add
+  %xchg16 = atomicrmw xchg ptr addrspace(1) %P16, i16 %V16 syncscope("device") monotonic, align 2
+  %add16 = atomicrmw add ptr addrspace(1) %P16, i16 %V16 syncscope("device") seq_cst, align 2
+  %sub16 = atomicrmw sub ptr addrspace(1) %P16, i16 %V16 syncscope("device") monotonic, align 2
+  %and16 = atomicrmw and ptr addrspace(1) %P16, i16 %V16 syncscope("device") monotonic, align 2
+  %or16 = atomicrmw or ptr addrspace(1) %P16, i16 %V16 syncscope("device") monotonic, align 2
+  %xor16 = atomicrmw xor ptr addrspace(1) %P16, i16 %V16 syncscope("device") monotonic, align 2
+  %min16 = atomicrmw min ptr addrspace(1) %P16, i16 %V16 syncscope("device") monotonic, align 2
+  %max16 = atomicrmw max ptr addrspace(1) %P16, i16 %V16 syncscope("device") monotonic, align 2
+  %umin16 = atomicrmw umin ptr addrspace(1) %P16, i16 %V16 syncscope("device") monotonic, align 2
+  %umax16 = atomicrmw umax ptr addrspace(1) %P16, i16 %V16 syncscope("device") monotonic, align 2
+  %nand16 = atomicrmw nand ptr addrspace(1) %P16, i16 %V16 syncscope("device") monotonic, align 2
+  %faddh = atomicrmw fadd ptr addrspace(1) %PH, half %VH syncscope("device") monotonic, align 2
+
+  ; cmpxchg: strong and weak, i8 and i16, global and generic
+  %cas = cmpxchg ptr addrspace(1) %P8, i8 %V8, i8 %add syncscope("device") monotonic monotonic, align 1
+  %cas.val = extractvalue { i8, i1 } %cas, 0
+  %cas.ok = extractvalue { i8, i1 } %cas, 1
+  %casw = cmpxchg weak ptr addrspace(4) %G8, i8 %V8, i8 %sub syncscope("device") acq_rel monotonic, align 1
+  %casw.val = extractvalue { i8, i1 } %casw, 0
+  %cas16 = cmpxchg ptr addrspace(1) %P16, i16 %V16, i16 %add16 seq_cst seq_cst, align 2
+  %cas16.val = extractvalue { i16, i1 } %cas16, 0
+  %casl = cmpxchg ptr addrspace(3) %L8, i8 %V8, i8 %xor syncscope("workgroup") monotonic monotonic, align 1
+  %casl.val = extractvalue { i8, i1 } %casl, 0
+
+  ; a 32 bit atomic that must be left alone
+  %add32 = atomicrmw add ptr addrspace(1) %P32, i32 %V32 syncscope("device") monotonic, align 4
+
+  ; keep every result alive
+  %s0 = add i8 %ld.mono, %ld.acq
+  %s1 = add i8 %s0, %ld.local
+  %s2 = add i8 %s1, %xchg
+  %s3 = add i8 %s2, %add
+  %s4 = add i8 %s3, %sub
+  %s5 = add i8 %s4, %and
+  %s6 = add i8 %s5, %or
+  %s7 = add i8 %s6, %xor
+  %s8 = add i8 %s7, %min
+  %s9 = add i8 %s8, %max
+  %s10 = add i8 %s9, %umin
+  %s11 = add i8 %s10, %umax
+  %s12 = add i8 %s11, %nand
+  %s13 = add i8 %s12, %cas.val
+  %s14 = add i8 %s13, %casw.val
+  %s15 = add i8 %s14, %casl.val
+  %ok8 = zext i1 %cas.ok to i8
+  %s16 = add i8 %s15, %ok8
+  store i8 %s16, ptr addrspace(1) %Out8, align 1
+  %t0 = add i16 %ld.seq, %xchg16
+  %t1 = add i16 %t0, %add16
+  %t2 = add i16 %t1, %sub16
+  %t3 = add i16 %t2, %and16
+  %t4 = add i16 %t3, %or16
+  %t5 = add i16 %t4, %xor16
+  %t6 = add i16 %t5, %min16
+  %t7 = add i16 %t6, %max16
+  %t8 = add i16 %t7, %umin16
+  %t9 = add i16 %t8, %umax16
+  %t10 = add i16 %t9, %nand16
+  %t11 = add i16 %t10, %cas16.val
+  %hbits = bitcast half %faddh to i16
+  %t12 = add i16 %t11, %hbits
+  %a32 = trunc i32 %add32 to i16
+  %t13 = add i16 %t12, %a32
+  store i16 %t13, ptr addrspace(1) %Out16, align 2
+  ret void
+}
+
+!opencl.ocl.version = !{!0}
+!0 = !{i32 2, i32 0}

--- a/tests/runtime/TestSubwordAtomics.hip
+++ b/tests/runtime/TestSubwordAtomics.hip
@@ -1,0 +1,258 @@
+// Reproduces CHIP-SPV/chipStar#1497: 8 and 16 bit atomics reach the SPIR-V
+// module as OpAtomicLoad / OpAtomicStore / OpAtomicCompareExchange and friends
+// on OpTypeInt 8 and 16, which OpenCL SPIR-V consumers do not implement (IGC
+// fails the module build with undefined references to
+// __spirv_AtomicLoad(char AS4*, int, int) and friends).
+//
+// Every kernel below hits all four byte lanes (or both short lanes) of a 32 bit
+// word from different threads at the same time, so a lowering that operates on
+// the containing word without a compare-and-swap loop is caught as lost updates
+// or clobbered neighbour lanes, not just a build failure.
+
+#include <hip/hip_runtime.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+static constexpr int NumBlocks = 8;
+static constexpr int BlockSize = 256;
+static constexpr int NumThreads = NumBlocks * BlockSize; // 2048
+static constexpr int NumElems = 64; // 32 threads share every element
+static constexpr int ThreadsPerElem = NumThreads / NumElems;
+// storeLoadKernel tags are Elem * Ranks + Rank + 1 and must stay non-zero and
+// inside 8 bits, so it runs in one block of StoreLoadThreads threads.
+static constexpr int StoreLoadThreads = 128;
+
+#define CHECK(Cmd)                                                             \
+  do {                                                                         \
+    hipError_t Err = (Cmd);                                                    \
+    if (Err != hipSuccess) {                                                   \
+      printf("FAILED: %s at %s:%d\n", hipGetErrorString(Err), __FILE__,        \
+             __LINE__);                                                        \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (0)
+
+template <typename T>
+__global__ void fetchAddKernel(T *Data, int Iters) {
+  int Tid = blockIdx.x * blockDim.x + threadIdx.x;
+  T *Slot = Data + (Tid % NumElems);
+  for (int I = 0; I < Iters; ++I)
+    __hip_atomic_fetch_add(Slot, T(1), __ATOMIC_RELAXED,
+                           __HIP_MEMORY_SCOPE_AGENT);
+}
+
+template <typename T>
+__global__ void fetchSubKernel(T *Data, int Iters) {
+  int Tid = blockIdx.x * blockDim.x + threadIdx.x;
+  T *Slot = Data + (Tid % NumElems);
+  for (int I = 0; I < Iters; ++I)
+    __hip_atomic_fetch_sub(Slot, T(1), __ATOMIC_RELAXED,
+                           __HIP_MEMORY_SCOPE_AGENT);
+}
+
+// Each thread ORs in / ANDs out one bit of its lane, then max / min its rank.
+template <typename T>
+__global__ void bitwiseMinMaxKernel(T *OrData, T *AndData, T *MaxData,
+                                    T *MinData) {
+  int Tid = blockIdx.x * blockDim.x + threadIdx.x;
+  int Elem = Tid % NumElems;
+  int Rank = Tid / NumElems; // 0 .. ThreadsPerElem - 1
+  T Bit = T(1) << (Rank % 8);
+  __hip_atomic_fetch_or(OrData + Elem, Bit, __ATOMIC_RELAXED,
+                        __HIP_MEMORY_SCOPE_AGENT);
+  __hip_atomic_fetch_and(AndData + Elem, T(~Bit), __ATOMIC_RELAXED,
+                         __HIP_MEMORY_SCOPE_AGENT);
+  __hip_atomic_fetch_max(MaxData + Elem, T(Rank + 1), __ATOMIC_RELAXED,
+                         __HIP_MEMORY_SCOPE_AGENT);
+  __hip_atomic_fetch_min(MinData + Elem, T(Rank + 1), __ATOMIC_RELAXED,
+                         __HIP_MEMORY_SCOPE_AGENT);
+}
+
+// Each thread swaps in its rank + 1 and records what it swapped out.
+template <typename T>
+__global__ void exchangeKernel(T *Data, T *Old) {
+  int Tid = blockIdx.x * blockDim.x + threadIdx.x;
+  Old[Tid] = __hip_atomic_exchange(Data + (Tid % NumElems),
+                                   T(Tid / NumElems + 1), __ATOMIC_RELAXED,
+                                   __HIP_MEMORY_SCOPE_AGENT);
+}
+
+// Increment through a CAS loop, then one CAS that must fail and leave the
+// value alone while reporting the current one.
+template <typename T>
+__global__ void casKernel(T *Data, int Iters, int *Errors) {
+  int Tid = blockIdx.x * blockDim.x + threadIdx.x;
+  T *Slot = Data + (Tid % NumElems);
+  for (int I = 0; I < Iters; ++I) {
+    T Expected = __hip_atomic_load(Slot, __ATOMIC_RELAXED,
+                                   __HIP_MEMORY_SCOPE_AGENT);
+    while (!__hip_atomic_compare_exchange_strong(
+        Slot, &Expected, T(Expected + 1), __ATOMIC_RELAXED, __ATOMIC_RELAXED,
+        __HIP_MEMORY_SCOPE_AGENT)) {
+    }
+  }
+  T Bogus = T(-1);
+  T Seen = Bogus;
+  if (__hip_atomic_compare_exchange_strong(Slot, &Seen, T(0), __ATOMIC_RELAXED,
+                                           __ATOMIC_RELAXED,
+                                           __HIP_MEMORY_SCOPE_AGENT))
+    atomicAdd(Errors, 1);
+  if (Seen == Bogus)
+    atomicAdd(Errors, 1);
+}
+
+// One block: every thread stores a tag unique to its (element, rank) pair,
+// then every thread loads its element back and checks the tag belongs to that
+// element. A store that rewrites the neighbour lanes non-atomically leaks a
+// foreign tag into them.
+template <typename T>
+__global__ void storeLoadKernel(T *Data, int *Errors) {
+  int Tid = threadIdx.x;
+  int Elem = Tid % NumElems;
+  int Rank = Tid / NumElems;
+  int Ranks = blockDim.x / NumElems;
+  __hip_atomic_store(Data + Elem, T(Elem * Ranks + Rank + 1), __ATOMIC_RELEASE,
+                     __HIP_MEMORY_SCOPE_AGENT);
+  __syncthreads();
+  T V = __hip_atomic_load(Data + Elem, __ATOMIC_ACQUIRE,
+                          __HIP_MEMORY_SCOPE_AGENT);
+  int Tag = int(V) - 1;
+  if (Tag < Elem * Ranks || Tag >= (Elem + 1) * Ranks)
+    atomicAdd(Errors, 1);
+}
+
+static int Failures = 0;
+
+template <typename T> static T *toDevice(const std::vector<T> &H) {
+  T *D;
+  CHECK(hipMalloc(&D, H.size() * sizeof(T)));
+  CHECK(hipMemcpy(D, H.data(), H.size() * sizeof(T), hipMemcpyHostToDevice));
+  return D;
+}
+
+template <typename T> static std::vector<T> toHost(T *D, size_t N) {
+  std::vector<T> H(N);
+  CHECK(hipMemcpy(H.data(), D, N * sizeof(T), hipMemcpyDeviceToHost));
+  CHECK(hipFree(D));
+  return H;
+}
+
+template <typename T>
+static void expectAll(const char *What, const std::vector<T> &Got, T Want) {
+  for (size_t I = 0; I < Got.size(); ++I)
+    if (Got[I] != Want) {
+      printf("FAILED: %s[%zu] = %d, expected %d\n", What, I, int(Got[I]),
+             int(Want));
+      ++Failures;
+      return;
+    }
+}
+
+template <typename T> static void testFetchAddSub(const char *Name, int Iters) {
+  T *Add = toDevice(std::vector<T>(NumElems, T(0)));
+  T *Sub = toDevice(std::vector<T>(NumElems, T(0)));
+  fetchAddKernel<T><<<NumBlocks, BlockSize>>>(Add, Iters);
+  fetchSubKernel<T><<<NumBlocks, BlockSize>>>(Sub, Iters);
+  CHECK(hipDeviceSynchronize());
+  expectAll(Name, toHost(Add, NumElems), T(ThreadsPerElem * Iters));
+  expectAll(Name, toHost(Sub, NumElems), T(-(ThreadsPerElem * Iters)));
+}
+
+template <typename T> static void testBitwiseMinMax(const char *Name) {
+  T *Or = toDevice(std::vector<T>(NumElems, T(0)));
+  T *And = toDevice(std::vector<T>(NumElems, T(-1)));
+  T *Max = toDevice(std::vector<T>(NumElems, T(0)));
+  T *Min = toDevice(std::vector<T>(NumElems, T(ThreadsPerElem + 1)));
+  bitwiseMinMaxKernel<T><<<NumBlocks, BlockSize>>>(Or, And, Max, Min);
+  CHECK(hipDeviceSynchronize());
+  expectAll(Name, toHost(Or, NumElems), T(0xFF));
+  expectAll(Name, toHost(And, NumElems), T(~0xFF));
+  expectAll(Name, toHost(Max, NumElems), T(ThreadsPerElem));
+  expectAll(Name, toHost(Min, NumElems), T(1));
+}
+
+template <typename T> static void testExchange(const char *Name) {
+  T *Data = toDevice(std::vector<T>(NumElems, T(0)));
+  T *Old = toDevice(std::vector<T>(NumThreads, T(0)));
+  exchangeKernel<T><<<NumBlocks, BlockSize>>>(Data, Old);
+  CHECK(hipDeviceSynchronize());
+  std::vector<T> Final = toHost(Data, NumElems);
+  std::vector<T> Olds = toHost(Old, NumThreads);
+  // Per element, {swapped-out values} + {final value} must be exactly
+  // {0, 1, ..., ThreadsPerElem}: nothing lost, nothing duplicated.
+  for (int E = 0; E < NumElems; ++E) {
+    std::vector<int> Seen;
+    for (int R = 0; R < ThreadsPerElem; ++R)
+      Seen.push_back(int(Olds[R * NumElems + E]));
+    Seen.push_back(int(Final[E]));
+    std::sort(Seen.begin(), Seen.end());
+    for (int I = 0; I <= ThreadsPerElem; ++I)
+      if (Seen[I] != I) {
+        printf("FAILED: %s exchange multiset broken at element %d\n", Name, E);
+        ++Failures;
+        return;
+      }
+  }
+}
+
+template <typename T> static void testCas(const char *Name, int Iters) {
+  T *Data = toDevice(std::vector<T>(NumElems, T(0)));
+  int *Errors = toDevice(std::vector<int>(1, 0));
+  casKernel<T><<<NumBlocks, BlockSize>>>(Data, Iters, Errors);
+  CHECK(hipDeviceSynchronize());
+  expectAll(Name, toHost(Data, NumElems), T(ThreadsPerElem * Iters));
+  int Errs = toHost(Errors, 1)[0];
+  if (Errs) {
+    printf("FAILED: %s failing CAS misbehaved %d times\n", Name, Errs);
+    ++Failures;
+  }
+}
+
+template <typename T> static void testStoreLoad(const char *Name) {
+  T *Data = toDevice(std::vector<T>(NumElems, T(0)));
+  int *Errors = toDevice(std::vector<int>(1, 0));
+  storeLoadKernel<T><<<1, StoreLoadThreads>>>(Data, Errors);
+  CHECK(hipDeviceSynchronize());
+  std::vector<T> Final = toHost(Data, NumElems);
+  int Ranks = StoreLoadThreads / NumElems;
+  for (int E = 0; E < NumElems; ++E) {
+    int Tag = int(Final[E]) - 1;
+    if (Tag < E * Ranks || Tag >= (E + 1) * Ranks) {
+      printf("FAILED: %s element %d holds foreign tag %d\n", Name, E, Tag);
+      ++Failures;
+      break;
+    }
+  }
+  int Errs = toHost(Errors, 1)[0];
+  if (Errs) {
+    printf("FAILED: %s device-side load saw %d foreign tags\n", Name, Errs);
+    ++Failures;
+  }
+}
+
+int main() {
+  // Iteration counts keep every count inside the type's range.
+  testFetchAddSub<unsigned char>("uchar", 7);   // 32 * 7 = 224
+  testFetchAddSub<signed char>("schar", 3);     // 32 * 3 = 96
+  testFetchAddSub<unsigned short>("ushort", 1000);
+  testFetchAddSub<short>("short", 500);
+  testBitwiseMinMax<unsigned char>("uchar");
+  testBitwiseMinMax<unsigned short>("ushort");
+  testExchange<unsigned char>("uchar");
+  testExchange<short>("short");
+  testCas<unsigned char>("uchar", 5);           // 32 * 5 = 160
+  testCas<signed char>("schar", 3);
+  testCas<unsigned short>("ushort", 200);
+  testStoreLoad<unsigned char>("uchar");        // tags 1 .. 128
+  testStoreLoad<short>("short");
+
+  if (Failures) {
+    printf("FAILED\n");
+    return 1;
+  }
+  printf("PASSED\n");
+  return 0;
+}


### PR DESCRIPTION
Clang lowers `__hip_atomic_*` on `char` and `short` to i8 and i16 atomic instructions, and both SPIR-V producers pass them through as `OpAtomicLoad`, `OpAtomicIAdd`, `OpAtomicCompareExchange` and friends on 8 and 16 bit integers, which OpenCL SPIR-V consumers do not implement: IGC fails the module build with `undefined reference to _Z18__spirv_AtomicLoadPU3AS4cii` and the Intel CPU OpenCL runtime with `JIT session error: Symbols not found`, taking every kernel in the module down with it. This adds `HipLowerSubwordAtomicsPass`, which rewrites each 8 and 16 bit atomic load, store, atomicrmw and cmpxchg onto the aligned 32 bit word that contains it (atomic load plus shift for loads, cmpxchg loops touching only the affected lane for the rest), keeping the ordering and syncscope. Found with Kokkos `TestAtomicOperations` on `signed char` on Aurora PVC. `TestSubwordAtomics` drives every form from all four byte lanes of a word concurrently, and `subwordAtomics/subword-atomics.ll` checks that no i8 or i16 atomic survives the post-link pipeline.

Fixes #1497
