### PR TITLE
build: hand the SPIRV-Tools external its compilers as full paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,55 +578,7 @@ add_subdirectory(bin)
 find_package(SPIRV-Tools)
 if (NOT SPIRV-Tools_FOUND)
   message(STATUS "spirv-tools not found, building...")
-  # Download and build SPIRV-Tools
-  include(ExternalProject)
-  
-  set(SPIRV_TOOLS_VERSION "main")
-  set(SPIRV_TOOLS_INSTALL_DIR "${CMAKE_BINARY_DIR}/external/spirv-tools")
-  
-  # Create the include directory before it's referenced
-  file(MAKE_DIRECTORY "${SPIRV_TOOLS_INSTALL_DIR}/include")
-  file(MAKE_DIRECTORY "${SPIRV_TOOLS_INSTALL_DIR}/lib")
-  
-  set(CHIPSTAR_C_COMPILER gcc)
-  set(CHIPSTAR_CXX_COMPILER g++)
-  message(STATUS "CHIPSTAR_C_COMPILER: ${CHIPSTAR_C_COMPILER}")
-  message(STATUS "CHIPSTAR_CXX_COMPILER: ${CHIPSTAR_CXX_COMPILER}")
-  ExternalProject_Add(SPIRV-Tools-External
-    GIT_REPOSITORY   https://github.com/CHIP-SPV/SPIRV-Tools.git
-    GIT_TAG          ${SPIRV_TOOLS_VERSION}
-    GIT_SHALLOW      TRUE
-    SOURCE_SUBDIR    "."
-    CMAKE_ARGS
-      -DCMAKE_INSTALL_PREFIX=${SPIRV_TOOLS_INSTALL_DIR}
-      -DSPIRV_SKIP_TESTS=ON
-      -DCMAKE_C_COMPILER=${CHIPSTAR_C_COMPILER}
-      -DCMAKE_CXX_COMPILER=${CHIPSTAR_CXX_COMPILER}
-      -DCMAKE_INSTALL_LIBDIR=lib
-      -DSPIRV_TOOLS_INSTALL_HEADERS=ON
-      -DSPIRV_TOOLS_BUILD_STATIC=ON
-      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-    UPDATE_COMMAND   ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> python3 utils/git-sync-deps
-    LOG_DOWNLOAD ON
-    LOG_UPDATE ON
-    LOG_CONFIGURE ON
-    LOG_BUILD ON
-    LOG_INSTALL ON
-    BUILD_BYPRODUCTS 
-      ${SPIRV_TOOLS_INSTALL_DIR}/lib/libSPIRV-Tools.a
-      ${SPIRV_TOOLS_INSTALL_DIR}/lib/libSPIRV-Tools-opt.a
-      ${SPIRV_TOOLS_INSTALL_DIR}/lib/libSPIRV-Tools-link.a
-      ${SPIRV_TOOLS_INSTALL_DIR}/lib/libSPIRV-Tools-reduce.a
-  )
-
-  # Create an imported target for SPIRV-Tools
-  add_library(SPIRV-Tools STATIC IMPORTED GLOBAL)
-  add_dependencies(SPIRV-Tools SPIRV-Tools-External)
-  
-  set_target_properties(SPIRV-Tools PROPERTIES
-    IMPORTED_LOCATION "${SPIRV_TOOLS_INSTALL_DIR}/lib/libSPIRV-Tools.a"
-    INTERFACE_INCLUDE_DIRECTORIES "${SPIRV_TOOLS_INSTALL_DIR}/include"
-  )
+  include(cmake/SpirvToolsExternal.cmake)
 else()
   message(STATUS "spirv-tools: ${SPIRV-Tools_FOUND}")
 endif()

--- a/cmake/SpirvToolsExternal.cmake
+++ b/cmake/SpirvToolsExternal.cmake
@@ -12,8 +12,14 @@ set(SPIRV_TOOLS_INSTALL_DIR "${CMAKE_BINARY_DIR}/external/spirv-tools")
 file(MAKE_DIRECTORY "${SPIRV_TOOLS_INSTALL_DIR}/include")
 file(MAKE_DIRECTORY "${SPIRV_TOOLS_INSTALL_DIR}/lib")
 
