### PR TITLE
Level Zero: drop the terminating NUL from the module build log and skip empty logs

### DIFF
--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -26,6 +26,7 @@
 
 #include <chrono>
 #include <cstdlib>
+#include <cstring>
 #include <ctime>
 #include <fstream>
 
@@ -3153,9 +3154,15 @@ std::string resultToString(ze_result_t zeStatus) {
 // CHIPModuleLevel0
 // ***********************************************************************
 
-/// Dumps build/link log into the error log stream and returns its contents.
-/// The 'Log' value must be a valid handle. This function will destroy the log
-/// handle.
+/// Dumps a non-empty build/link log into the info log stream and returns its
+/// contents. The 'Log' value must be a valid handle. This function will
+/// destroy the log handle.
+///
+/// The size zeModuleBuildLogGetString reports counts the terminating NUL
+/// (the spec calls pBuildLog a null-terminated string; the Compute Runtime
+/// returns buildLog.size() + 1), so the string is cut at the first NUL: a NUL
+/// on stderr truncates it for any parent that reads the stream back as a C
+/// string, which is how gtest death tests match the child's abort message.
 static std::string dumpBuildLog(ze_module_build_log_handle_t &&Log) {
   std::string LogStr;
   size_t LogSize;
@@ -3164,8 +3171,9 @@ static std::string dumpBuildLog(ze_module_build_log_handle_t &&Log) {
     std::vector<char> LogVec(LogSize);
     zeStatus = zeModuleBuildLogGetString(Log, &LogSize, LogVec.data());
     if (zeStatus == ZE_RESULT_SUCCESS) {
-      LogStr.assign(LogVec.data(), LogSize);
-      logInfo("ZE Build Log:\n{}", LogStr);
+      LogStr.assign(LogVec.data(), strnlen(LogVec.data(), LogSize));
+      if (!LogStr.empty())
+        logInfo("ZE Build Log:\n{}", LogStr);
     }
   }
 

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -113,6 +113,13 @@ if(SPIRV_DIS AND (NOT USE_NEW_OFFLOAD_DRIVER OR CLANG_OFFLOAD_BUNDLER))
   add_shell_test(TestBoolKernelParamSPIRV.bash)
 endif()
 
+# The runtime's stderr must stay NUL-free at CHIP_LOGLEVEL=info (the Level
+# Zero build log dump wrote the driver's terminating NUL and printed the
+# "ZE Build Log:" line for empty logs; gtest death tests read captured stderr
+# as a C string). Runs TestKernelArgs and inspects its stderr; only meaningful
+# for the build log path on the Level Zero backend.
+add_shell_test(TestFixZeBuildLogNul.bash)
+
 add_shell_test(../run_testenvvars.sh)
 set_tests_properties(run_testenvvars PROPERTIES
   TIMEOUT 60)

--- a/tests/runtime/TestFixZeBuildLogNul.bash
+++ b/tests/runtime/TestFixZeBuildLogNul.bash
@@ -1,0 +1,68 @@
+#!/bin/bash
+# The runtime's diagnostic output must be NUL-free, and a build log must only
+# be printed when there is one.
+#
+# The Level Zero backend's dumpBuildLog() copies zeModuleBuildLogGetString's
+# output into a std::string using the size the driver reports, which counts
+# the terminating NUL, and logs "ZE Build Log:\n<log>" at info level for every
+# zeModuleCreate, empty log or not. At CHIP_LOGLEVEL=info this puts a literal
+# NUL byte on stderr after each "ZE Build Log:" line. gtest death tests treat
+# the child's captured stderr as a C string, so on PVC the NUL truncated it
+# before the expected abort message and every Kokkos_CoreUnitTest_HIP death
+# test failed with "died but not with expected error".
+#
+# Runs TestKernelArgs (any small test that builds a module will do) at info
+# level, captures stderr and fails if it holds a NUL byte, or if a
+# "ZE Build Log:" line is followed by an empty log. Both checks are backend
+# agnostic. Only the Level Zero backend prints "ZE Build Log:", so on an
+# OpenCL run (the CPU gate) a pass proves only that the OpenCL path is clean;
+# run with CHIP_BE=level0 to exercise the path this guards.
+set -u
+
+BIN="@CMAKE_CURRENT_BINARY_DIR@/TestKernelArgs"
+OUT="@CMAKE_CURRENT_BINARY_DIR@/@TEST_NAME@.d"
+
+rm -rf "${OUT}"
+mkdir -p "${OUT}"
+cd "${OUT}"
+
+CHIP_LOGLEVEL=info "${BIN}" > stdout.log 2> stderr.log
+RC=$?
+if [ "${RC}" -ne 0 ]; then
+  echo "FAIL: ${BIN} exited with ${RC}"
+  exit 1
+fi
+
+STATUS=0
+fail() {
+  echo "FAIL: $1"
+  STATUS=1
+}
+
+# Backend actually exercised, for the record.
+if grep -q "ZE Build Log:" stderr.log; then
+  echo "Level Zero backend: 'ZE Build Log:' lines seen"
+else
+  echo "NOTE: no 'ZE Build Log:' line; the Level Zero backend was not exercised"
+fi
+
+NULS=$(tr -cd '\000' < stderr.log | wc -c)
+if [ "${NULS}" -ne 0 ]; then
+  fail "stderr contains ${NULS} NUL byte(s):"
+  grep -a -n -B1 -P '\x00' stderr.log | head -6 | cat -v
+fi
+
+# Each "ZE Build Log:" line must be followed by a non-empty log line. NULs are
+# stripped first so this check is about printing for nothing, not about the
+# NUL itself.
+EMPTY=$(tr -d '\000' < stderr.log |
+        awk '/ZE Build Log:/ { getline nxt; if (nxt == "") n++ } END { print n+0 }')
+if [ "${EMPTY}" -ne 0 ]; then
+  fail "${EMPTY} 'ZE Build Log:' line(s) printed with an empty log"
+fi
+
+if [ "${STATUS}" -ne 0 ]; then
+  echo "See ${OUT}/stderr.log"
+  exit 1
+fi
+echo "PASSED"


### PR DESCRIPTION
The Level Zero backend copied the module build log into a `std::string` of the full size reported by `zeModuleBuildLogGetString`, which includes the driver's terminating NUL, and printed a `ZE Build Log:` line even when the log was empty. The NUL byte reached stderr at `CHIP_LOGLEVEL=info`, and gtest death tests read captured stderr as a C string, so their stderr matchers saw a truncated log.

`dumpBuildLog` now strips the trailing NUL and returns nothing for an empty log, so the `ZE Build Log:` line is only printed when there is something to show. The new `TestFixZeBuildLogNul` runs `TestKernelArgs` at info level and fails on a NUL byte or an empty build log on stderr.

Found with the Kokkos gtest death tests on Aurora PVC.

Fixes #1510
