### PR TITLE
runtime: bind storage for unregistered device variables in every module

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -397,6 +397,38 @@ chipstar::DeviceVar *chipstar::Module::getGlobalVar(const char *VarName) {
   return *VarFound;
 }
 
+void chipstar::Module::addUnregisteredDeviceVariables() {
+  // A __chip_var_info_<X> shadow kernel means HipGlobalVariables.cpp lowered X
+  // into a __chip_var_<X> address slot: the module's code reads X through the
+  // slot and __chip_var_init_all writes X's initializer through it, so the
+  // slot must be bound to storage before the module's first launch whether or
+  // not the host registered X. clang emits no __hipRegisterVar for a
+  // function-local static __device__ variable, for an inline __device__
+  // variable or a template static data member that host code does not ODR-use
+  // (clang/lib/CodeGen/CGCUDANV.cpp, handleVarRegistration), or for any
+  // variable of a code object loaded through hipModuleLoadData. Such
+  // variables have no host pointer; they are looked up by name only.
+  static int NoHostPtr = 0;
+  for (auto *Kernel : ChipKernels_) {
+    const std::string &KernelName = Kernel->getName();
+    if (KernelName.rfind(ChipVarInfoPrefix, 0) != 0)
+      continue;
+    std::string VarName = KernelName.substr(strlen(ChipVarInfoPrefix));
+    bool HasVar = std::any_of(ChipVars_.begin(), ChipVars_.end(),
+                              [&VarName](chipstar::DeviceVar *Var) {
+                                return Var->getName() == VarName;
+                              });
+    if (HasVar)
+      continue;
+    logTrace("Device variable {} has no host registration in module {}, "
+             "binding it from its shadow kernels",
+             VarName, (void *)this);
+    UnregisteredVars_.push_back(std::make_unique<SPVVariable>(SPVVariable{
+        {const_cast<SPVModule *>(Src_), HostPtr(&NoHostPtr), VarName}, 0}));
+    addDeviceVariable(new chipstar::DeviceVar(UnregisteredVars_.back().get()));
+  }
+}
+
 hipError_t
 chipstar::Module::allocateDeviceVariablesNoLock(chipstar::Device *Device,
                                                 chipstar::Queue *Queue) {
@@ -1268,36 +1300,9 @@ void chipstar::Device::registerModuleVariables(chipstar::Module *ChipModule,
     DeviceVarLookup_.insert(std::make_pair(Info.Ptr, Var));
   }
 
-  // For hipRTC modules, discover variables from shadow kernels
-  // (SrcMod->Variables is empty for hipRTC)
-  if (SrcMod->Variables.empty()) {
-    auto &Kernels = ChipModule->getKernels();
-
-    // Create fake SPVVariables for hipRTC - these will be owned by SrcMod
-    auto *MutableSrcMod = const_cast<SPVModule *>(SrcMod);
-
-    for (auto *Kernel : Kernels) {
-      std::string KernelName = Kernel->getName();
-
-      // Look for variable info shadow kernels
-      if (KernelName.find(ChipVarInfoPrefix) == 0) {
-        // Extract variable name from __chip_var_info_<varname>
-        std::string VarName = KernelName.substr(strlen(ChipVarInfoPrefix));
-
-        // Create fake SPVVariable for hipRTC - add to SrcMod's Variables list
-        // Use a dummy host pointer since hipRTC variables don't have real host
-        // pointers
-        void *DummyPtr = reinterpret_cast<void *>(
-            static_cast<uintptr_t>(0x1000 + MutableSrcMod->Variables.size()));
-        MutableSrcMod->Variables.emplace_back(
-            SPVVariable{{MutableSrcMod, HostPtr(DummyPtr), VarName}, 0});
-
-        // Now register this variable with the module
-        auto *Var = new chipstar::DeviceVar(&MutableSrcMod->Variables.back());
-        ChipModule->addDeviceVariable(Var);
-      }
-    }
-  }
+  // hipRTC and hipModuleLoadData code objects have no host registration at
+  // all; a HIP fat binary may still carry variables the host did not register.
+  ChipModule->addUnregisteredDeviceVariables();
 }
 
 void chipstar::Device::invalidateDeviceVariables() {
@@ -1376,68 +1381,9 @@ chipstar::Module *chipstar::Device::getOrCreateModule(HostPtr Ptr) {
     HostPtrToCompiledMod_[Info.Ptr] = Mod;
   }
 
-  // Discover device-only variables (e.g., template instantiations) that weren't
-  // registered via __hipRegisterVar. These have shadow kernels but no host symbol.
-  // Static variables protected by DeviceVarMtx to ensure thread safety.
-  static int DummyHostPtr = 0;
-  // Use unique_ptr for automatic cleanup when the program exits
-  static std::vector<std::unique_ptr<SPVVariable>> SyntheticVars;
-
   {
-    LOCK(DeviceVarMtx); // Protect static SyntheticVars from concurrent access
-    for (auto *Kernel : Mod->getKernels()) {
-      const std::string &KernelName = Kernel->getName();
-      size_t PrefixLen = strlen(ChipVarInfoPrefix);
-
-      // Check if this is a variable info shadow kernel
-      if (KernelName.length() <= PrefixLen ||
-          KernelName.substr(0, PrefixLen) != ChipVarInfoPrefix)
-        continue;
-
-      // Extract variable name
-      std::string VarName = KernelName.substr(PrefixLen);
-
-      // Check if we already processed this variable
-      bool AlreadyRegistered = false;
-      for (const auto &Info : SrcMod->Variables) {
-        std::string NameTmp(Info.Name.begin(), Info.Name.end());
-        if (NameTmp == VarName) {
-          AlreadyRegistered = true;
-          break;
-        }
-      }
-
-      if (AlreadyRegistered)
-        continue;
-
-      // Check if already in SyntheticVars (another thread may have added it)
-      bool AlreadySynthesized = false;
-      for (const auto &SV : SyntheticVars) {
-        if (SV->Name == VarName) {
-          AlreadySynthesized = true;
-          break;
-        }
-      }
-      if (AlreadySynthesized)
-        continue;
-
-      // This is a device-only variable - create a DeviceVar for it
-      logTrace("Found device-only variable: {} (no host symbol)", VarName);
-
-      // Create a synthetic SPVVariable for this device-only variable
-      // Use aggregate initialization since SPVVariable has no default constructor
-      auto *RawVar = new SPVVariable{
-          {const_cast<SPVModule *>(SrcMod), HostPtr(&DummyHostPtr), VarName}, 0};
-      std::unique_ptr<SPVVariable> SyntheticVar(RawVar);
-
-      auto *Var = new chipstar::DeviceVar(SyntheticVar.get());
-      Mod->addDeviceVariable(Var);
-
-      // Store the synthetic variable so it persists (unique_ptr handles cleanup)
-      SyntheticVars.push_back(std::move(SyntheticVar));
-
-      // Note: We don't add to DeviceVarLookup_ since there's no host pointer
-    }
+    LOCK(DeviceVarMtx); // chipstar::Module::ChipVars_
+    Mod->addUnregisteredDeviceVariables();
   }
 
 #ifndef NDEBUG

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -44,6 +44,7 @@
 #include "logging.hh"
 #include "macros.hh"
 #include "CHIPException.hh"
+#include <memory>
 #include <utility>
 
 #include "SPVRegister.hh"
@@ -955,6 +956,12 @@ protected:
   std::mutex Mtx_;
   // Global variables
   std::vector<chipstar::DeviceVar *> ChipVars_;
+  /// Source descriptions of the device variables this module carries but the
+  /// host never registered with __hipRegisterVar, see
+  /// addUnregisteredDeviceVariables(). Owned per module: every module that
+  /// carries such a variable has its own copy of it and needs its own
+  /// storage bound to it.
+  std::vector<std::unique_ptr<SPVVariable>> UnregisteredVars_;
   // Kernels
   std::vector<chipstar::Kernel *> ChipKernels_;
   /// Binary representation extracted from FatBinary.
@@ -1072,6 +1079,11 @@ public:
   }
 
   std::vector<chipstar::DeviceVar *> &getDeviceVariables() { return ChipVars_; }