-set(CHIPSTAR_C_COMPILER gcc)
-set(CHIPSTAR_CXX_COMPILER g++)
+# Full paths, not bare names: the external's configure step re-runs on every
+# build (UPDATE_COMMAND is never up to date) and passes these again each time.
+# A bare name is resolved through PATH at every run, and a PATH that resolves
+# it differently between two runs makes cmake treat the compiler as changed,
+# delete the external's cache and reconfigure with only the compiler entries,
+# which sends the install to /usr/local (#1486).
+find_program(CHIPSTAR_C_COMPILER gcc REQUIRED)
+find_program(CHIPSTAR_CXX_COMPILER g++ REQUIRED)
 message(STATUS "CHIPSTAR_C_COMPILER: ${CHIPSTAR_C_COMPILER}")
 message(STATUS "CHIPSTAR_CXX_COMPILER: ${CHIPSTAR_CXX_COMPILER}")
 ExternalProject_Add(SPIRV-Tools-External

--- a/cmake/SpirvToolsExternal.cmake
+++ b/cmake/SpirvToolsExternal.cmake
@@ -1,0 +1,53 @@
+# Builds SPIRV-Tools from source as an ExternalProject when find_package did
+# not find an installed copy, and exposes it as the imported target
+# SPIRV-Tools rooted at ${CMAKE_BINARY_DIR}/external/spirv-tools.
+
+# Download and build SPIRV-Tools
+include(ExternalProject)
+
+set(SPIRV_TOOLS_VERSION "main")
+set(SPIRV_TOOLS_INSTALL_DIR "${CMAKE_BINARY_DIR}/external/spirv-tools")
+
+# Create the include directory before it's referenced
+file(MAKE_DIRECTORY "${SPIRV_TOOLS_INSTALL_DIR}/include")
+file(MAKE_DIRECTORY "${SPIRV_TOOLS_INSTALL_DIR}/lib")
+
+set(CHIPSTAR_C_COMPILER gcc)
+set(CHIPSTAR_CXX_COMPILER g++)
+message(STATUS "CHIPSTAR_C_COMPILER: ${CHIPSTAR_C_COMPILER}")
+message(STATUS "CHIPSTAR_CXX_COMPILER: ${CHIPSTAR_CXX_COMPILER}")
+ExternalProject_Add(SPIRV-Tools-External
+  GIT_REPOSITORY   https://github.com/CHIP-SPV/SPIRV-Tools.git
+  GIT_TAG          ${SPIRV_TOOLS_VERSION}
+  GIT_SHALLOW      TRUE
+  SOURCE_SUBDIR    "."
+  CMAKE_ARGS
+    -DCMAKE_INSTALL_PREFIX=${SPIRV_TOOLS_INSTALL_DIR}
+    -DSPIRV_SKIP_TESTS=ON
+    -DCMAKE_C_COMPILER=${CHIPSTAR_C_COMPILER}
+    -DCMAKE_CXX_COMPILER=${CHIPSTAR_CXX_COMPILER}
+    -DCMAKE_INSTALL_LIBDIR=lib
+    -DSPIRV_TOOLS_INSTALL_HEADERS=ON
+    -DSPIRV_TOOLS_BUILD_STATIC=ON
+    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+  UPDATE_COMMAND   ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> python3 utils/git-sync-deps
+  LOG_DOWNLOAD ON
+  LOG_UPDATE ON
+  LOG_CONFIGURE ON
+  LOG_BUILD ON
+  LOG_INSTALL ON
+  BUILD_BYPRODUCTS 
+    ${SPIRV_TOOLS_INSTALL_DIR}/lib/libSPIRV-Tools.a
+    ${SPIRV_TOOLS_INSTALL_DIR}/lib/libSPIRV-Tools-opt.a
+    ${SPIRV_TOOLS_INSTALL_DIR}/lib/libSPIRV-Tools-link.a
+    ${SPIRV_TOOLS_INSTALL_DIR}/lib/libSPIRV-Tools-reduce.a
+)
+
+# Create an imported target for SPIRV-Tools
+add_library(SPIRV-Tools STATIC IMPORTED GLOBAL)
+add_dependencies(SPIRV-Tools SPIRV-Tools-External)
+
+set_target_properties(SPIRV-Tools PROPERTIES
+  IMPORTED_LOCATION "${SPIRV_TOOLS_INSTALL_DIR}/lib/libSPIRV-Tools.a"
+  INTERFACE_INCLUDE_DIRECTORIES "${SPIRV_TOOLS_INSTALL_DIR}/include"
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,3 +48,14 @@ if(CMAKE_GENERATOR MATCHES "Ninja" AND Python3_Interpreter_FOUND)
       --ninja ${CMAKE_MAKE_PROGRAM} --build-dir ${CMAKE_BINARY_DIR}
       --required $<TARGET_FILE:LLVMHipPasses> ${BUILD_ORDER_PROBES})
 endif()
+
+# Reproduce #1486: the SPIRV-Tools ExternalProject named its compilers by bare
+# name, so a PATH that differs between two builds made cmake wipe the
+# external's cache and `ninja install` wrote to /usr/local. Script test:
+# configures the module on its own and drives the generated configure step.
+add_test(NAME TestFix1486SpirvToolsInstallPrefix
+  COMMAND ${CMAKE_COMMAND}
+    -DCHIPSTAR_SOURCE_DIR=${CMAKE_SOURCE_DIR}
+    -DGENERATOR=${CMAKE_GENERATOR}
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/TestFix1486SpirvToolsInstallPrefix.cmake)
+set_tests_properties(TestFix1486SpirvToolsInstallPrefix PROPERTIES TIMEOUT 300)

--- a/tests/TestFix1486SpirvToolsInstallPrefix.cmake
+++ b/tests/TestFix1486SpirvToolsInstallPrefix.cmake
@@ -1,0 +1,132 @@
+# Reproduces #1486: the SPIRV-Tools ExternalProject installs to /usr/local.
+#
+# cmake/SpirvToolsExternal.cmake hands the external project its compilers as
+# CMAKE_ARGS. The external's configure step re-runs on every build (its
+# UPDATE_COMMAND is never up to date), and each run passes those arguments to
+# cmake again. If the compiler argument is a bare name, cmake resolves it
+# through PATH at every run; when PATH differs between two runs (a module
+# loaded in one shell but not the other, `ninja` then `ninja install` from
+# different environments) the resolved path changes, cmake declares the
+# compiler changed, deletes CMakeCache.txt and re-runs configure keeping only
+# the compiler entries: CMAKE_INSTALL_PREFIX, CMAKE_INSTALL_LIBDIR and every
+# other CMAKE_ARGS value revert to their defaults, and `ninja install` then
+# tries to write /usr/local/lib64.
+#
+# The check configures a tiny project that includes the module, then runs the
+# configure step cmake generated for the external project twice against a stub
+# source tree: once with the ambient PATH and once with a directory of gcc/g++
+# symlinks prepended. Whatever the external's CMakeCache.txt says afterwards
+# is what `ninja install` would use, so CMAKE_INSTALL_PREFIX must still lie
+# inside the build tree and CMAKE_INSTALL_LIBDIR must still be lib. No real
+# SPIRV-Tools source is downloaded, built or installed.
+#
+# Invoked as:
+#   cmake -DCHIPSTAR_SOURCE_DIR=<chipStar source> -DGENERATOR=<generator>
+#         -P TestFix1486SpirvToolsInstallPrefix.cmake
+
+if(NOT CHIPSTAR_SOURCE_DIR)
+  message(FATAL_ERROR "CHIPSTAR_SOURCE_DIR not set")
+endif()
+if(NOT GENERATOR)
+  set(GENERATOR "Ninja")
+endif()
+
+find_program(REAL_GCC gcc)
+find_program(REAL_GXX g++)
+if(NOT REAL_GCC OR NOT REAL_GXX)
+  message(FATAL_ERROR "gcc and g++ are required (the external project builds with them)")
+endif()
+
+string(RANDOM LENGTH 12 ALPHABET "abcdefghijklmnopqrstuvwxyz0123456789" SUFFIX)
+set(SCRATCH_DIR "$ENV{TMPDIR}")
+if(NOT SCRATCH_DIR)
+  set(SCRATCH_DIR "/tmp")
+endif()
+set(SCRATCH_DIR "${SCRATCH_DIR}/chipstar-spirv-tools-external-${SUFFIX}")
+file(REMOVE_RECURSE "${SCRATCH_DIR}")
+file(MAKE_DIRECTORY "${SCRATCH_DIR}")
+
+# A consumer of the module: the same ExternalProject_Add chipStar runs, with
+# its install prefix under this consumer's build tree.
+set(CONSUMER_DIR "${SCRATCH_DIR}/consumer")
+set(CONSUMER_BUILD "${CONSUMER_DIR}/build")
+file(WRITE "${CONSUMER_DIR}/CMakeLists.txt"
+  "cmake_minimum_required(VERSION 3.20)\n"
+  "project(SpirvToolsExternalProbe NONE)\n"
+  "include(${CHIPSTAR_SOURCE_DIR}/cmake/SpirvToolsExternal.cmake)\n")
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -G "${GENERATOR}" -DCMAKE_BUILD_TYPE=Release
+          -S "${CONSUMER_DIR}" -B "${CONSUMER_BUILD}"
+  RESULT_VARIABLE RC OUTPUT_VARIABLE OUT ERROR_VARIABLE ERR)
+if(NOT RC EQUAL 0)
+  message(FATAL_ERROR "configuring the consumer project failed (exit ${RC})\n${OUT}\n${ERR}")
+endif()
+
+# The step cmake generated for the external's configure: the exact command
+# `ninja` runs, including the CMAKE_ARGS as they were spelled.
+set(EXT_PREFIX "${CONSUMER_BUILD}/SPIRV-Tools-External-prefix")
+file(GLOB CONFIGURE_SCRIPT
+  "${EXT_PREFIX}/src/SPIRV-Tools-External-stamp/SPIRV-Tools-External-configure-*.cmake")
+list(LENGTH CONFIGURE_SCRIPT N_SCRIPTS)
+if(NOT N_SCRIPTS EQUAL 1)
+  message(FATAL_ERROR
+    "expected one generated configure step under ${EXT_PREFIX}, found: '${CONFIGURE_SCRIPT}'")
+endif()
+
+# Stand in for the downloaded SPIRV-Tools checkout: the smallest project that
+# still runs the compiler checks the CMAKE_C_COMPILER/CMAKE_CXX_COMPILER
+# arguments trigger.
+set(EXT_SOURCE "${EXT_PREFIX}/src/SPIRV-Tools-External")
+set(EXT_BUILD "${EXT_PREFIX}/src/SPIRV-Tools-External-build")
+file(WRITE "${EXT_SOURCE}/CMakeLists.txt"
+  "cmake_minimum_required(VERSION 3.20)\n"
+  "project(stub C CXX)\n")
+file(MAKE_DIRECTORY "${EXT_BUILD}")
+
+# gcc and g++ reachable through a different path than the ambient PATH gives.
+set(SHIM_DIR "${SCRATCH_DIR}/shim")
+file(MAKE_DIRECTORY "${SHIM_DIR}")
+file(CREATE_LINK "${REAL_GCC}" "${SHIM_DIR}/gcc" SYMBOLIC)
+file(CREATE_LINK "${REAL_GXX}" "${SHIM_DIR}/g++" SYMBOLIC)
+
+function(run_configure_step LABEL)
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E env ${ARGN} ${CMAKE_COMMAND} -P "${CONFIGURE_SCRIPT}"
+    WORKING_DIRECTORY "${EXT_BUILD}"
+    RESULT_VARIABLE RC OUTPUT_VARIABLE OUT ERROR_VARIABLE ERR)
+  if(NOT RC EQUAL 0)
+    message(FATAL_ERROR "${LABEL}: the external's configure step failed (exit ${RC})\n${OUT}\n${ERR}")
+  endif()
+  message(STATUS "${LABEL}: configure step ran")
+endfunction()
+
+run_configure_step("ambient PATH")
+run_configure_step("shim first on PATH" "PATH=${SHIM_DIR}:$ENV{PATH}")
+
+file(STRINGS "${EXT_BUILD}/CMakeCache.txt" PREFIX_LINE REGEX "^CMAKE_INSTALL_PREFIX:")
+file(STRINGS "${EXT_BUILD}/CMakeCache.txt" LIBDIR_LINE REGEX "^CMAKE_INSTALL_LIBDIR:")
+string(REGEX REPLACE "^[^=]*=" "" INSTALL_PREFIX "${PREFIX_LINE}")
+string(REGEX REPLACE "^[^=]*=" "" INSTALL_LIBDIR "${LIBDIR_LINE}")
+message(STATUS "external CMAKE_INSTALL_PREFIX: ${INSTALL_PREFIX}")
+message(STATUS "external CMAKE_INSTALL_LIBDIR: ${INSTALL_LIBDIR}")
+
+set(FAILURES "")
+string(FIND "${INSTALL_PREFIX}" "${CONSUMER_BUILD}/" AT)
+if(NOT AT EQUAL 0)
+  set(FAILURES "${FAILURES}  CMAKE_INSTALL_PREFIX is '${INSTALL_PREFIX}', not under ${CONSUMER_BUILD}\n")
+endif()
+if(NOT INSTALL_LIBDIR STREQUAL "lib")
+  set(FAILURES "${FAILURES}  CMAKE_INSTALL_LIBDIR is '${INSTALL_LIBDIR}', not lib\n")
+endif()
+
+if(NOT FAILURES STREQUAL "")
+  file(READ "${EXT_PREFIX}/src/SPIRV-Tools-External-stamp/SPIRV-Tools-External-configure-err.log" CONFIGURE_ERR)
+  message(FATAL_ERROR
+    "the SPIRV-Tools external project lost its CMAKE_ARGS across two configure runs:\n"
+    "${FAILURES}"
+    "configure stderr of the last run:\n${CONFIGURE_ERR}"
+    "scratch tree kept at ${SCRATCH_DIR}")
+endif()
+
+file(REMOVE_RECURSE "${SCRATCH_DIR}")
+message(STATUS "TestFix1486SpirvToolsInstallPrefix passed")

