### PR TITLE
Keep the interior offset in hipHostGetDevicePointer and range-check registered host memory correctly

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -277,16 +277,20 @@ chipstar::AllocationTracker::getAllocInfoCheckPtrRanges(void *DevPtr) {
   // Note: This function is called from within a locked context
 
   // upper_bound gives the first entry with key > DevPtr; step back one to get
-  // the candidate whose start address is <= DevPtr, then range-check it.
+  // the candidate whose start address is <= DevPtr, then range-check it. The
+  // key is the start of either the host or the device range of the record, so
+  // the range is measured from the key: a hipHostRegister'ed record has a host
+  // range at a different address than its device range, and no device range
+  // at all until hipHostGetDevicePointer creates the backing.
   const auto It = PtrToAllocInfo_.upper_bound(DevPtr);
   if (It == PtrToAllocInfo_.cbegin())
     return nullptr;
 
-  chipstar::AllocationInfo *AllocInfo = std::prev(It)->second;
-  void *End = (char*) AllocInfo->DevPtr + AllocInfo->Size;
+  const auto &Candidate = *std::prev(It);
+  void *End = static_cast<char *>(Candidate.first) + Candidate.second->Size;
 
   if (DevPtr < End)
-    return AllocInfo;
+    return Candidate.second;
 
   return nullptr;
 }

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -2218,13 +2218,18 @@ chipstar::Queue::RegisteredVarCopy(chipstar::ExecItem *ExecItem,
       if (ModInfo.HasNoIGBAs) {
         bool IsKernelArg = false;
         const auto &FuncInfo = *ExecItem->getKernel()->getFuncInfo();
+        void *DevBegin = AllocInfo.DevPtr;
+        void *DevEnd = static_cast<char *>(AllocInfo.DevPtr) + AllocInfo.Size;
         FuncInfo.visitKernelArgs(ExecItem->getArgs(),
                                  [&](const SPVFuncInfo::KernelArg &Arg) {
                                    if (Arg.Kind == SPVTypeKind::Pointer &&
                                        !Arg.isWorkgroupPtr()) {
                                      void *PtrVal = *static_cast<void **>(
                                          const_cast<void *>(Arg.Data));
-                                     if (PtrVal == AllocInfo.DevPtr)
+                                     // The argument may point anywhere inside
+                                     // the allocation, e.g. the device pointer
+                                     // of an interior host pointer.
+                                     if (PtrVal >= DevBegin && PtrVal < DevEnd)
                                        IsKernelArg = true;
                                    }
                                  });

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -4415,6 +4415,19 @@ hipError_t hipHostGetDevicePointer(void **DevPtr, void *HostPtr,
                           "registered with hipHostRegister!",
                           hipErrorInvalidValue);
 
+  // HostPtr may point anywhere inside the allocation and the device pointer
+  // must carry the same offset from the device base. The offset is measured
+  // from whichever range of the record contains HostPtr: the host range when
+  // there is one (mapped host USM and unified allocations record
+  // HostPtr = DevPtr), else the device range.
+  auto InRange = [&](void *Start) {
+    return Start && HostPtr >= Start &&
+           HostPtr < static_cast<char *>(Start) + AllocInfo->Size;
+  };
+  char *Base = static_cast<char *>(
+      InRange(AllocInfo->HostPtr) ? AllocInfo->HostPtr : AllocInfo->DevPtr);
+  size_t Offset = static_cast<char *>(HostPtr) - Base;
+
   if (AllocInfo->DevPtr == nullptr) {
     // First call: erase the deferred placeholder and allocate backing device
     // memory now.
@@ -4427,11 +4440,13 @@ hipError_t hipHostGetDevicePointer(void **DevPtr, void *HostPtr,
       RETURN(hipErrorInvalidValue);
     CHIP_CATCH_RETURN_CODE(hipErrorInvalidValue)
 
-    Device->AllocTracker->registerHostPointer(HostPtr, DevPtr_internal);
-    *DevPtr = DevPtr_internal;
+    // Register the base of the host range, not the queried pointer, so that
+    // later queries at any offset resolve to this record.
+    Device->AllocTracker->registerHostPointer(Base, DevPtr_internal);
+    *DevPtr = static_cast<char *>(DevPtr_internal) + Offset;
   }
   else {
-    *DevPtr = AllocInfo->DevPtr;
+    *DevPtr = static_cast<char *>(AllocInfo->DevPtr) + Offset;
   }
   RETURN(hipSuccess);
   CHIP_CATCH

--- a/tests/runtime/TestFixHostGetDevicePointerOffset.hip
+++ b/tests/runtime/TestFixHostGetDevicePointerOffset.hip
@@ -1,0 +1,148 @@
+// Reproduces: hipHostGetDevicePointer() called on a pointer inside a
+// hipHostMalloc(hipHostMallocMapped) or hipHostRegister(hipHostRegisterMapped)
+// buffer returns the device address of the allocation base, dropping the
+// offset of the queried pointer within the allocation. Trilinos STK does one
+// hipHostMalloc per bucket and asks for the device pointer of every field's
+// interior pointer (stk_mesh FieldDataManager get_host_pointer_for_device), so
+// every field but the first gets a device pointer to the wrong bytes.
+//
+// For several interior pointers this checks two things: the returned device
+// pointer has the same offset from the base's device pointer as the host
+// pointer has from the host base, and a kernel reading one word through the
+// returned device pointer sees the value the host wrote at that interior
+// pointer. The hipHostRegister half queries an interior pointer before the
+// base, which is the order STK uses, so the lazily created device backing is
+// exercised the same way.
+
+#include <hip/hip_runtime.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#define CHECK(Expr)                                                            \
+  do {                                                                         \
+    hipError_t E = (Expr);                                                     \
+    if (E != hipSuccess) {                                                     \
+      printf("FAIL: %s -> %s (%d) at line %d\n", #Expr, hipGetErrorString(E),  \
+             (int)E, __LINE__);                                                \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+constexpr size_t Size = 1u << 20; // 1 MiB
+constexpr size_t Offsets[] = {4096, 65536 + 8, Size - 8};
+constexpr size_t NumOffsets = sizeof(Offsets) / sizeof(Offsets[0]);
+
+__global__ void readWord(const uint32_t *In, uint32_t *Out) { *Out = *In; }
+
+static int Failures = 0;
+
+static void fillPattern(char *Base) {
+  for (size_t I = 0; I < Size / sizeof(uint32_t); I++) {
+    uint32_t W = 0x9e3779b9u * (uint32_t)I + 0x1234567u;
+    std::memcpy(Base + I * sizeof(uint32_t), &W, sizeof(W));
+  }
+}
+
+// Queries the device pointer of Base + Offset and verifies both the pointer
+// arithmetic against DevBase and the bytes a kernel reads through it.
+static int checkInterior(const char *What, char *Base, void *DevBase,
+                         size_t Offset, uint32_t *DevOut) {
+  char *H = Base + Offset;
+  void *Dev = nullptr;
+  CHECK(hipHostGetDevicePointer(&Dev, H, 0));
+  ptrdiff_t DevOff = (char *)Dev - (char *)DevBase;
+  printf("%s: host base+%zu -> device base%+td\n", What, Offset, DevOff);
+  if (DevOff != (ptrdiff_t)Offset) {
+    printf("  mismatch: device offset %td, expected %zu\n", DevOff, Offset);
+    Failures++;
+  }
+
+  const uint32_t Sentinel = 0xdeadbeefu;
+  CHECK(hipMemcpy(DevOut, &Sentinel, sizeof(Sentinel), hipMemcpyHostToDevice));
+  readWord<<<1, 1>>>((const uint32_t *)Dev, DevOut);
+  CHECK(hipGetLastError());
+  CHECK(hipDeviceSynchronize());
+  uint32_t Got = 0;
+  CHECK(hipMemcpy(&Got, DevOut, sizeof(Got), hipMemcpyDeviceToHost));
+  uint32_t Want;
+  std::memcpy(&Want, H, sizeof(Want));
+  if (Got != Want) {
+    printf("  mismatch: kernel read 0x%08x through the device pointer, host "
+           "holds 0x%08x at that offset\n",
+           Got, Want);
+    Failures++;
+  }
+  return 0;
+}
+
+static int testHostMalloc(uint32_t *DevOut) {
+  char *Base = nullptr;
+  CHECK(hipHostMalloc((void **)&Base, Size, hipHostMallocMapped));
+  fillPattern(Base);
+
+  void *DevBase = nullptr;
+  CHECK(hipHostGetDevicePointer(&DevBase, Base, 0));
+  printf("hipHostMalloc: host %p -> device %p\n", (void *)Base, DevBase);
+
+  for (size_t I = 0; I < NumOffsets; I++)
+    if (checkInterior("hipHostMalloc", Base, DevBase, Offsets[I], DevOut))
+      return 1;
+
+  CHECK(hipHostFree(Base));
+  return 0;
+}
+
+static int testHostRegister(uint32_t *DevOut) {
+  char *Base = nullptr;
+  if (posix_memalign((void **)&Base, 4096, Size) != 0 || !Base) {
+    printf("FAIL: posix_memalign\n");
+    return 1;
+  }
+  fillPattern(Base);
+  CHECK(hipHostRegister(Base, Size, hipHostRegisterMapped));
+
+  // Interior pointer first: this is the query that creates the device backing.
+  void *DevFirst = nullptr;
+  CHECK(hipHostGetDevicePointer(&DevFirst, Base + Offsets[0], 0));
+
+  void *DevBase = nullptr;
+  CHECK(hipHostGetDevicePointer(&DevBase, Base, 0));
+  printf("hipHostRegister: host %p -> device %p\n", (void *)Base, DevBase);
+
+  ptrdiff_t FirstOff = (char *)DevFirst - (char *)DevBase;
+  if (FirstOff != (ptrdiff_t)Offsets[0]) {
+    printf("  mismatch: first query (base+%zu) sits at device base%+td\n",
+           Offsets[0], FirstOff);
+    Failures++;
+  }
+
+  for (size_t I = 0; I < NumOffsets; I++)
+    if (checkInterior("hipHostRegister", Base, DevBase, Offsets[I], DevOut))
+      return 1;
+
+  CHECK(hipHostUnregister(Base));
+  free(Base);
+  return 0;
+}
+
+int main() {
+  uint32_t *DevOut = nullptr;
+  CHECK(hipMalloc(&DevOut, sizeof(uint32_t)));
+
+  if (testHostMalloc(DevOut))
+    return 1;
+  if (testHostRegister(DevOut))
+    return 1;
+
+  CHECK(hipFree(DevOut));
+
+  if (Failures) {
+    printf("FAIL: %d mismatches\n", Failures);
+    return 1;
+  }
+  printf("PASS\n");
+  return 0;
+}


### PR DESCRIPTION
`hipHostGetDevicePointer()` on a pointer inside a `hipHostMalloc(Mapped)` or `hipHostRegister(Mapped)` buffer returned the device base of the allocation instead of base plus offset, and for a registered range an interior pointer queried before the base failed the lookup outright because `getAllocInfoCheckPtrRanges()` measured the record's extent from the still null `DevPtr` rather than from the key it matched. This keeps the interior offset in the returned device pointer (as ROCm does), range-checks against the matched key, registers the host base rather than the queried pointer when the device backing is created lazily, and makes `RegisteredVarCopy()` sync a registered range when a kernel argument points anywhere inside its backing rather than only at its base. Found with Trilinos STK on Aurora PVC, which does one `hipHostMalloc` per bucket and asks for the device pointer of each field's interior pointer. `TestFixHostGetDevicePointerOffset` covers both the `hipHostMalloc` and the `hipHostRegister` paths.

Fixes #1505