+
+  /// Record a device variable for every __chip_var_info_<X> shadow kernel of
+  /// this module whose X has no device variable yet. Caller must hold
+  /// DeviceVarMtx.
+  void addUnregisteredDeviceVariables();
 
   hipError_t allocateDeviceVariablesNoLock(chipstar::Device *Device,
                                            chipstar::Queue *Queue);

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -322,6 +322,15 @@ endif()
 # so the test is linked from two translation units, which
 # add_hip_runtime_test cannot express. Run at warn level so the runtime's
 # device variable diagnostics are visible in the log.
+#
+# The function-local static and the inline variable are not lowered by
+# HipGlobalVariables (not externally_initialized, local_unnamed_addr) and stay
+# initialized program-scope globals in the device module. That is what
+# CHIP_ENABLE_DEVICE_PROGRAM_SCOPE_GLOBALS=OFF is built for avoiding: its
+# target drivers (rusticl/radeonsi) reject the module outright ("Initializer
+# for CrossWorkgroup variable not yet supported in Mesa", #1279), so the test
+# is only registered when the option is ON.
+if(CHIP_ENABLE_DEVICE_PROGRAM_SCOPE_GLOBALS)
 set_source_files_properties(TestFixFunctionLocalStaticDeviceVar.hip
   inputs/FunctionLocalStaticDeviceVarTU2.hip PROPERTIES LANGUAGE CXX)
 add_executable(TestFixFunctionLocalStaticDeviceVar
@@ -344,3 +353,4 @@ set_tests_properties(TestFixFunctionLocalStaticDeviceVar PROPERTIES
   SKIP_RETURN_CODE ${CHIP_SKIP_TEST}
   SKIP_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST"
   TIMEOUT 120)
+endif()

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -70,6 +70,7 @@ set(RUNTIME_TESTS_MANUAL
   TestDeviceAbortStderr.hip       # SIGABRT death + stderr checked by a driver script
   TestEnvVars.hip                 # driven by ../run_testenvvars.sh, not by ctest
   TestFix1393ExitDuringModuleBuild.hip # run under an interposer by a driver script
+  TestFixFunctionLocalStaticDeviceVar.hip # multi-TU, second TU under inputs/
   TestFixLlvmUsedAddrspace.hip    # not registered as a test
   TestModuleCacheInvalidation.hip # run several times through a driver script
   TestStreamWaitEventOrdering.cpp # not registered as a test
@@ -315,3 +316,31 @@ if(CHIP_ENABLE_DEVICE_PROGRAM_SCOPE_GLOBALS)
       -P ${CMAKE_SOURCE_DIR}/tests/run_device_abort_stderr_test.cmake)
   set_tests_properties(TestDeviceAbortStderr PROPERTIES TIMEOUT 120)
 endif()
+# Reproducer for the unregistered comdat device variables (a function-local
+# static __device__ variable, an inline __device__ variable, a template static
+# data member). The bug needs two device modules carrying the same variables,
+# so the test is linked from two translation units, which
+# add_hip_runtime_test cannot express. Run at warn level so the runtime's
+# device variable diagnostics are visible in the log.
+set_source_files_properties(TestFixFunctionLocalStaticDeviceVar.hip
+  inputs/FunctionLocalStaticDeviceVarTU2.hip PROPERTIES LANGUAGE CXX)
+add_executable(TestFixFunctionLocalStaticDeviceVar
+  TestFixFunctionLocalStaticDeviceVar.hip
+  inputs/FunctionLocalStaticDeviceVarTU2.hip)
+set_target_properties(TestFixFunctionLocalStaticDeviceVar PROPERTIES
+  CXX_STANDARD_REQUIRED ON)
+target_link_libraries(TestFixFunctionLocalStaticDeviceVar CHIP deviceInternal)
+target_include_directories(TestFixFunctionLocalStaticDeviceVar
+  PRIVATE $<TARGET_PROPERTY:CHIP,INCLUDE_DIRECTORIES>)
+target_compile_definitions(TestFixFunctionLocalStaticDeviceVar
+  PRIVATE CHIP_SKIP_TEST=${CHIP_SKIP_TEST})
+add_test(NAME TestFixFunctionLocalStaticDeviceVar
+  COMMAND ${HIP_PROFILE_TESTS_COMMAND} ${SKIP_DOUBLE_TESTS}
+    ${CMAKE_CURRENT_BINARY_DIR}/TestFixFunctionLocalStaticDeviceVar)
+set_tests_properties(TestFixFunctionLocalStaticDeviceVar PROPERTIES
+  ENVIRONMENT "CHIP_LOGLEVEL=warn"
+  PASS_REGULAR_EXPRESSION "PASS"
+  FAIL_REGULAR_EXPRESSION "FAIL"
+  SKIP_RETURN_CODE ${CHIP_SKIP_TEST}
+  SKIP_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST"
+  TIMEOUT 120)

--- a/tests/runtime/TestFixFunctionLocalStaticDeviceVar.hip
+++ b/tests/runtime/TestFixFunctionLocalStaticDeviceVar.hip
@@ -1,0 +1,167 @@
+// Reproduces: a device module whose comdat device variables (a function-local
+// static __device__ variable in an inline __host__ __device__ function, a C++17
+// inline __device__ variable, a __device__ static data member of a class
+// template) are not registered by the host faults at module initialisation
+// when a second module carries the same variables.
+//
+// HipGlobalVariables.cpp lowers every externally_initialized global into an
+// address slot __chip_var_<X> plus __chip_var_info_<X> / __chip_var_bind_<X>
+// shadow kernels, and __chip_var_init_all writes each variable's initializer
+// through its slot. clang emits no __hipRegisterVar for these variables, so
+// the runtime discovers them from the info kernels instead; that discovery
+// de-duplicates by name across all modules of the process, so only the first
+// module gets storage bound. In every later module the slot stays 0 and
+// __chip_var_init_all writes the initializer to address 0: on Aurora PVC every
+// Trilinos STK NGP test executable dies with "Segmentation fault from GPU at
+// 0x0 ... access: 1 (Write)" (stk_mesh_utest
+// LateFieldsTestFixture.get_ngp_field_multistate_no_seg_fault and all of
+// stk_ngp_test_unit_tests).
+//
+// Two translation units (this file and inputs/FunctionLocalStaticDeviceVarTU2
+// .hip) carry the same three variables. Each module must observe the initial
+// values, a kernel must see a value written by an earlier kernel from the same
+// module, every __chip_var_info_<X> kernel of each module must have storage
+// bound for X, and a plain registered __device__ variable must still round
+// trip through hipMemcpyToSymbol / hipMemcpyFromSymbol / hipGetSymbolAddress.
+
+#include "inputs/FunctionLocalStaticDeviceVar.hh"
+#include "CHIPBackend.hh"
+
+#include <cstdio>
+#include <cstring>
+
+#define CHECK(Expr)                                                            \
+  do {                                                                         \
+    hipError_t E = (Expr);                                                     \
+    if (E != hipSuccess) {                                                     \
+      printf("FAIL: %s -> %s (%d) at line %d\n", #Expr, hipGetErrorString(E), \
+             (int)E, __LINE__);                                                \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+// (4) A plain namespace-scope __device__ variable, which clang does register.
+__device__ int PlainVar = 5;
+
+__global__ void readShapesTU1(int *Out) { readShapes(Out); }
+__global__ void writeShapesTU1(int V) { writeShapes(V); }
+__global__ void readPlain(int *Out) { *Out = PlainVar; }
+
+void launchReadShapesTU2(int *Out);
+void launchWriteShapesTU2(int V);
+const void *readShapesTU2HostPtr();
+
+static int Failures = 0;
+
+static void expectShapes(const char *What, const int *Got, int Want) {
+  printf("%s: local static %d, inline var %d, template member %d, expected "
+         "%d\n",
+         What, Got[0], Got[1], Got[2], Want);
+  for (int I = 0; I < 3; I++)
+    if (Got[I] != Want)
+      Failures++;
+}
+
+// Every __chip_var_info_<X> shadow kernel in a module means the module's code
+// reads X through a __chip_var_<X> address slot that only the runtime can
+// fill. Count the info kernels whose variable has no storage bound.
+static int countUnboundVariables(const char *Label, const void *KernelPtr) {
+  auto *Kernel = Backend->getActiveDevice()->findKernel(HostPtr(KernelPtr));
+  if (!Kernel) {
+    printf("FAIL: %s: kernel not found\n", Label);
+    return 1;
+  }
+  auto *Mod = Kernel->getModule();
+  int Unbound = 0;
+  for (auto *K : Mod->getKernels()) {
+    const std::string &Name = K->getName();
+    if (Name.rfind(ChipVarInfoPrefix, 0) != 0)
+      continue;
+    std::string VarName = Name.substr(strlen(ChipVarInfoPrefix));
+    auto *Var = Mod->getGlobalVar(VarName.c_str());
+    bool Bound = Var && Var->getDevAddr();
+    printf("%s: %s -> %s\n", Label, VarName.c_str(),
+           Bound ? "bound" : "NOT BOUND");
+    if (!Bound)
+      Unbound++;
+  }
+  return Unbound;
+}
+
+int main() {
+  int *Out = nullptr;
+  CHECK(hipMalloc(&Out, 3 * sizeof(int)));
+  int Got[3] = {0, 0, 0};
+
+  // Module 1: initial values, then a write seen by a later kernel.
+  readShapesTU1<<<1, 1>>>(Out);
+  CHECK(hipGetLastError());
+  CHECK(hipDeviceSynchronize());
+  CHECK(hipMemcpy(Got, Out, sizeof(Got), hipMemcpyDeviceToHost));
+  expectShapes("TU1 initial", Got, 7);
+
+  writeShapesTU1<<<1, 1>>>(11);
+  CHECK(hipGetLastError());
+  readShapesTU1<<<1, 1>>>(Out);
+  CHECK(hipGetLastError());
+  CHECK(hipDeviceSynchronize());
+  CHECK(hipMemcpy(Got, Out, sizeof(Got), hipMemcpyDeviceToHost));
+  expectShapes("TU1 after write", Got, 11);
+
+  // Module 2: its own copies, starting from their initializers.
+  launchReadShapesTU2(Out);
+  CHECK(hipGetLastError());
+  CHECK(hipDeviceSynchronize());
+  CHECK(hipMemcpy(Got, Out, sizeof(Got), hipMemcpyDeviceToHost));
+  expectShapes("TU2 initial", Got, 7);
+
+  launchWriteShapesTU2(13);
+  CHECK(hipGetLastError());
+  launchReadShapesTU2(Out);
+  CHECK(hipGetLastError());
+  CHECK(hipDeviceSynchronize());
+  CHECK(hipMemcpy(Got, Out, sizeof(Got), hipMemcpyDeviceToHost));
+  expectShapes("TU2 after write", Got, 13);
+
+  // Module 1 is unaffected by module 2's writes.
+  readShapesTU1<<<1, 1>>>(Out);
+  CHECK(hipGetLastError());
+  CHECK(hipDeviceSynchronize());
+  CHECK(hipMemcpy(Got, Out, sizeof(Got), hipMemcpyDeviceToHost));
+  expectShapes("TU1 after TU2 write", Got, 11);
+
+  int Unbound =
+      countUnboundVariables("TU1 module",
+                            reinterpret_cast<const void *>(readShapesTU1)) +
+      countUnboundVariables("TU2 module", readShapesTU2HostPtr());
+  if (Unbound) {
+    printf("FAIL: %d device variables have no storage bound\n", Unbound);
+    Failures++;
+  }
+
+  // (4) A registered variable keeps working from the host.
+  int V = 9;
+  CHECK(hipMemcpyToSymbol(HIP_SYMBOL(PlainVar), &V, sizeof(int)));
+  readPlain<<<1, 1>>>(Out);
+  CHECK(hipGetLastError());
+  CHECK(hipDeviceSynchronize());
+  CHECK(hipMemcpy(Got, Out, sizeof(int), hipMemcpyDeviceToHost));
+  int Back = 0;
+  CHECK(hipMemcpyFromSymbol(&Back, HIP_SYMBOL(PlainVar), sizeof(int)));
+  void *Addr = nullptr;
+  CHECK(hipGetSymbolAddress(&Addr, HIP_SYMBOL(PlainVar)));
+  printf("plain var: kernel read %d, hipMemcpyFromSymbol %d, expected 9, "
+         "hipGetSymbolAddress %p\n",
+         Got[0], Back, Addr);
+  if (Got[0] != 9 || Back != 9 || !Addr)
+    Failures++;
+
+  CHECK(hipFree(Out));
+
+  if (Failures) {
+    printf("FAIL: %d mismatches\n", Failures);
+    return 1;
+  }
+  printf("PASS\n");
+  return 0;
+}

--- a/tests/runtime/inputs/FunctionLocalStaticDeviceVar.hh
+++ b/tests/runtime/inputs/FunctionLocalStaticDeviceVar.hh
@@ -1,0 +1,49 @@
+// Device variables shared by the two translation units of
+// TestFixFunctionLocalStaticDeviceVar. Each TU that includes this header gets
+// its own linkonce_odr comdat copy of every variable below in its own device
+// module, and clang registers none of them with __hipRegisterVar (a
+// function-local static is never registered; an inline variable and a
+// template static data member are registered only when host code ODR-uses
+// them).
+#ifndef FUNCTION_LOCAL_STATIC_DEVICE_VAR_HH
+#define FUNCTION_LOCAL_STATIC_DEVICE_VAR_HH
+
+#include <hip/hip_runtime.h>
+
+struct Reporter {
+  int Count;
+  int Pad[3];
+};
+
+// (1) A function-local static __device__ variable in an inline
+// __host__ __device__ function: the shape of Trilinos STK
+// stk_ngp_test/GlobalReporter.hpp getDeviceReporterOnDevice().
+inline __host__ __device__ Reporter *localStaticReporter() {
+  static __device__ Reporter Rep = {7, {0, 0, 0}};
+  return &Rep;
+}
+
+// (2) A C++17 inline __device__ namespace-scope variable.
+namespace shapes {
+inline __device__ int InlineVar = 7;
+}
+
+// (3) A __device__ static data member of a class template.
+template <typename T> struct Holder {
+  static __device__ T Member;
+};
+template <typename T> __device__ T Holder<T>::Member = T(7);
+
+__device__ inline void readShapes(int *Out) {
+  Out[0] = localStaticReporter()->Count;
+  Out[1] = shapes::InlineVar;
+  Out[2] = Holder<int>::Member;
+}
+
+__device__ inline void writeShapes(int V) {
+  localStaticReporter()->Count = V;
+  shapes::InlineVar = V;
+  Holder<int>::Member = V;
+}
+
+#endif

--- a/tests/runtime/inputs/FunctionLocalStaticDeviceVarTU2.hip
+++ b/tests/runtime/inputs/FunctionLocalStaticDeviceVarTU2.hip
@@ -1,0 +1,12 @@
+// Second translation unit of TestFixFunctionLocalStaticDeviceVar: a second
+// device module carrying the same unregistered comdat device variables.
+#include "FunctionLocalStaticDeviceVar.hh"
+
+__global__ void readShapesTU2(int *Out) { readShapes(Out); }
+__global__ void writeShapesTU2(int V) { writeShapes(V); }
+
+void launchReadShapesTU2(int *Out) { readShapesTU2<<<1, 1>>>(Out); }
+void launchWriteShapesTU2(int V) { writeShapesTU2<<<1, 1>>>(V); }
+const void *readShapesTU2HostPtr() {
+  return reinterpret_cast<const void *>(readShapesTU2);
+}


### PR DESCRIPTION
clang does not register comdat device variables (a function local static `__device__` variable, a C++17 inline `__device__` variable, a `__device__` static data member of a class template) with `__hipRegisterVar`, so the runtime discovers them from the `__chip_var_info_<X>` shadow kernels. That discovery de duplicated by name across all modules of the process, so when a second module carried the same variables it never got storage bound and `__chip_var_init_all` wrote the initializer through a zero address slot.

The runtime now binds storage for every unregistered variable in each module that carries it, and `registerModuleVariables` / `getOrCreateModule` share one path for that. The reproducer links two translation units with the same comdat variables, checks that every `__chip_var_info_<X>` kernel of each module has storage bound, and that a plain registered variable still round trips through `hipMemcpyToSymbol`, `hipMemcpyFromSymbol` and `hipGetSymbolAddress`.

Found with the Trilinos STK NGP tests on Aurora PVC, where every STK test executable faulted at module initialisation with `Segmentation fault from GPU at 0x0`.

Fixes #1500