--- a/tests/TestFix1486SpirvToolsInstallPrefix.cmake
+++ b/tests/TestFix1486SpirvToolsInstallPrefix.cmake
@@ -63,8 +63,17 @@ if(NOT RC EQUAL 0)
 endif()
 
 # The step cmake generated for the external's configure: the exact command
-# `ninja` runs, including the CMAKE_ARGS as they were spelled.
+# `ninja` runs, including the CMAKE_ARGS as they were spelled. The install
+# prefix that command asks for is what the external's cache must still hold
+# afterwards; it is taken from the generated command rather than recomputed
+# here so the comparison is exact (TMPDIR on macOS ends in a slash, which
+# cmake collapses in CMAKE_BINARY_DIR and a string-prefix check would not).
 set(EXT_PREFIX "${CONSUMER_BUILD}/SPIRV-Tools-External-prefix")
+file(READ "${EXT_PREFIX}/tmp/SPIRV-Tools-External-cfgcmd.txt" CFGCMD)
+if(NOT CFGCMD MATCHES "-DCMAKE_INSTALL_PREFIX=([^;']+)")
+  message(FATAL_ERROR "no -DCMAKE_INSTALL_PREFIX in the generated configure command:\n${CFGCMD}")
+endif()
+set(EXPECTED_PREFIX "${CMAKE_MATCH_1}")
 file(GLOB CONFIGURE_SCRIPT
   "${EXT_PREFIX}/src/SPIRV-Tools-External-stamp/SPIRV-Tools-External-configure-*.cmake")
 list(LENGTH CONFIGURE_SCRIPT N_SCRIPTS)
