### PR TITLE
devicelib: map the missing <cmath> C libcalls to OpenCL builtins and lower llvm.ldexp

### DIFF
--- a/bitcode/c_to_opencl.c
+++ b/bitcode/c_to_opencl.c
@@ -22,6 +22,10 @@
 
 // See c_to_opencl.def for details.
 
+// The C library prototypes of the *l functions take long double, which is a
+// 64-bit double on spirv64 (see c_to_opencl.def).
+#define C2OCL_LONG_DOUBLE long double
+
 #define DEF_UNARY_FN_MAP(FROM_FN_, TO_FN_, TYPE_)                              \
   extern TYPE_ __chip_c2ocl_##FROM_FN_(TYPE_);                                 \
   TYPE_ FROM_FN_(TYPE_ x) { return __chip_c2ocl_##FROM_FN_(x); }
@@ -29,6 +33,14 @@
 #define DEF_BINARY_FN_MAP(FROM_FN_, TO_FN_, TYPE_)                             \
   extern TYPE_ __chip_c2ocl_##FROM_FN_(TYPE_, TYPE_);                          \
   TYPE_ FROM_FN_(TYPE_ x, TYPE_ y) { return __chip_c2ocl_##FROM_FN_(x, y); }
+
+#define DEF_UNARY_FN_MAP_RET(FROM_FN_, TO_FN_, RET_TYPE_, TYPE_)               \
+  extern RET_TYPE_ __chip_c2ocl_##FROM_FN_(TYPE_);                             \
+  RET_TYPE_ FROM_FN_(TYPE_ x) { return __chip_c2ocl_##FROM_FN_(x); }
+
+#define DEF_BINARY_FN_MAP_MIXED(FROM_FN_, TO_FN_, TYPE_, TYPE2_)               \
+  extern TYPE_ __chip_c2ocl_##FROM_FN_(TYPE_, TYPE2_);                         \
+  TYPE_ FROM_FN_(TYPE_ x, TYPE2_ y) { return __chip_c2ocl_##FROM_FN_(x, y); }
 
 #include "c_to_opencl.def"
 

--- a/bitcode/c_to_opencl.def
+++ b/bitcode/c_to_opencl.def
@@ -26,6 +26,15 @@
 // definitions for mapping the C math calls to corresponding OpenCL
 // built-ins.
 //
+// The C names arrive from several directions: HIP device built-ins in
+// include/hip/devicelib that expand to __builtin_*, libstdc++'s <cmath>
+// float and long double overloads (constexpr wrappers around __builtin_*f
+// and __builtin_*l, which HIP makes implicitly __host__ __device__ so they
+// win overload resolution in device code), and calls the optimizer
+// synthesises itself (pow(2, i) -> ldexp(1, i)). Only the built-ins that
+// have no LLVM intrinsic reach a C name; the rest become intrinsics that
+// the SPIR-V producer maps to OpenCL.std instructions directly.
+//
 // We can't define non-overloaded function that would call the builtin
 // by the same in OpenCL in the same translation unit. To get around
 // it we define the former in C source file, for example:
@@ -37,27 +46,59 @@
 //   double __chip_c2ocl_lgamma(double x) { return lgamma(x); }
 //
 // In this file we define the functions which receive this treatment.
+//
+// long double is a 64-bit double on spirv64, in HIP device code and in the
+// C compile of c_to_opencl.c alike, so the *l names carry a double. OpenCL C
+// has no long double, so the entries spell it C2OCL_LONG_DOUBLE: the C side
+// defines it as long double (matching the C library prototypes, so clang
+// does not flag an incompatible library redeclaration) and the OpenCL side
+// takes the default below.
 
 // Note: Include guards are not desired here.
 
-// DEF_UNARY_FN_MAP(FROM_FN, TO_FN, TYPE)
+#ifndef C2OCL_LONG_DOUBLE
+#define C2OCL_LONG_DOUBLE double
+#endif
+
+// DEF_UNARY_FN_MAP(FROM_FN, TO_FN, TYPE): TYPE FROM_FN(TYPE)
 #ifndef DEF_UNARY_FN_MAP
 #define DEF_UNARY_FN_MAP
 #endif
 
-// DEF_BINARY_FN_MAP(FROM_FN, TO_FN, TYPE)
+// DEF_BINARY_FN_MAP(FROM_FN, TO_FN, TYPE): TYPE FROM_FN(TYPE, TYPE)
 #ifndef DEF_BINARY_FN_MAP
 #define DEF_BINARY_FN_MAP
 #endif
 
+// DEF_UNARY_FN_MAP_RET(FROM_FN, TO_FN, RET_TYPE, TYPE): RET_TYPE FROM_FN(TYPE)
+#ifndef DEF_UNARY_FN_MAP_RET
+#define DEF_UNARY_FN_MAP_RET
+#endif
+
+// DEF_BINARY_FN_MAP_MIXED(FROM_FN, TO_FN, TYPE, TYPE2):
+//   TYPE FROM_FN(TYPE, TYPE2)
+#ifndef DEF_BINARY_FN_MAP_MIXED
+#define DEF_BINARY_FN_MAP_MIXED
+#endif
+
 DEF_UNARY_FN_MAP(acos, acos, double)
 DEF_UNARY_FN_MAP(acosf, acos, float)
+DEF_UNARY_FN_MAP(acosh, acosh, double)
+DEF_UNARY_FN_MAP(acoshf, acosh, float)
+DEF_UNARY_FN_MAP(acoshl, acosh, C2OCL_LONG_DOUBLE)
 DEF_UNARY_FN_MAP(asin, asin, double)
 DEF_UNARY_FN_MAP(asinf, asin, float)
+DEF_UNARY_FN_MAP(asinh, asinh, double)
+DEF_UNARY_FN_MAP(asinhf, asinh, float)
+DEF_UNARY_FN_MAP(asinhl, asinh, C2OCL_LONG_DOUBLE)
 DEF_UNARY_FN_MAP(atan, atan, double)
 DEF_UNARY_FN_MAP(atanf, atan, float)
+DEF_UNARY_FN_MAP(atanh, atanh, double)
+DEF_UNARY_FN_MAP(atanhf, atanh, float)
+DEF_UNARY_FN_MAP(atanhl, atanh, C2OCL_LONG_DOUBLE)
 DEF_UNARY_FN_MAP(cbrt, cbrt, double)
 DEF_UNARY_FN_MAP(cbrtf, cbrt, float)
+DEF_UNARY_FN_MAP(cbrtl, cbrt, C2OCL_LONG_DOUBLE)
 DEF_UNARY_FN_MAP(ceil, ceil, double)
 DEF_UNARY_FN_MAP(ceilf, ceil, float)
 DEF_UNARY_FN_MAP(cos, cos, double)
@@ -66,12 +107,15 @@ DEF_UNARY_FN_MAP(cosh, cosh, double)
 DEF_UNARY_FN_MAP(coshf, cosh, float)
 DEF_UNARY_FN_MAP(erf, erf, double)
 DEF_UNARY_FN_MAP(erff, erf, float)
+DEF_UNARY_FN_MAP(erfl, erf, C2OCL_LONG_DOUBLE)
 DEF_UNARY_FN_MAP(erfc, erfc, double)
 DEF_UNARY_FN_MAP(erfcf, erfc, float)
+DEF_UNARY_FN_MAP(erfcl, erfc, C2OCL_LONG_DOUBLE)
 DEF_UNARY_FN_MAP(exp, exp, double)
 DEF_UNARY_FN_MAP(expf, exp, float)
 DEF_UNARY_FN_MAP(expm1, expm1, double)
 DEF_UNARY_FN_MAP(expm1f, expm1, float)
+DEF_UNARY_FN_MAP(expm1l, expm1, C2OCL_LONG_DOUBLE)
 DEF_UNARY_FN_MAP(exp2, exp2, double)
 DEF_UNARY_FN_MAP(exp2f, exp2, float)
 DEF_UNARY_FN_MAP(fabs, fabs, double)
@@ -80,10 +124,17 @@ DEF_UNARY_FN_MAP(floor, floor, double)
 DEF_UNARY_FN_MAP(floorf, floor, float)
 DEF_UNARY_FN_MAP(lgamma, lgamma, double)
 DEF_UNARY_FN_MAP(lgammaf, lgamma, float)
+DEF_UNARY_FN_MAP(lgammal, lgamma, C2OCL_LONG_DOUBLE)
 DEF_UNARY_FN_MAP(log, log, double)
 DEF_UNARY_FN_MAP(logf, log, float)
 DEF_UNARY_FN_MAP(log10, log10, double)
 DEF_UNARY_FN_MAP(log10f, log10, float)
+DEF_UNARY_FN_MAP(log1p, log1p, double)
+DEF_UNARY_FN_MAP(log1pf, log1p, float)
+DEF_UNARY_FN_MAP(log1pl, log1p, C2OCL_LONG_DOUBLE)
+DEF_UNARY_FN_MAP(logb, logb, double)
+DEF_UNARY_FN_MAP(logbf, logb, float)
+DEF_UNARY_FN_MAP(logbl, logb, C2OCL_LONG_DOUBLE)
 DEF_UNARY_FN_MAP(rint, rint, double)
 DEF_UNARY_FN_MAP(rintf, rint, float)
 DEF_UNARY_FN_MAP(round, round, double)
@@ -100,10 +151,20 @@ DEF_UNARY_FN_MAP(tan, tan, double)
 DEF_UNARY_FN_MAP(tanf, tan, float)
 DEF_UNARY_FN_MAP(tanh, tanh, double)
 DEF_UNARY_FN_MAP(tanhf, tanh, float)
+DEF_UNARY_FN_MAP(tgamma, tgamma, double)
+DEF_UNARY_FN_MAP(tgammaf, tgamma, float)
+DEF_UNARY_FN_MAP(tgammal, tgamma, C2OCL_LONG_DOUBLE)
 DEF_UNARY_FN_MAP(trunc, trunc, double)
 DEF_UNARY_FN_MAP(truncf, trunc, float)
 
+DEF_UNARY_FN_MAP_RET(ilogb, ilogb, int, double)
+DEF_UNARY_FN_MAP_RET(ilogbf, ilogb, int, float)
+DEF_UNARY_FN_MAP_RET(ilogbl, ilogb, int, C2OCL_LONG_DOUBLE)
+
 DEF_BINARY_FN_MAP(copysign, copysign, double)
+DEF_BINARY_FN_MAP(fdim, fdim, double)
+DEF_BINARY_FN_MAP(fdimf, fdim, float)
+DEF_BINARY_FN_MAP(fdiml, fdim, C2OCL_LONG_DOUBLE)
 DEF_BINARY_FN_MAP(fmax, fmax, double)
 DEF_BINARY_FN_MAP(fmaxf, fmax, float)
 DEF_BINARY_FN_MAP(fmin, fmin, double)
@@ -112,4 +173,32 @@ DEF_BINARY_FN_MAP(fmod, fmod, double)
 DEF_BINARY_FN_MAP(fmodf, fmod, float)
 DEF_BINARY_FN_MAP(hypot, hypot, double)
 DEF_BINARY_FN_MAP(hypotf, hypot, float)
+DEF_BINARY_FN_MAP(hypotl, hypot, C2OCL_LONG_DOUBLE)
 DEF_BINARY_FN_MAP(nextafter, nextafter, double)
+DEF_BINARY_FN_MAP(nextafterf, nextafter, float)
+DEF_BINARY_FN_MAP(nextafterl, nextafter, C2OCL_LONG_DOUBLE)
+// nexttowardl(x, y) differs from nextafter only in y's type, long double,
+// which is the same 64-bit double here.
+DEF_BINARY_FN_MAP(nexttowardl, nextafter, C2OCL_LONG_DOUBLE)
+DEF_BINARY_FN_MAP(remainder, remainder, double)
+DEF_BINARY_FN_MAP(remainderf, remainder, float)
+DEF_BINARY_FN_MAP(remainderl, remainder, C2OCL_LONG_DOUBLE)
+
+// nexttoward(x, y) takes a long double y, the same 64-bit double as x here,
+// so it is nextafter. nexttowardf(x, y) narrows it; __chip_nexttoward
+// (devicelib.cl) applies C's rule that y is returned converted to float when
+// x == y.
+DEF_BINARY_FN_MAP_MIXED(nexttoward, nextafter, double, C2OCL_LONG_DOUBLE)
+DEF_BINARY_FN_MAP_MIXED(nexttowardf, __chip_nexttoward, float,
+                        C2OCL_LONG_DOUBLE)
+// C's scalbn(x, n) is x * FLT_RADIX^n. OpenCL C fixes FLT_RADIX at 2 and
+// defines ldexp(x, k) as "Multiply x by 2 to the power k", so scalbn is
+// ldexp. scalbln takes a long exponent; __chip_scalbln (devicelib.cl) clamps
+// it to int first, which is exact because ldexp saturates to 0 or infinity
+// long before either end of int.
+DEF_BINARY_FN_MAP_MIXED(scalbln, __chip_scalbln, double, long)
+DEF_BINARY_FN_MAP_MIXED(scalblnf, __chip_scalbln, float, long)
+DEF_BINARY_FN_MAP_MIXED(scalblnl, __chip_scalbln, C2OCL_LONG_DOUBLE, long)
+DEF_BINARY_FN_MAP_MIXED(scalbn, ldexp, double, int)
+DEF_BINARY_FN_MAP_MIXED(scalbnf, ldexp, float, int)
+DEF_BINARY_FN_MAP_MIXED(scalbnl, ldexp, C2OCL_LONG_DOUBLE, int)

--- a/bitcode/devicelib.cl
+++ b/bitcode/devicelib.cl
@@ -1107,11 +1107,36 @@ EXPORT OVLD void __chip_syncwarp() {
   return sub_group_barrier(CLK_GLOBAL_MEM_FENCE);
 }
 
+// Targets of the c_to_opencl.def entries whose OpenCL counterpart is not a
+// plain builtin.
+//
+// scalbln takes a long exponent and ldexp an int. ldexp already returns 0 or
+// infinity for any finite nonzero x once |k| passes a few thousand, so
+// clamping the exponent to int changes nothing.
+static OVLD float __chip_scalbln(float x, long n) {
+  return ldexp(x, (int)clamp(n, (long)INT_MIN, (long)INT_MAX));
+}
+static OVLD double __chip_scalbln(double x, long n) {
+  return ldexp(x, (int)clamp(n, (long)INT_MIN, (long)INT_MAX));
+}
+// nexttowardf(x, y): y is a long double, a 64-bit double on spirv64. C
+// returns y converted to float when x == y (which is how -0.0f steps to
+// +0.0f), and otherwise the next float after x in the direction of y.
+static float __chip_nexttoward(float x, double y) {
+  if (isnan(y) || x == y)
+    return (float)y;
+  return nextafter(x, y > x ? INFINITY : -INFINITY);
+}
+
 // See c_to_opencl.def for details.
 #define DEF_UNARY_FN_MAP(FROM_FN_, TO_FN_, TYPE_)                              \
   TYPE_ __chip_c2ocl_##FROM_FN_(TYPE_ x) { return TO_FN_(x); }
 #define DEF_BINARY_FN_MAP(FROM_FN_, TO_FN_, TYPE_)                             \
   TYPE_ __chip_c2ocl_##FROM_FN_(TYPE_ x, TYPE_ y) { return TO_FN_(x, y); }
+#define DEF_UNARY_FN_MAP_RET(FROM_FN_, TO_FN_, RET_TYPE_, TYPE_)               \
+  RET_TYPE_ __chip_c2ocl_##FROM_FN_(TYPE_ x) { return TO_FN_(x); }
+#define DEF_BINARY_FN_MAP_MIXED(FROM_FN_, TO_FN_, TYPE_, TYPE2_)               \
+  TYPE_ __chip_c2ocl_##FROM_FN_(TYPE_ x, TYPE2_ y) { return TO_FN_(x, y); }
 #include "c_to_opencl.def"
 #undef UNARY_FN
 #undef BINARY_FN

--- a/llvm_passes/HipLowerRoundIntrinsics.cpp
+++ b/llvm_passes/HipLowerRoundIntrinsics.cpp
@@ -39,18 +39,37 @@
 // code. Taking the whole set also means the pass can be deleted in one go once
 // the producers cover all of it.
 //
+// llvm.ldexp arrives the same way and dies the same way:
+//
+//   InvalidFunctionCall: Unexpected llvm intrinsic: llvm.ldexp.f64.i32
+//
+// There is no equivalent "expand into another intrinsic" trick for it -- the
+// multiply-by-a-power-of-two rewrite loses subnormals and overflows -- but
+// OpenCL has ldexp natively, so emit a call to the OpenCL builtin instead. That
+// is not the same thing as calling devicelib: _Z5ldexpfi and _Z5ldexpdi stay
+// *undefined* in the module (devicelib itself leaves them undefined, see
+// bitcode/devicelib.cl) and llvm-spirv turns the call into the OpenCL ExtInst
+// Ldexp, so nothing has to be linked in after the fact. HipPrintf.cpp declares
+// the OpenCL printf the same way.
+//
 // (c) 2026 chipStar developers
 //===----------------------------------------------------------------------===//
 
 #include "HipLowerRoundIntrinsics.h"
 
 #include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/IR/CallingConv.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Intrinsics.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Passes/PassBuilder.h>
 #include "PassPluginCompat.h"
+
+#include <cstdint>
 
 #define PASS_NAME "hip-lower-round-intrinsics"
 #define DEBUG_TYPE PASS_NAME
@@ -107,10 +126,132 @@ static bool lowerRoundIntrinsics(Module &M) {
   return !WorkList.empty();
 }
 
+/// The OpenCL C mangled name of ldexp for the scalar floating point type \p Ty,
+/// or an empty string when OpenCL has no ldexp taking it. OpenCL declares
+/// ldexp only over the half, float and double gentypes; those are also the only
+/// floating point types that reach a SPIR-V device module, so anything else
+/// (x86_fp80, fp128, bfloat) is deliberately left for the translator to reject
+/// rather than silently mistranslated.
+static StringRef getOpenCLLdexpName(Type *Ty) {
+  if (Ty->isHalfTy())
+    return "_Z5ldexpDhi";
+  if (Ty->isFloatTy())
+    return "_Z5ldexpfi";
+  if (Ty->isDoubleTy())
+    return "_Z5ldexpdi";
+  return "";
+}
+
+/// Narrow \p Exp to the i32 that the OpenCL ldexp takes. llvm.ldexp accepts any
+/// integer width and reads it as signed; clang only ever emits i32 here, but
+/// InstCombine and SimplifyLibCalls also synthesise the intrinsic (from
+/// exp2(sitofp x) and pow(2, sitofp x)) with whatever width the source integer
+/// had. Clamping before the truncation keeps the wide case exact: every type
+/// OpenCL's ldexp accepts has already saturated to zero or infinity long before
+/// |exp| reaches 2^31, so a clamped exponent gives the same result as the
+/// original one. A plain truncation would not: it turns 2^32 into 0.
+static Value *coerceLdexpExponent(IRBuilder<> &Builder, Value *Exp) {
+  auto *ExpTy = cast<IntegerType>(Exp->getType());
+  if (ExpTy->getBitWidth() == 32)
+    return Exp;
+  if (ExpTy->getBitWidth() < 32)
+    return Builder.CreateSExt(Exp, Builder.getInt32Ty());
+
+  Value *Lo = ConstantInt::getSigned(ExpTy, INT32_MIN);
+  Value *Hi = ConstantInt::getSigned(ExpTy, INT32_MAX);
+  Value *Clamped =
+      Builder.CreateSelect(Builder.CreateICmpSLT(Exp, Lo), Lo, Exp);
+  Clamped = Builder.CreateSelect(Builder.CreateICmpSGT(Clamped, Hi), Hi,
+                                 Clamped);
+  return Builder.CreateTrunc(Clamped, Builder.getInt32Ty());
+}
+
+/// Emit a call to the OpenCL ldexp builtin for the scalar value \p X and the
+/// i32 exponent \p Exp. The callee is left undefined on purpose: llvm-spirv
+/// recognises the mangled name and emits the OpenCL ExtInst Ldexp for it.
+static Value *emitOpenCLLdexp(IRBuilder<> &Builder, Module &M, Value *X,
+                              Value *Exp) {
+  Type *Ty = X->getType();
+  FunctionCallee Callee = M.getOrInsertFunction(getOpenCLLdexpName(Ty), Ty, Ty,
+                                                Builder.getInt32Ty());
+  if (auto *F = dyn_cast<Function>(Callee.getCallee())) {
+    // SPIR_FUNC is what marks this as a device side call for the translator,
+    // and InternalizePass in the chipStar pipeline keys off it to keep the
+    // declaration alive.
+    F->setCallingConv(CallingConv::SPIR_FUNC);
+    F->setVisibility(GlobalValue::HiddenVisibility);
+    F->setDoesNotAccessMemory();
+    F->setDoesNotThrow();
+  }
+  CallInst *Call = Builder.CreateCall(Callee, {X, Exp});
+  Call->setCallingConv(CallingConv::SPIR_FUNC);
+  return Call;
+}
+
+/// True when \p Call is an llvm.ldexp this pass knows how to rewrite.
+static bool isLowerableLdexp(CallInst *Call) {
+  Function *Callee = Call->getCalledFunction();
+  if (!Callee || Callee->getIntrinsicID() != Intrinsic::ldexp ||
+      Call->arg_size() != 2)
+    return false;
+
+  Type *Ty = Call->getType();
+  // Scalable vectors cannot occur on a SPIR-V device module and cannot be
+  // scalarised, so leave them be.
+  if (isa<ScalableVectorType>(Ty))
+    return false;
+  if (!getOpenCLLdexpName(Ty->getScalarType()).empty() &&
+      Call->getArgOperand(1)->getType()->isIntOrIntVectorTy())
+    return true;
+  return false;
+}
+
+static bool lowerLdexpIntrinsics(Module &M) {
+  SmallVector<CallInst *, 8> WorkList;
+  for (auto &F : M)
+    for (auto &BB : F)
+      for (auto &I : BB)
+        if (auto *Call = dyn_cast<CallInst>(&I))
+          if (isLowerableLdexp(Call))
+            WorkList.push_back(Call);
+
+  for (auto *Call : WorkList) {
+    Value *X = Call->getArgOperand(0);
+    Value *Exp = Call->getArgOperand(1);
+    IRBuilder<> Builder(Call);
+
+    Value *Result;
+    if (auto *VecTy = dyn_cast<FixedVectorType>(Call->getType())) {
+      // OpenCL does have vector ldexp, but scalarising avoids having to mangle
+      // the vector overloads and vector ldexp is vanishingly rare here anyway:
+      // it can only come out of the vectorisers, never out of a source builtin.
+      Result = PoisonValue::get(VecTy);
+      for (unsigned Idx = 0; Idx < VecTy->getNumElements(); ++Idx) {
+        Value *LaneX = Builder.CreateExtractElement(X, Idx);
+        Value *LaneExp = Exp->getType()->isVectorTy()
+                             ? Builder.CreateExtractElement(Exp, Idx)
+                             : Exp;
+        Value *Lane = emitOpenCLLdexp(Builder, M, LaneX,
+                                      coerceLdexpExponent(Builder, LaneExp));
+        Result = Builder.CreateInsertElement(Result, Lane, Idx);
+      }
+    } else {
+      Result =
+          emitOpenCLLdexp(Builder, M, X, coerceLdexpExponent(Builder, Exp));
+    }
+
+    Call->replaceAllUsesWith(Result);
+    Call->eraseFromParent();
+  }
+
+  return !WorkList.empty();
+}
+
 PreservedAnalyses HipLowerRoundIntrinsicsPass::run(Module &M,
                                                    ModuleAnalysisManager &AM) {
-  return lowerRoundIntrinsics(M) ? PreservedAnalyses::none()
-                                 : PreservedAnalyses::all();
+  bool Changed = lowerRoundIntrinsics(M);
+  Changed |= lowerLdexpIntrinsics(M);
+  return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
 }
 
 #ifndef CHIP_COMBINED_PASS_PLUGIN

--- a/llvm_passes/HipLowerRoundIntrinsics.cpp
+++ b/llvm_passes/HipLowerRoundIntrinsics.cpp
@@ -52,6 +52,10 @@
 // Ldexp, so nothing has to be linked in after the fact. HipPrintf.cpp declares
 // the OpenCL printf the same way.
 //
+// The ldexp lowering is a bridge too, on its own upstream schedule rather than
+// the rounding one, and carries its own WORKAROUND marker below. chipStar#1476
+// tracks deleting the pass and holds the removal condition for both halves.
+//
 // (c) 2026 chipStar developers
 //===----------------------------------------------------------------------===//
 
@@ -125,6 +129,17 @@ static bool lowerRoundIntrinsics(Module &M) {
 
   return !WorkList.empty();
 }
+
+// WORKAROUND(CHIP-SPV/chipStar#1476, llvm/llvm-project#195402,
+// KhronosGroup/SPIRV-LLVM-Translator#3608): neither SPIR-V producer lowers
+// llvm.ldexp. The in tree backend fails to legalize G_FLDEXP and the translator
+// rejects the intrinsic outright, so the calls are rewritten here instead.
+// Both upstream fixes have merged, but neither has reached a version chipStar
+// pins: llvm/llvm-project#195402 landed on main after the llvmorg-23.1.0-rc2
+// tag, and the LLVM 21 lanes will never receive it. Remove this block, from
+// here down to the end of lowerLdexpIntrinsics, once every supported LLVM and
+// translator carries them; CHIP-SPV/chipStar#1476 holds the removal condition
+// for the whole pass.
 
 /// The OpenCL C mangled name of ldexp for the scalar floating point type \p Ty,
 /// or an empty string when OpenCL has no ldexp taking it. OpenCL declares
@@ -246,6 +261,7 @@ static bool lowerLdexpIntrinsics(Module &M) {
 
   return !WorkList.empty();
 }
+// END WORKAROUND(CHIP-SPV/chipStar#1476) for llvm.ldexp.
 
 PreservedAnalyses HipLowerRoundIntrinsicsPass::run(Module &M,
                                                    ModuleAnalysisManager &AM) {

--- a/llvm_passes/HipLowerRoundIntrinsics.h
+++ b/llvm_passes/HipLowerRoundIntrinsics.h
@@ -6,10 +6,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// Expands the type-crossing rounding intrinsics llvm.lround.*, llvm.llround.*,
-// llvm.lrint.* and llvm.llrint.* to llvm.round / llvm.rint plus a conversion.
-// They return an integer, and OpenCL.std has only float to float rounding
-// instructions, so neither SPIR-V producer can translate them directly.
+// Rewrites the math intrinsics the SPIR-V producers have no translation for.
+// The type-crossing rounding intrinsics llvm.lround.*, llvm.llround.*,
+// llvm.lrint.* and llvm.llrint.* become llvm.round / llvm.rint plus a
+// conversion: they return an integer, and OpenCL.std has only float to float
+// rounding instructions, so neither SPIR-V producer can translate them
+// directly. llvm.ldexp becomes a call to the OpenCL ldexp builtin.
 //
 // (c) 2026 chipStar developers
 //===----------------------------------------------------------------------===//

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -200,3 +200,6 @@ add_subdirectory(irVerification)
 
 # Add the 8 and 16 bit atomic lowering pass tests
 add_subdirectory(subwordAtomics)
+
+# Add the untranslatable math intrinsic (llround / llrint / ldexp) pass tests
+add_subdirectory(mathIntrinsics)

--- a/tests/compiler/mathIntrinsics/CMakeLists.txt
+++ b/tests/compiler/mathIntrinsics/CMakeLists.txt
@@ -1,0 +1,50 @@
+#=============================================================================
+#  Copyright (c) 2026 chipStar developers
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+#
+#=============================================================================
+
+configure_file(run_math_intrinsics_pass.bash
+  ${CMAKE_CURRENT_BINARY_DIR}/run_math_intrinsics_pass.bash @ONLY)
+
+# Every llvm.ldexp variant that can reach a device module. llvm-spirv has no
+# translation for the intrinsic, so HipLowerRoundIntrinsicsPass has to rewrite
+# it into a call to the OpenCL ldexp builtin.
+list(APPEND TEST_IR_FILES ${CMAKE_CURRENT_SOURCE_DIR}/ldexp.ll)
+
+# The llround / llrint half of the same pass, which shipped without a test.
+list(APPEND TEST_IR_FILES ${CMAKE_CURRENT_SOURCE_DIR}/llround.ll)
+
+foreach(IR_FILE ${TEST_IR_FILES})
+  get_filename_component(FILENAME ${IR_FILE} NAME)
+  get_filename_component(BASENAME ${IR_FILE} NAME_WE)
+  configure_file(${IR_FILE} ${CMAKE_CURRENT_BINARY_DIR}/${FILENAME} COPYONLY)
+
+  add_test(
+    NAME hipMathIntrinsics-${BASENAME}
+    COMMAND env
+      LLVM_OPT=${LLVM_TOOLS_BINARY_DIR}/opt
+      LLVM_DIS=${LLVM_TOOLS_BINARY_DIR}/llvm-dis
+      LLVM_SPIRV=${LLVM_TOOLS_BINARY_DIR}/llvm-spirv
+      HIP_SPV_PASSES_LIB=${CMAKE_BINARY_DIR}/lib/libLLVMHipSpvPasses.so
+      ${CMAKE_CURRENT_BINARY_DIR}/run_math_intrinsics_pass.bash
+      ${CMAKE_CURRENT_BINARY_DIR}/${FILENAME}
+  )
+endforeach()

--- a/tests/compiler/mathIntrinsics/ldexp.ll
+++ b/tests/compiler/mathIntrinsics/ldexp.ll
@@ -1,0 +1,47 @@
+; Every llvm.ldexp variant that can reach a SPIR-V device module.
+;
+; The value type is one of half / float / double, because those are the only
+; floating point types OpenCL declares ldexp over and the only ones clang can
+; produce for this target. The exponent is crossed against several integer
+; widths: clang itself only ever emits i32, but InstCombine and SimplifyLibCalls
+; also synthesise llvm.ldexp out of exp2(sitofp x) and pow(2, sitofp x) and keep
+; the source integer's width. The vector form comes from the same rewrite when
+; it fires on a vectorised expression.
+;
+; See CHIP-SPV/chipStar#1404.
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spirv64"
+
+declare double @llvm.ldexp.f64.i32(double, i32)
+declare float @llvm.ldexp.f32.i32(float, i32)
+declare half @llvm.ldexp.f16.i32(half, i32)
+declare double @llvm.ldexp.f64.i64(double, i64)
+declare float @llvm.ldexp.f32.i16(float, i16)
+declare <4 x float> @llvm.ldexp.v4f32.v4i32(<4 x float>, <4 x i32>)
+
+define spir_kernel void @ldexp_variants(ptr addrspace(1) %DOut,
+                                        ptr addrspace(1) %FOut,
+                                        ptr addrspace(1) %HOut,
+                                        ptr addrspace(1) %VOut,
+                                        i32 %E32, i64 %E64, i16 %E16,
+                                        <4 x i32> %EV) {
+entry:
+  %d32 = call double @llvm.ldexp.f64.i32(double 3.000000e+00, i32 %E32)
+  %f32 = call float @llvm.ldexp.f32.i32(float 3.000000e+00, i32 %E32)
+  %h32 = call half @llvm.ldexp.f16.i32(half 0xH4200, i32 %E32)
+  %d64 = call double @llvm.ldexp.f64.i64(double 3.000000e+00, i64 %E64)
+  %f16 = call float @llvm.ldexp.f32.i16(float 3.000000e+00, i16 %E16)
+  %vec = call <4 x float> @llvm.ldexp.v4f32.v4i32(
+             <4 x float> <float 1.000000e+00, float 2.000000e+00,
+                          float 3.000000e+00, float 4.000000e+00>,
+             <4 x i32> %EV)
+
+  %dsum = fadd double %d32, %d64
+  %fsum = fadd float %f32, %f16
+  store double %dsum, ptr addrspace(1) %DOut
+  store float %fsum, ptr addrspace(1) %FOut
+  store half %h32, ptr addrspace(1) %HOut
+  store <4 x float> %vec, ptr addrspace(1) %VOut
+  ret void
+}

--- a/tests/compiler/mathIntrinsics/llround.ll
+++ b/tests/compiler/mathIntrinsics/llround.ll
@@ -1,0 +1,27 @@
+; The llvm.llround / llvm.llrint half of HipLowerRoundIntrinsicsPass, which had
+; no test of its own. Guards against a regression in the rewrite that
+; llvm.ldexp support was bolted onto.
+;
+; See CHIP-SPV/chipStar#1404.
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spirv64"
+
+declare i64 @llvm.llround.i64.f32(float)
+declare i64 @llvm.llround.i64.f64(double)
+declare i64 @llvm.llrint.i64.f32(float)
+declare i64 @llvm.llrint.i64.f64(double)
+
+define spir_kernel void @llround_variants(ptr addrspace(1) %Out, float %F,
+                                          double %D) {
+entry:
+  %a = call i64 @llvm.llround.i64.f32(float %F)
+  %b = call i64 @llvm.llround.i64.f64(double %D)
+  %c = call i64 @llvm.llrint.i64.f32(float %F)
+  %d = call i64 @llvm.llrint.i64.f64(double %D)
+  %ab = add i64 %a, %b
+  %cd = add i64 %c, %d
+  %sum = add i64 %ab, %cd
+  store i64 %sum, ptr addrspace(1) %Out
+  ret void
+}

--- a/tests/compiler/mathIntrinsics/run_math_intrinsics_pass.bash
+++ b/tests/compiler/mathIntrinsics/run_math_intrinsics_pass.bash
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Check that HipLowerRoundIntrinsicsPass leaves behind no llvm math intrinsic
+# llvm-spirv cannot translate, and that the result really does translate.
+#
+# Usage: run_math_intrinsics_pass.bash <input.ll>
+#
+# llvm.llround, llvm.llrint and llvm.ldexp all reach hipspv-link intact and all
+# die there with
+#
+#   InvalidFunctionCall: Unexpected llvm intrinsic: <name>
+#
+# with no source location, so the only cheap way to catch a regression is to
+# look at the module after the pass pipeline and then hand it to the translator.
+# See CHIP-SPV/chipStar#1404.
+
+set -e
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <input.ll>"
+  exit 1
+fi
+
+INPUT_FILE="$1"
+BASE_NAME=$(basename "${INPUT_FILE}" .ll)
+OUTPUT_BC="${BASE_NAME}.math.bc"
+OUTPUT_LL="${BASE_NAME}.math.ll"
+OUTPUT_SPV="${BASE_NAME}.math.spv"
+SPIRV_OPTS="--spirv-max-version=1.2 --spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups"
+
+# CHIP_VERIFY_MODE=off for the same reason promoteInt does it: the in-pass
+# IR->SPIR-V re-verification is on by default in Debug builds and is redundant
+# here, the translation below is the check.
+CHIP_VERIFY_MODE=off "${LLVM_OPT}" -load-pass-plugin "${HIP_SPV_PASSES_LIB}" \
+  -passes=hip-post-link-passes "${INPUT_FILE}" -o "${OUTPUT_BC}"
+"${LLVM_DIS}" "${OUTPUT_BC}" -o "${OUTPUT_LL}"
+
+KERNELS=$(grep -c 'spir_kernel' "${OUTPUT_LL}" || true)
+if [ "${KERNELS}" -eq 0 ]; then
+  echo "ERROR: no spir_kernel survived the pass pipeline; test input is stale"
+  exit 1
+fi
+
+LEFTOVER=$(grep -o -E 'llvm\.(llround|llrint|ldexp)\.[a-z0-9.]+' "${OUTPUT_LL}" |
+           sort -u || true)
+if [ -n "${LEFTOVER}" ]; then
+  echo "ERROR: untranslatable intrinsic(s) survived the pass pipeline:"
+  echo "${LEFTOVER}"
+  echo "See ${OUTPUT_LL} for details"
+  exit 1
+fi
+
+# The rewrite is only useful if the translator actually accepts the result.
+"${LLVM_SPIRV}" "${OUTPUT_BC}" ${SPIRV_OPTS} -o "${OUTPUT_SPV}"
+
+echo "kernels=${KERNELS} no untranslatable math intrinsics, SPIR-V ok"
+exit 0

--- a/tests/devicelib/CMakeLists.txt
+++ b/tests/devicelib/CMakeLists.txt
@@ -79,3 +79,7 @@ set_tests_properties(TestAtomicFPMinMaxBuiltins PROPERTIES
 add_hip_test(TestStdLlroundFloat.cpp)
 set_tests_properties(TestStdLlroundFloat PROPERTIES
   PASS_REGULAR_EXPRESSION "PASSED")
+
+add_hip_test(TestStdLdexp.cpp)
+set_tests_properties(TestStdLdexp PROPERTIES
+  PASS_REGULAR_EXPRESSION "PASSED")

--- a/tests/devicelib/TestStdLdexp.cpp
+++ b/tests/devicelib/TestStdLdexp.cpp
@@ -1,0 +1,99 @@
+// Reproduces: std::ldexp in device code emits llvm.ldexp, which llvm-spirv
+// cannot translate.
+//
+// libstdc++ declares std::ldexp as constexpr, which HIP turns into an
+// implicitly __host__ __device__ function, so it wins overload resolution over
+// chipStar's __device__ ldexp and expands to __builtin_ldexp. The module then
+// carries an llvm.ldexp intrinsic and hipspv-link dies with
+//
+//   InvalidFunctionCall: Unexpected llvm intrinsic: llvm.ldexp.f64.i32
+//
+// with no source location at all. Same shape as the llvm.llround failure this
+// pass was originally written for, and found the same way: it was sitting right
+// behind it in Kokkos_CoreUnitTest_HIP.
+//
+// The exponents below are deliberately not compile time constants: a constant
+// one is folded away before the pass ever sees an intrinsic, which would make
+// the test pass even with the lowering removed.
+
+#include <hip/hip_runtime.h>
+#include <cmath>
+#include <cstdio>
+
+#define CHECK(X)                                                               \
+  do {                                                                         \
+    hipError_t E = (X);                                                        \
+    if (E != hipSuccess) {                                                     \
+      printf("FAILED: %s -> %s\n", #X, hipGetErrorString(E));                  \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+__device__ double callLdexpDouble(double X, int Exp) {
+  using std::ldexp;
+  return ldexp(X, Exp);
+}
+
+__device__ float callLdexpFloat(float X, int Exp) {
+  using std::ldexp;
+  return ldexp(X, Exp);
+}
+
+__global__ void run(double *DOut, float *FOut, const int *Exps) {
+  DOut[0] = callLdexpDouble(3.0, Exps[0]);   //  3 * 2^4    = 48
+  DOut[1] = callLdexpDouble(-1.5, Exps[1]);  // -1.5 * 2^-3 = -0.1875
+  DOut[2] = callLdexpDouble(1.0, Exps[2]);   //  1 * 2^0    = 1
+  DOut[3] = callLdexpDouble(0.0, Exps[0]);   //  0 stays 0
+  FOut[0] = callLdexpFloat(3.0f, Exps[0]);
+  FOut[1] = callLdexpFloat(-1.5f, Exps[1]);
+  FOut[2] = callLdexpFloat(1.0f, Exps[2]);
+  // A power of two large enough that a naive x * 2^n lowering would overflow
+  // the intermediate: 2^-120 * 2^120 must come back as exactly 1.
+  FOut[3] = callLdexpFloat(7.52316385e-37f /* 2^-120 */, Exps[3]);
+}
+
+int main() {
+  const int HostExps[4] = {4, -3, 0, 120};
+  int *Exps;
+  double *DOut;
+  float *FOut;
+  CHECK(hipMalloc(&Exps, sizeof(HostExps)));
+  CHECK(hipMalloc(&DOut, 4 * sizeof(double)));
+  CHECK(hipMalloc(&FOut, 4 * sizeof(float)));
+  CHECK(hipMemcpy(Exps, HostExps, sizeof(HostExps), hipMemcpyHostToDevice));
+
+  hipLaunchKernelGGL(run, dim3(1), dim3(1), 0, 0, DOut, FOut, Exps);
+  CHECK(hipDeviceSynchronize());
+
+  double D[4];
+  float F[4];
+  CHECK(hipMemcpy(D, DOut, sizeof(D), hipMemcpyDeviceToHost));
+  CHECK(hipMemcpy(F, FOut, sizeof(F), hipMemcpyDeviceToHost));
+
+  const double DExpected[4] = {48.0, -0.1875, 1.0, 0.0};
+  const float FExpected[4] = {48.0f, -0.1875f, 1.0f, 1.0f};
+
+  int Errors = 0;
+  for (int I = 0; I < 4; ++I) {
+    if (D[I] != DExpected[I]) {
+      printf("double ldexp #%d: got %g, expected %g\n", I, D[I], DExpected[I]);
+      ++Errors;
+    }
+    if (F[I] != FExpected[I]) {
+      printf("float ldexp #%d: got %g, expected %g\n", I, (double)F[I],
+             (double)FExpected[I]);
+      ++Errors;
+    }
+  }
+
+  CHECK(hipFree(Exps));
+  CHECK(hipFree(DOut));
+  CHECK(hipFree(FOut));
+
+  if (Errors) {
+    printf("FAILED\n");
+    return 1;
+  }
+  printf("PASSED\n");
+  return 0;
+}

--- a/tests/devicelib/TestStdLdexp.cpp
+++ b/tests/devicelib/TestStdLdexp.cpp
@@ -15,10 +15,22 @@
 // The exponents below are deliberately not compile time constants: a constant
 // one is folded away before the pass ever sees an intrinsic, which would make
 // the test pass even with the lowering removed.
+//
+// The float and double calls sit in separate kernels, and the double kernel is
+// not launched when fp64 is IGC software emulation (IGC_EnableDPEmulation=1,
+// which is how the x86 Intel GPU CI runs its fp64-less devices): on the UHD 730
+// the emulated ldexp(double) hangs the GPU for this set of inputs, and a kernel
+// mixing a float and a double ldexp returns 0 for the float one, see
+// https://github.com/CHIP-SPV/chipStar/issues/1536. Keeping the kernels apart
+// leaves the float lowering covered there. The module still needs an fp64
+// device to build at all, so this is a skip of the double half only, not fp64
+// portability; the skip can go once IGC's emulation handles ldexp.
 
 #include <hip/hip_runtime.h>
 #include <cmath>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #define CHECK(X)                                                               \
   do {                                                                         \
@@ -39,11 +51,14 @@ __device__ float callLdexpFloat(float X, int Exp) {
   return ldexp(X, Exp);
 }
 
-__global__ void run(double *DOut, float *FOut, const int *Exps) {
+__global__ void runDouble(double *DOut, const int *Exps) {
   DOut[0] = callLdexpDouble(3.0, Exps[0]);   //  3 * 2^4    = 48
   DOut[1] = callLdexpDouble(-1.5, Exps[1]);  // -1.5 * 2^-3 = -0.1875
   DOut[2] = callLdexpDouble(1.0, Exps[2]);   //  1 * 2^0    = 1
   DOut[3] = callLdexpDouble(0.0, Exps[0]);   //  0 stays 0
+}
+
+__global__ void runFloat(float *FOut, const int *Exps) {
   FOut[0] = callLdexpFloat(3.0f, Exps[0]);
   FOut[1] = callLdexpFloat(-1.5f, Exps[1]);
   FOut[2] = callLdexpFloat(1.0f, Exps[2]);
@@ -52,8 +67,15 @@ __global__ void run(double *DOut, float *FOut, const int *Exps) {
   FOut[3] = callLdexpFloat(7.52316385e-37f /* 2^-120 */, Exps[3]);
 }
 
+/// True when IGC is emulating fp64 in software (see the header comment).
+static bool fp64IsEmulated() {
+  const char *Var = getenv("IGC_EnableDPEmulation");
+  return Var && *Var && strcmp(Var, "0") != 0;
+}
+
 int main() {
   const int HostExps[4] = {4, -3, 0, 120};
+  const bool RunDouble = !fp64IsEmulated();
   int *Exps;
   double *DOut;
   float *FOut;
@@ -62,12 +84,17 @@ int main() {
   CHECK(hipMalloc(&FOut, 4 * sizeof(float)));
   CHECK(hipMemcpy(Exps, HostExps, sizeof(HostExps), hipMemcpyHostToDevice));
 
-  hipLaunchKernelGGL(run, dim3(1), dim3(1), 0, 0, DOut, FOut, Exps);
+  hipLaunchKernelGGL(runFloat, dim3(1), dim3(1), 0, 0, FOut, Exps);
+  if (RunDouble)
+    hipLaunchKernelGGL(runDouble, dim3(1), dim3(1), 0, 0, DOut, Exps);
+  else
+    printf("fp64 is IGC software emulation, skipping the double kernel\n");
   CHECK(hipDeviceSynchronize());
 
   double D[4];
   float F[4];
-  CHECK(hipMemcpy(D, DOut, sizeof(D), hipMemcpyDeviceToHost));
+  if (RunDouble)
+    CHECK(hipMemcpy(D, DOut, sizeof(D), hipMemcpyDeviceToHost));
   CHECK(hipMemcpy(F, FOut, sizeof(F), hipMemcpyDeviceToHost));
 
   const double DExpected[4] = {48.0, -0.1875, 1.0, 0.0};
@@ -75,7 +102,7 @@ int main() {
 
   int Errors = 0;
   for (int I = 0; I < 4; ++I) {
-    if (D[I] != DExpected[I]) {
+    if (RunDouble && D[I] != DExpected[I]) {
       printf("double ldexp #%d: got %g, expected %g\n", I, D[I], DExpected[I]);
       ++Errors;
     }

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -163,6 +163,14 @@ set_tests_properties(TestEventResetWarnFlood PROPERTIES
 # __clz(0)-poison miscompile only manifests at -O1 and above.
 target_compile_options(TestSnakeMiscompileO2 PRIVATE -O2)
 
+# Reproducer for the unresolved C99 <cmath> float libcalls (tgammaf and co).
+# Run at warn level so the runtime's "Missing definition for 'tgammaf'" report
+# is visible, and fail on it: on Level Zero the unresolved import surfaces only
+# later, as ZE_RESULT_ERROR_INVALID_MODULE_UNLINKED after the relink fallback.
+set_tests_properties(TestFixStdCmathFloatLibcalls PROPERTIES
+  ENVIRONMENT "CHIP_LOGLEVEL=warn"
+  FAIL_REGULAR_EXPRESSION "FAIL;Missing definition for")
+
 ######################################
 # Extra ctest invocations of already-registered executables.
 ######################################

--- a/tests/runtime/TestFixStdCmathFloatLibcalls.hip
+++ b/tests/runtime/TestFixStdCmathFloatLibcalls.hip
@@ -1,0 +1,319 @@
+// Reproduces: the C99 libcalls behind libstdc++'s <cmath> float overloads are
+// undefined in the device module, so the driver refuses to link it.
+//
+// libstdc++ implements std::tgamma(float) and friends as constexpr inline
+// wrappers around __builtin_tgammaf. HIP makes constexpr functions implicitly
+// __host__ __device__, so in device code they win overload resolution over
+// chipStar's extern "C++" __device__ float tgamma(float) unless sp_math.hh
+// re-exports that one into namespace std (it does for acosh, lgamma, log1p,
+// nearbyint, nextafter, ... but not for these). Builtins with no LLVM
+// intrinsic then lower to calls of the C-linkage names:
+//
+//   asinhf atanhf fdimf ilogbf logbf nexttowardf remainderf scalblnf scalbnf
+//   tgammaf
+//
+// Nothing defines those: sp_math.hh only has C++-linkage overloads, and
+// bitcode/c_to_opencl.def, the table that maps the C names of the other
+// <cmath> functions (expf, cosf, lgammaf, ...) to OpenCL builtins inside the
+// device library hipspv-link pulls in at compile time, lacks them. The SPIR-V
+// module imports them and the JIT fails:
+//
+//   CHIP warning : Missing definition for 'tgammaf'
+//   error : unresolved external symbol tgammaf at offset 1644 in instructions
+//   segment #4336 (aka kernel : _ZN6Kokkos4ImplL32hip_parallel_launch_...)
+//   CHIP warning : Module created with multiple inputs is unlinked.
+//   Attempting fallback: create separate modules and link.
+//
+// Found with Kokkos_CoreUnitTest_HIP (TestMathematicalFunctions.hpp, float
+// variants) on Aurora PVC, where it costs a 340 s device compile plus the
+// multi-input relink fallback before failing.
+//
+// The same route exists for long double, which is a 64-bit double on spirv64:
+// std::tgamma(long double) compiles and reaches tgammal. The double overloads
+// take a different route: libstdc++ gets them from <math.h> as plain host
+// functions, so chipStar's __device__ overloads win and no C name is formed.
+// The unsuffixed C names (tgamma, asinh, ...) are still reachable through
+// __builtin_* directly, or through optimizer-synthesised calls (#880's
+// pow(2, i) -> ldexpf), so the Builtin flavour below covers them for float and
+// double.
+//
+// Every argument is loaded from memory so nothing constant-folds away. The
+// point is that the module links and every symbol resolves; the values are a
+// secondary check with a loose tolerance.
+
+#include <hip/hip_runtime.h>
+#include <cmath>
+#include <cstdio>
+#include <type_traits>
+
+// (name, argument): every unary <cmath> function libstdc++ implements for
+// float through __builtin_*f (GCC 13 <cmath>), plus the classic ones.
+#define UNARY_LIST(X)                                                          \
+  X(acos, x) X(acosh, xp1) X(asin, x) X(asinh, x) X(atan, x) X(atanh, x)       \
+  X(cbrt, x) X(ceil, y) X(cos, x) X(cosh, x) X(erf, x) X(erfc, x) X(exp, x)     \
+  X(exp2, x) X(expm1, x) X(fabs, nx) X(floor, y) X(lgamma, x) X(log, xp1)      \
+  X(log10, xp1) X(log1p, x) X(log2, xp1) X(logb, y) X(nearbyint, y)            \
+  X(rint, y) X(round, y) X(sin, x) X(sinh, x) X(sqrt, x) X(tan, x) X(tanh, x)  \
+  X(tgamma, x) X(trunc, y)
+
+// (name, lhs, rhs)
+#define BINARY_LIST(X)                                                         \
+  X(atan2, x, y) X(copysign, x, ny) X(fdim, y, x) X(fmax, x, y) X(fmin, x, y)  \
+  X(fmod, y, x) X(hypot, x, y) X(nextafter, x, y) X(pow, x, y)                 \
+  X(remainder, y, x)
+
+// Functions with other signatures are spelled out in evalAll below, in this
+// order: fma, ldexp, scalbn, scalbln, frexp (+ exponent), modf (+ integral
+// part), remquo (+ quotient), nexttoward; then the integer-valued ilogb,
+// lrint, lround, llrint, llround.
+#define COUNT1(NAME, ARG) +1
+#define COUNT2(NAME, A, B) +1
+constexpr int NumOut = 0 UNARY_LIST(COUNT1) BINARY_LIST(COUNT2) + 9;
+constexpr int NumIOut = 7;
+
+// Per-type wrappers so one evaluator can reach both the std:: overloads and
+// the __builtin_* forms that name the C functions directly.
+#define DEF_BUILTIN1(NAME, ARG)                                                \
+  __host__ __device__ inline float bi_##NAME(float a) {                        \
+    return __builtin_##NAME##f(a);                                             \
+  }                                                                            \
+  __host__ __device__ inline double bi_##NAME(double a) {                      \
+    return __builtin_##NAME(a);                                                \
+  }
+#define DEF_BUILTIN2(NAME, A, B)                                               \
+  __host__ __device__ inline float bi_##NAME(float a, float b) {               \
+    return __builtin_##NAME##f(a, b);                                          \
+  }                                                                            \
+  __host__ __device__ inline double bi_##NAME(double a, double b) {            \
+    return __builtin_##NAME(a, b);                                             \
+  }
+UNARY_LIST(DEF_BUILTIN1)
+BINARY_LIST(DEF_BUILTIN2)
+__host__ __device__ inline float bi_fma(float a, float b, float c) {
+  return __builtin_fmaf(a, b, c);
+}
+__host__ __device__ inline double bi_fma(double a, double b, double c) {
+  return __builtin_fma(a, b, c);
+}
+__host__ __device__ inline float bi_ldexp(float a, int n) {
+  return __builtin_ldexpf(a, n);
+}
+__host__ __device__ inline double bi_ldexp(double a, int n) {
+  return __builtin_ldexp(a, n);
+}
+__host__ __device__ inline float bi_scalbn(float a, int n) {
+  return __builtin_scalbnf(a, n);
+}
+__host__ __device__ inline double bi_scalbn(double a, int n) {
+  return __builtin_scalbn(a, n);
+}
+__host__ __device__ inline float bi_scalbln(float a, long n) {
+  return __builtin_scalblnf(a, n);
+}
+__host__ __device__ inline double bi_scalbln(double a, long n) {
+  return __builtin_scalbln(a, n);
+}
+__host__ __device__ inline float bi_nexttoward(float a, long double b) {
+  return __builtin_nexttowardf(a, b);
+}
+__host__ __device__ inline double bi_nexttoward(double a, long double b) {
+  return __builtin_nexttoward(a, b);
+}
+__host__ __device__ inline int bi_ilogb(float a) { return __builtin_ilogbf(a); }
+__host__ __device__ inline int bi_ilogb(double a) { return __builtin_ilogb(a); }
+__host__ __device__ inline long bi_lrint(float a) { return __builtin_lrintf(a); }
+__host__ __device__ inline long bi_lrint(double a) { return __builtin_lrint(a); }
+__host__ __device__ inline long bi_lround(float a) {
+  return __builtin_lroundf(a);
+}
+__host__ __device__ inline long bi_lround(double a) {
+  return __builtin_lround(a);
+}
+__host__ __device__ inline long long bi_llrint(float a) {
+  return __builtin_llrintf(a);
+}
+__host__ __device__ inline long long bi_llrint(double a) {
+  return __builtin_llrint(a);
+}
+__host__ __device__ inline long long bi_llround(float a) {
+  return __builtin_llroundf(a);
+}
+__host__ __device__ inline long long bi_llround(double a) {
+  return __builtin_llround(a);
+}
+
+// One body for the kernels and for the host reference, so the two cannot
+// drift apart. T is the argument type, OutT the storage type (long double is
+// 8 bytes on the device and 16 on the host, so it is stored as double).
+template <typename T, typename OutT, bool UseBuiltin>
+__host__ __device__ void evalAll(T x, T y, int n, long ln, OutT *Out,
+                                 long long *IOut) {
+  constexpr bool IsLongDouble = std::is_same<T, long double>::value;
+  constexpr bool IsDouble = std::is_same<T, double>::value;
+  T xp1 = x + T(1);
+  T nx = -x;
+  T ny = -y;
+  int i = 0;
+  int j = 0;
+#define EVAL1(NAME, ARG)                                                       \
+  if constexpr (UseBuiltin)                                                    \
+    Out[i++] = (OutT)bi_##NAME(ARG);                                           \
+  else                                                                         \
+    Out[i++] = (OutT)std::NAME(ARG);
+#define EVAL2(NAME, A, B)                                                      \
+  if constexpr (UseBuiltin)                                                    \
+    Out[i++] = (OutT)bi_##NAME(A, B);                                          \
+  else                                                                         \
+    Out[i++] = (OutT)std::NAME(A, B);
+  UNARY_LIST(EVAL1)
+  BINARY_LIST(EVAL2)
+#undef EVAL1
+#undef EVAL2
+  if constexpr (UseBuiltin) {
+    Out[i++] = (OutT)bi_fma(x, y, x);
+    Out[i++] = (OutT)bi_ldexp(x, n);
+    Out[i++] = (OutT)bi_scalbn(x, n);
+    Out[i++] = (OutT)bi_scalbln(x, ln);
+  } else {
+    Out[i++] = (OutT)std::fma(x, y, x);
+    Out[i++] = (OutT)std::ldexp(x, n);
+    Out[i++] = (OutT)std::scalbn(x, n);
+    Out[i++] = (OutT)std::scalbln(x, ln);
+  }
+  // frexp, modf and remquo take a pointer. Through std:: they resolve to
+  // chipStar's __device__ overloads on every type that has a viable one, so
+  // they never form a C name; they are evaluated through std:: in both
+  // flavours. std::modf(long double, long double *) has no device candidate
+  // at all, so that slot is a placeholder for long double.
+  int e = 0;
+  Out[i++] = (OutT)std::frexp(y, &e);
+  IOut[j++] = e;
+  if constexpr (IsLongDouble) {
+    Out[i++] = (OutT)(y - std::trunc(y));
+    Out[i++] = (OutT)std::trunc(y);
+  } else {
+    T ip = 0;
+    Out[i++] = (OutT)std::modf(y, &ip);
+    Out[i++] = (OutT)ip;
+  }
+  int q = 0;
+  Out[i++] = (OutT)std::remquo(y, x, &q);
+  IOut[j++] = q;
+  // std::nexttoward(double, long double) is ambiguous in device code (the
+  // exact match is libstdc++'s host-only one), so that slot is a placeholder.
+  if constexpr (UseBuiltin)
+    Out[i++] = (OutT)bi_nexttoward(x, (long double)y);
+  else if constexpr (IsDouble)
+    Out[i++] = (OutT)x;
+  else
+    Out[i++] = (OutT)std::nexttoward(x, (long double)y);
+  if constexpr (UseBuiltin) {
+    IOut[j++] = bi_ilogb(y);
+    IOut[j++] = bi_lrint(y);
+    IOut[j++] = bi_lround(y);
+    IOut[j++] = bi_llrint(y);
+    IOut[j++] = bi_llround(y);
+  } else {
+    IOut[j++] = std::ilogb(y);
+    IOut[j++] = std::lrint(y);
+    IOut[j++] = std::lround(y);
+    IOut[j++] = std::llrint(y);
+    IOut[j++] = std::llround(y);
+  }
+}
+
+template <typename T, typename OutT, bool UseBuiltin>
+__global__ void evalKernel(const OutT *In, const int *IIn, OutT *Out,
+                           long long *IOut) {
+  evalAll<T, OutT, UseBuiltin>((T)In[0], (T)In[1], IIn[0], (long)IIn[1], Out,
+                               IOut);
+}
+
+#define NAME1(NAME, ARG) #NAME,
+#define NAME2(NAME, A, B) #NAME,
+static const char *OutNames[NumOut] = {
+    UNARY_LIST(NAME1) BINARY_LIST(NAME2) "fma",  "ldexp",  "scalbn",
+    "scalbln",        "frexp",           "modf", "modf.ip", "remquo",
+    "nexttoward"};
+static const char *IOutNames[NumIOut] = {"frexp.exp", "remquo.quo", "ilogb",
+                                         "lrint",     "lround",     "llrint",
+                                         "llround"};
+
+template <typename T, typename OutT, bool UseBuiltin>
+int runOne(const char *Label, double Tol) {
+  const OutT HostIn[2] = {(OutT)0.75, (OutT)2.5};
+  const int HostIIn[2] = {3, 3};
+  OutT *In, *Out;
+  int *IIn;
+  long long *IOut;
+  if (hipMalloc(&In, sizeof(HostIn)) != hipSuccess ||
+      hipMalloc(&IIn, sizeof(HostIIn)) != hipSuccess ||
+      hipMalloc(&Out, NumOut * sizeof(OutT)) != hipSuccess ||
+      hipMalloc(&IOut, NumIOut * sizeof(long long)) != hipSuccess) {
+    printf("FAIL: %s: hipMalloc\n", Label);
+    return 1;
+  }
+  (void)hipMemcpy(In, HostIn, sizeof(HostIn), hipMemcpyHostToDevice);
+  (void)hipMemcpy(IIn, HostIIn, sizeof(HostIIn), hipMemcpyHostToDevice);
+
+  evalKernel<T, OutT, UseBuiltin><<<1, 1>>>(In, IIn, Out, IOut);
+  hipError_t LaunchErr = hipGetLastError();
+  hipError_t SyncErr = hipDeviceSynchronize();
+  if (LaunchErr != hipSuccess || SyncErr != hipSuccess) {
+    printf("FAIL: %s: launch=%s sync=%s\n", Label, hipGetErrorString(LaunchErr),
+           hipGetErrorString(SyncErr));
+    return 1;
+  }
+
+  OutT HostOut[NumOut];
+  long long HostIOut[NumIOut];
+  (void)hipMemcpy(HostOut, Out, sizeof(HostOut), hipMemcpyDeviceToHost);
+  (void)hipMemcpy(HostIOut, IOut, sizeof(HostIOut), hipMemcpyDeviceToHost);
+  (void)hipFree(In);
+  (void)hipFree(IIn);
+  (void)hipFree(Out);
+  (void)hipFree(IOut);
+
+  OutT Expected[NumOut];
+  long long IExpected[NumIOut];
+  evalAll<T, OutT, UseBuiltin>((T)HostIn[0], (T)HostIn[1], HostIIn[0],
+                               (long)HostIIn[1], Expected, IExpected);
+
+  int Mismatches = 0;
+  for (int K = 0; K < NumOut; ++K) {
+    double Got = (double)HostOut[K], Want = (double)Expected[K];
+    double Scale = std::fabs(Want) > 1.0 ? std::fabs(Want) : 1.0;
+    if (!(std::fabs(Got - Want) <= Tol * Scale)) {
+      printf("MISMATCH: %s: %s: got %.9g expected %.9g\n", Label, OutNames[K],
+             Got, Want);
+      ++Mismatches;
+    }
+  }
+  for (int K = 0; K < NumIOut; ++K)
+    if (HostIOut[K] != IExpected[K]) {
+      printf("MISMATCH: %s: %s: got %lld expected %lld\n", Label, IOutNames[K],
+             HostIOut[K], IExpected[K]);
+      ++Mismatches;
+    }
+  if (Mismatches) {
+    printf("FAIL: %s: %d mismatches\n", Label, Mismatches);
+    return 1;
+  }
+  printf("%s: ok (%d values, %d integers)\n", Label, NumOut, NumIOut);
+  return 0;
+}
+
+int main() {
+  int Failures = 0;
+  Failures += runOne<float, float, false>("float via std::", 1e-4);
+  Failures += runOne<float, float, true>("float via __builtin_*f", 1e-4);
+  Failures += runOne<double, double, false>("double via std::", 1e-9);
+  Failures += runOne<double, double, true>("double via __builtin_*", 1e-9);
+  Failures += runOne<long double, double, false>("long double via std::", 1e-9);
+  if (Failures) {
+    printf("FAIL\n");
+    return 1;
+  }
+  printf("PASS\n");
+  return 0;
+}

--- a/tests/runtime/TestFixStdCmathFloatLibcalls.hip
+++ b/tests/runtime/TestFixStdCmathFloatLibcalls.hip
@@ -46,6 +46,26 @@
 #include <cstdio>
 #include <type_traits>
 
+// The std:: route to the C names is a libstdc++ property: its float and long
+// double overloads are constexpr wrappers, so HIP treats them as __host__
+// __device__ and they reach __builtin_*f / __builtin_*l. libc++ (macOS)
+// implements them as plain host inlines. There, std::acosh(float) still works
+// because libc++ pulls the C names into std with using-declarations, which
+// picks up chipStar's __device__ float overloads and, since a same-side
+// candidate exists, drops the host one. Two calls have no such fallback and
+// do not compile in device code on libc++:
+//
+//   - every long double call: chipStar has no long double overloads, so the
+//     float and double ones tie ("call to 'acosh' is ambiguous");
+//   - std::nexttoward(float, long double): chipStar has no nexttoward at all.
+//
+// Those slots are exercised through std:: only where the route exists.
+#if defined(__GLIBCXX__)
+#define STD_ROUTE_TO_LIBCALLS 1
+#else
+#define STD_ROUTE_TO_LIBCALLS 0
+#endif
+
 // (name, argument): every unary <cmath> function libstdc++ implements for
 // float through __builtin_*f (GCC 13 <cmath>), plus the classic ones.
 #define UNARY_LIST(X)                                                          \
@@ -200,10 +220,11 @@ __host__ __device__ void evalAll(T x, T y, int n, long ln, OutT *Out,
   Out[i++] = (OutT)std::remquo(y, x, &q);
   IOut[j++] = q;
   // std::nexttoward(double, long double) is ambiguous in device code (the
-  // exact match is libstdc++'s host-only one), so that slot is a placeholder.
+  // exact match is libstdc++'s host-only one), so that slot is a placeholder,
+  // as it is for every type on libc++.
   if constexpr (UseBuiltin)
     Out[i++] = (OutT)bi_nexttoward(x, (long double)y);
-  else if constexpr (IsDouble)
+  else if constexpr (IsDouble || !STD_ROUTE_TO_LIBCALLS)
     Out[i++] = (OutT)x;
   else
     Out[i++] = (OutT)std::nexttoward(x, (long double)y);
@@ -309,7 +330,9 @@ int main() {
   Failures += runOne<float, float, true>("float via __builtin_*f", 1e-4);
   Failures += runOne<double, double, false>("double via std::", 1e-9);
   Failures += runOne<double, double, true>("double via __builtin_*", 1e-9);
+#if STD_ROUTE_TO_LIBCALLS
   Failures += runOne<long double, double, false>("long double via std::", 1e-9);
+#endif
   if (Failures) {
     printf("FAIL\n");
     return 1;

--- a/tests/runtime/TestFixStdCmathFloatLibcalls.hip
+++ b/tests/runtime/TestFixStdCmathFloatLibcalls.hip
@@ -324,14 +324,22 @@ int runOne(const char *Label, double Tol) {
   return 0;
 }
 
+// The tolerances only have to tell the right OpenCL builtin from the wrong
+// one (tan for tanh, swapped arguments, ...); ULP accuracy is the math
+// suites' business. The double bound admits rusticl/radeonsi, whose fp64 is
+// off by default as non-conformant (RUSTICL_FEATURES=fp64 in Mesa's
+// docs/envvars.rst) and whose sqrt, rsqrt and division are accurate to about
+// 2^-27: its OpenCL sqrt(0.75) is 0.866025410592556 against the correctly
+// rounded 0.8660254037844386, a relative error of 7.9e-9 that hypot and tan
+// inherit. 1e-9 tripped on exactly those three.
 int main() {
   int Failures = 0;
   Failures += runOne<float, float, false>("float via std::", 1e-4);
   Failures += runOne<float, float, true>("float via __builtin_*f", 1e-4);
-  Failures += runOne<double, double, false>("double via std::", 1e-9);
-  Failures += runOne<double, double, true>("double via __builtin_*", 1e-9);
+  Failures += runOne<double, double, false>("double via std::", 1e-6);
+  Failures += runOne<double, double, true>("double via __builtin_*", 1e-6);
 #if STD_ROUTE_TO_LIBCALLS
-  Failures += runOne<long double, double, false>("long double via std::", 1e-9);
+  Failures += runOne<long double, double, false>("long double via std::", 1e-6);
 #endif
   if (Failures) {
     printf("FAIL\n");


### PR DESCRIPTION
libstdc++ implements its float and long double `<cmath>` overloads as constexpr wrappers around `__builtin_*f` and `__builtin_*l`, which HIP makes implicitly `__host__ __device__`, so in device code they beat chipStar's `__device__` overloads and compile to C99 libcalls (`tgammaf`, `asinhf`, `scalbnf` and 41 more) that the device library never defined, leaving dangling imports in the SPIR-V module and `ZE_RESULT_ERROR_INVALID_MODULE_UNLINKED` with `unresolved external symbol tgammaf` when `Kokkos_CoreUnitTest_HIP` was linked on Aurora PVC. This maps the missing float, double and long double names in `bitcode/c_to_opencl.def` to OpenCL builtins, adding two table shapes for the signatures the existing macros cannot express (`ilogb` returning int, `scalbn`, `scalbln` and `nexttoward` taking a mixed second operand) and small `devicelib.cl` helpers for the `scalbln` exponent clamp and the `nexttowardf` conversion rule. It also carries the `llvm.ldexp` lowering it depends on: clang emits `llvm.ldexp` for `std::ldexp` and `scalbn`, which no SPIR-V producer accepts (https://github.com/CHIP-SPV/chipStar/issues/1437), so `HipLowerRoundIntrinsics` now rewrites it to the OpenCL `ldexp` builtin. That lowering is a temporary workaround, not the real fix. Both upstream fixes have already merged, llvm/llvm-project#195402 https://github.com/llvm/llvm-project/pull/195402 for the in tree SPIR-V backend and KhronosGroup/SPIRV-LLVM-Translator#3608 https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/3608 for the translator, but neither has reached a version chipStar pins: #195402 landed on `main` after the `llvmorg-23.1.0-rc2` tag and is not on `release/23.x`, and the LLVM 21 lanes will never receive it. The block is delimited in the source by `WORKAROUND` and `END WORKAROUND` comments and comes out when those propagate; https://github.com/CHIP-SPV/chipStar/issues/1476 holds the removal condition for the whole pass. `TestFixStdCmathFloatLibcalls` evaluates every `<cmath>` overload against the host and fails on any `Missing definition for` warning; `TestStdLdexp` and the `mathIntrinsics` opt fixtures cover the lowering.

Fixes #1437
Fixes #1509