@@ -111,9 +120,8 @@ message(STATUS "external CMAKE_INSTALL_PREFIX: ${INSTALL_PREFIX}")
 message(STATUS "external CMAKE_INSTALL_LIBDIR: ${INSTALL_LIBDIR}")
 
 set(FAILURES "")
-string(FIND "${INSTALL_PREFIX}" "${CONSUMER_BUILD}/" AT)
-if(NOT AT EQUAL 0)
-  set(FAILURES "${FAILURES}  CMAKE_INSTALL_PREFIX is '${INSTALL_PREFIX}', not under ${CONSUMER_BUILD}\n")
+if(NOT INSTALL_PREFIX STREQUAL EXPECTED_PREFIX)
+  set(FAILURES "${FAILURES}  CMAKE_INSTALL_PREFIX is '${INSTALL_PREFIX}', the configure step asked for '${EXPECTED_PREFIX}'\n")
 endif()
 if(NOT INSTALL_LIBDIR STREQUAL "lib")
   set(FAILURES "${FAILURES}  CMAKE_INSTALL_LIBDIR is '${INSTALL_LIBDIR}', not lib\n")


### PR DESCRIPTION
When SPIRV-Tools is not found, the ExternalProject that builds it passes `-DCMAKE_C_COMPILER=gcc` by bare name; its configure step re-runs on every build, and a PATH that resolves `gcc` differently between `ninja` and `ninja install` makes cmake delete the external's cache and reconfigure with only the compiler entries, so `CMAKE_INSTALL_PREFIX` falls back to `/usr/local` and the install fails with a permission error. Found building chipStar on Aurora, where the two steps ran from shells with different modules loaded.

The ExternalProject block moves into `cmake/SpirvToolsExternal.cmake` and resolves `gcc`/`g++` once with `find_program`, so the argument is a stable absolute path. `TestFix1486SpirvToolsInstallPrefix` configures that module on its own, runs the generated configure step twice with a gcc symlink directory prepended to PATH the second time, and asserts the external's cache keeps the build-tree prefix; it fails without the fix and nothing is downloaded or installed.

Fixes #1486
