### PR TITLE
hipGraph: fixes needed by Kokkos::Graph on chipStar

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -2191,7 +2191,12 @@ void chipstar::Queue::updateLastNode(CHIPGraphNode *NewNode) {
   LastNode_ = NewNode;
 }
 
-void chipstar::Queue::initCaptureGraph() { CaptureGraph_ = new CHIPGraph(); }
+void chipstar::Queue::initCaptureGraph() {
+  CaptureGraph_ = new CHIPGraph();
+  // The first node recorded into the new graph is a root; a node left over
+  // from an earlier capture on this stream belongs to another graph.
+  LastNode_ = nullptr;
+}
 
 std::shared_ptr<chipstar::Event>
 chipstar::Queue::RegisteredVarCopy(chipstar::ExecItem *ExecItem,

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -2309,7 +2309,6 @@ public:
    */
   template <class GraphNodeType, class... ArgTypes>
   bool captureIntoGraph(ArgTypes... ArgsPack) {
-    return false; // TODO: fix this in graphs refactor
     if (getCaptureStatus() == hipStreamCaptureStatusActive) {
       auto Graph = getCaptureGraph();
       auto Node = new GraphNodeType(ArgsPack...);

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -284,13 +284,46 @@ hipError_t hipGraphMemFreeNodeGetParams(hipGraphNode_t node, void *dptr) {
   CHIP_CATCH
 }
 
+/// Resolve hNode to its copy in hGraphExec for hipGraphNodeGetEnabled and
+/// hipGraphNodeSetEnabled. The enabled switch is defined for kernel, memcpy
+/// and memset nodes only; any other type, and a node that was not part of the
+/// graph when hGraphExec was instantiated, is hipErrorInvalidValue.
+static CHIPGraphNode *findEnableableExecNode(hipGraphExec_t hGraphExec,
+                                             hipGraphNode_t hNode) {
+  if (!hGraphExec || !hNode)
+    CHIPERR_LOG_AND_THROW("Null hipGraphExec_t or hipGraphNode_t",
+                          hipErrorInvalidValue);
+
+  auto *ExecNode = EXEC(hGraphExec)->getExecNode(NODE(hNode));
+  if (!ExecNode)
+    CHIPERR_LOG_AND_THROW("Node is not part of the instantiated graph",
+                          hipErrorInvalidValue);
+
+  switch (ExecNode->getType()) {
+  case hipGraphNodeTypeKernel:
+  case hipGraphNodeTypeMemcpy:
+  case hipGraphNodeTypeMemset:
+    break;
+  default:
+    CHIPERR_LOG_AND_THROW(
+        "Only kernel, memcpy and memset nodes can be enabled or disabled",
+        hipErrorInvalidValue);
+  }
+  return ExecNode;
+}
+
 hipError_t hipGraphNodeGetEnabled(hipGraphExec_t hGraphExec,
                                   hipGraphNode_t hNode,
                                   unsigned int *isEnabled) {
   CHIP_TRY
   LOCK(ApiMtx);
   CHIPInitialize();
-  UNIMPLEMENTED(hipErrorNotSupported);
+
+  if (!isEnabled)
+    RETURN(hipErrorInvalidValue);
+
+  *isEnabled = findEnableableExecNode(hGraphExec, hNode)->isEnabled() ? 1 : 0;
+  RETURN(hipSuccess);
   CHIP_CATCH
 }
 
@@ -300,7 +333,9 @@ hipError_t hipGraphNodeSetEnabled(hipGraphExec_t hGraphExec,
   CHIP_TRY
   LOCK(ApiMtx);
   CHIPInitialize();
-  UNIMPLEMENTED(hipErrorNotSupported);
+
+  findEnableableExecNode(hGraphExec, hNode)->setEnabled(isEnabled != 0);
+  RETURN(hipSuccess);
   CHIP_CATCH
 }
 

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -227,7 +227,14 @@ hipError_t hipGraphDebugDotPrint(hipGraph_t graph, const char *path,
   CHIP_TRY
   LOCK(ApiMtx);
   CHIPInitialize();
-  UNIMPLEMENTED(hipErrorNotSupported);
+  if (!graph || !path)
+    RETURN(hipErrorInvalidValue);
+  std::ofstream Out(path);
+  if (!Out)
+    RETURN(hipErrorOperatingSystem);
+  GRAPH(graph)->writeDot(Out, flags);
+  Out.close();
+  RETURN(Out.good() ? hipSuccess : hipErrorOperatingSystem);
   CHIP_CATCH
 }
 

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -972,6 +972,14 @@ hipError_t hipLaunchHostFunc(hipStream_t stream, hipHostFn_t fn,
 
   auto ChipQueue = Backend->findQueue(static_cast<chipstar::Queue *>(stream));
 
+  // On a capturing stream the call is recorded as a host node, which runs
+  // the function in dependency order when the graph is launched.
+  hipHostNodeParams Params = {};
+  Params.fn = fn;
+  Params.userData = userData;
+  if (ChipQueue->captureIntoGraph<CHIPGraphNodeHost>(&Params))
+    RETURN(hipSuccess);
+
   ChipQueue->launchHostFunc(fn, userData);
   RETURN(hipSuccess);
   CHIP_CATCH

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2302,8 +2302,10 @@ hipError_t hipGraphExecChildGraphNodeSetParams(hipGraphExec_t hGraphExec,
 
   auto CastNode = static_cast<CHIPGraphNodeGraph *>(node);
 
-  // Check if childGraph is not parent graph
-  if (CastNode->getGraph() != childGraph)
+  // The node holds its own clone, so compare topology rather than identity:
+  // the replacement must have the same number of nodes as the embedded graph.
+  if (CastNode->getGraph()->getNodes().size() !=
+      GRAPH(childGraph)->getNodes().size())
     RETURN(hipErrorInvalidValue);
 
   CastNode->setGraph(GRAPH(childGraph));

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -1246,15 +1246,32 @@ hipError_t hipGraphGetEdges(hipGraph_t graph, hipGraphNode_t *from,
   CHIP_CATCH
 }
 
+/// Shared body of hipGraphGetNodes and hipGraphGetRootNodes. A null Out
+/// array asks for the count only; otherwise *Count is the array's capacity on
+/// entry and the number of entries written on return.
+static hipError_t copyGraphNodes(const std::vector<CHIPGraphNode *> &Nodes,
+                                 hipGraphNode_t *Out, size_t *Count) {
+  if (!Count)
+    return hipErrorInvalidValue;
+  if (!Out) {
+    *Count = Nodes.size();
+    return hipSuccess;
+  }
+  size_t NumToCopy = std::min(*Count, Nodes.size());
+  for (size_t i = 0; i < NumToCopy; i++)
+    Out[i] = Nodes[i];
+  *Count = NumToCopy;
+  return hipSuccess;
+}
+
 hipError_t hipGraphGetNodes(hipGraph_t graph, hipGraphNode_t *nodes,
                             size_t *numNodes) {
   CHIP_TRY
   LOCK(ApiMtx);
   CHIPInitialize();
-  auto Nodes = GRAPH(graph)->getNodes();
-  *nodes = *(Nodes.data());
-  *numNodes = GRAPH(graph)->getNodes().size();
-  RETURN(hipSuccess);
+  if (!graph)
+    RETURN(hipErrorInvalidValue);
+  RETURN(copyGraphNodes(GRAPH(graph)->getNodes(), nodes, numNodes));
   CHIP_CATCH
 }
 
@@ -1263,10 +1280,10 @@ hipError_t hipGraphGetRootNodes(hipGraph_t graph, hipGraphNode_t *pRootNodes,
   CHIP_TRY
   LOCK(ApiMtx);
   CHIPInitialize();
-  auto Nodes = GRAPH(graph)->getRootNodes();
-  *pRootNodes = *(Nodes.data());
-  *pNumRootNodes = GRAPH(graph)->getNodes().size();
-  RETURN(hipSuccess);
+  if (!graph)
+    RETURN(hipErrorInvalidValue);
+  RETURN(copyGraphNodes(GRAPH(graph)->getRootNodes(), pRootNodes,
+                        pNumRootNodes));
   CHIP_CATCH
 }
 

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2214,6 +2214,13 @@ hipError_t hipGraphExecHostNodeSetParams(hipGraphExec_t hGraphExec,
   CHIP_TRY
   LOCK(ApiMtx);
   CHIPInitialize();
+
+  if (!pNodeParams)
+    RETURN(hipErrorInvalidValue);
+
+  if (!pNodeParams->fn)
+    RETURN(hipErrorInvalidValue);
+
   static_cast<CHIPGraphNodeHost *>(
       findExecNode(hGraphExec, node, hipGraphNodeTypeHost))
       ->setParams(pNodeParams);

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -312,6 +312,29 @@ static CHIPGraphNode *findEnableableExecNode(hipGraphExec_t hGraphExec,
   return ExecNode;
 }
 
+/// Resolve hNode to its copy of type Type in hGraphExec for the
+/// hipGraphExec*NodeSetParams family. Those update the instantiated graph
+/// only, so the copy is what they must touch; the original node is left as it
+/// is. A node that was not part of the graph when hGraphExec was instantiated,
+/// or one of another type, is hipErrorInvalidValue.
+static CHIPGraphNode *findExecNode(hipGraphExec_t hGraphExec,
+                                   hipGraphNode_t hNode,
+                                   hipGraphNodeType Type) {
+  if (!hGraphExec || !hNode)
+    CHIPERR_LOG_AND_THROW("Null hipGraphExec_t or hipGraphNode_t",
+                          hipErrorInvalidValue);
+
+  auto *ExecNode = EXEC(hGraphExec)->getExecNode(NODE(hNode));
+  if (!ExecNode)
+    CHIPERR_LOG_AND_THROW("Node is not part of the instantiated graph",
+                          hipErrorInvalidValue);
+
+  if (ExecNode->getType() != Type)
+    CHIPERR_LOG_AND_THROW("Node is not of the type this API updates",
+                          hipErrorInvalidValue);
+  return ExecNode;
+}
+
 hipError_t hipGraphNodeGetEnabled(hipGraphExec_t hGraphExec,
                                   hipGraphNode_t hNode,
                                   unsigned int *isEnabled) {
@@ -1749,15 +1772,9 @@ hipGraphExecKernelNodeSetParams(hipGraphExec_t hGraphExec, hipGraphNode_t node,
   if (!pNodeParams->kernelParams)
     RETURN(hipErrorInvalidValue);
 
-  // Graph obtained from hipGraphExec_t is a clone of the original
-  CHIPGraph *Graph = EXEC(hGraphExec)->getOriginalGraphPtr();
-  // KernelNode here is a handle to the original
-
-  CHIPGraphNodeKernel *ExecKernelNode = static_cast<CHIPGraphNodeKernel *>(
-      GRAPH(Graph)->getClonedNodeFromOriginal(NODE(node)));
-  assert(ExecKernelNode);
-
-  ExecKernelNode->setParams(*pNodeParams);
+  static_cast<CHIPGraphNodeKernel *>(
+      findExecNode(hGraphExec, node, hipGraphNodeTypeKernel))
+      ->setParams(*pNodeParams);
   RETURN(hipSuccess);
   CHIP_CATCH
 }
@@ -1837,18 +1854,9 @@ hipError_t hipGraphExecMemcpyNodeSetParams(hipGraphExec_t hGraphExec,
   CHIP_TRY
   LOCK(ApiMtx);
   CHIPInitialize();
-  auto ExecNode =
-      EXEC(hGraphExec)->getOriginalGraphPtr()->nodeLookup(NODE(node));
-  if (!ExecNode)
-    CHIPERR_LOG_AND_THROW("Failed to find the node in hipGraphExec_t",
-                          hipErrorInvalidValue);
-
-  auto CastNode = static_cast<CHIPGraphNodeMemcpy *>(node);
-  if (!CastNode)
-    CHIPERR_LOG_AND_THROW("Node provided failed to cast to CHIPGraphNodeMemcpy",
-                          hipErrorInvalidValue);
-
-  CastNode->setParams(const_cast<hipMemcpy3DParms *>(pNodeParams));
+  static_cast<CHIPGraphNodeMemcpy *>(
+      findExecNode(hGraphExec, node, hipGraphNodeTypeMemcpy))
+      ->setParams(pNodeParams);
   RETURN(hipSuccess);
   CHIP_CATCH
 }
@@ -1951,18 +1959,9 @@ hipError_t hipGraphExecMemcpyNodeSetParams1D(hipGraphExec_t hGraphExec,
       (static_cast<const char *>(src) < static_cast<char *>(dst) + count))
     RETURN(hipErrorInvalidValue);
 
-  auto ExecNode =
-      EXEC(hGraphExec)->getOriginalGraphPtr()->nodeLookup(NODE(node));
-  if (!ExecNode)
-    CHIPERR_LOG_AND_THROW("Failed to find the node in hipGraphExec_t",
-                          hipErrorInvalidValue);
-
-  auto CastNode = static_cast<CHIPGraphNodeMemcpy *>(node);
-  if (!CastNode)
-    CHIPERR_LOG_AND_THROW("Node provided failed to cast to CHIPGraphNodeMemcpy",
-                          hipErrorInvalidValue);
-
-  CastNode->setParams(dst, src, count, kind);
+  static_cast<CHIPGraphNodeMemcpy *>(
+      findExecNode(hGraphExec, node, hipGraphNodeTypeMemcpy))
+      ->setParams(dst, src, count, kind);
   RETURN(hipSuccess);
   CHIP_CATCH
 }
@@ -2005,16 +2004,9 @@ hipError_t hipGraphExecMemcpyNodeSetParamsFromSymbol(
   CHIP_TRY
   LOCK(ApiMtx);
   CHIPInitialize();
-  // Graph obtained from hipGraphExec_t is a clone of the original
-  CHIPGraph *Graph = EXEC(hGraphExec)->getOriginalGraphPtr();
-  // KernelNode here is a handle to the original
-  CHIPGraphNodeMemcpyFromSymbol *KernelNode =
-      ((CHIPGraphNodeMemcpyFromSymbol *)node);
-  CHIPGraphNodeMemcpyFromSymbol *ExecKernelNode =
-      ((CHIPGraphNodeMemcpyFromSymbol *)GRAPH(Graph)->getClonedNodeFromOriginal(
-          KernelNode));
-
-  ExecKernelNode->setParams(dst, symbol, count, offset, kind);
+  static_cast<CHIPGraphNodeMemcpyFromSymbol *>(
+      findExecNode(hGraphExec, node, hipGraphNodeTypeMemcpyFromSymbol))
+      ->setParams(dst, symbol, count, offset, kind);
   RETURN(hipSuccess);
   CHIP_CATCH
 }
@@ -2059,19 +2051,9 @@ hipError_t hipGraphExecMemcpyNodeSetParamsToSymbol(
   CHIP_TRY
   LOCK(ApiMtx);
   CHIPInitialize();
-  auto ExecNode =
-      EXEC(hGraphExec)->getOriginalGraphPtr()->nodeLookup(NODE(node));
-  if (!ExecNode)
-    CHIPERR_LOG_AND_THROW("Failed to find the node in hipGraphExec_t",
-                          hipErrorInvalidValue);
-
-  auto CastNode = static_cast<CHIPGraphNodeMemcpyToSymbol *>(node);
-  if (!CastNode)
-    CHIPERR_LOG_AND_THROW(
-        "Node provided failed to cast to CHIPGraphNodeMemcpyToSymbol",
-        hipErrorInvalidValue);
-
-  CastNode->setParams(const_cast<void *>(src), symbol, count, offset, kind);
+  static_cast<CHIPGraphNodeMemcpyToSymbol *>(
+      findExecNode(hGraphExec, node, hipGraphNodeTypeMemcpyToSymbol))
+      ->setParams(const_cast<void *>(src), symbol, count, offset, kind);
   RETURN(hipSuccess);
   CHIP_CATCH
 }
@@ -2140,18 +2122,9 @@ hipError_t hipGraphExecMemsetNodeSetParams(hipGraphExec_t hGraphExec,
   CHIP_TRY
   LOCK(ApiMtx);
   CHIPInitialize();
-  auto ExecNode =
-      EXEC(hGraphExec)->getOriginalGraphPtr()->nodeLookup(NODE(node));
-  if (!ExecNode)
-    CHIPERR_LOG_AND_THROW("Failed to find the node in hipGraphExec_t",
-                          hipErrorInvalidValue);
-
-  auto CastNode = static_cast<CHIPGraphNodeMemset *>(node);
-  if (!CastNode)
-    CHIPERR_LOG_AND_THROW("Node provided failed to cast to CHIPGraphNodeMemset",
-                          hipErrorInvalidValue);
-
-  CastNode->setParams(pNodeParams);
+  static_cast<CHIPGraphNodeMemset *>(
+      findExecNode(hGraphExec, node, hipGraphNodeTypeMemset))
+      ->setParams(pNodeParams);
   RETURN(hipSuccess);
   CHIP_CATCH
 }
@@ -2233,18 +2206,9 @@ hipError_t hipGraphExecHostNodeSetParams(hipGraphExec_t hGraphExec,
   CHIP_TRY
   LOCK(ApiMtx);
   CHIPInitialize();
-  auto ExecNode =
-      EXEC(hGraphExec)->getOriginalGraphPtr()->nodeLookup(NODE(node));
-  if (!ExecNode)
-    CHIPERR_LOG_AND_THROW("Failed to find the node in hipGraphExec_t",
-                          hipErrorInvalidValue);
-
-  auto CastNode = static_cast<CHIPGraphNodeHost *>(ExecNode);
-  if (!CastNode)
-    CHIPERR_LOG_AND_THROW("Node provided failed to cast to CHIPGraphNodeMemset",
-                          hipErrorInvalidValue);
-
-  CastNode->setParams(pNodeParams);
+  static_cast<CHIPGraphNodeHost *>(
+      findExecNode(hGraphExec, node, hipGraphNodeTypeHost))
+      ->setParams(pNodeParams);
   RETURN(hipSuccess);
   CHIP_CATCH
 }
@@ -2453,19 +2417,9 @@ hipError_t hipGraphExecEventRecordNodeSetEvent(hipGraphExec_t hGraphExec,
   if (NodeType != hipGraphNodeTypeEventRecord)
     RETURN(hipErrorInvalidValue);
 
-  auto ExecNode =
-      EXEC(hGraphExec)->getOriginalGraphPtr()->nodeLookup(NODE(hNode));
-  if (!ExecNode)
-    CHIPERR_LOG_AND_THROW("Failed to find the node in hipGraphExec_t",
-                          hipErrorInvalidValue);
-
-  auto CastNode = static_cast<CHIPGraphNodeEventRecord *>(hNode);
-  if (!CastNode)
-    CHIPERR_LOG_AND_THROW(
-        "Node provided failed to cast to CHIPGraphNodeEventRecord",
-        hipErrorInvalidValue);
-
-  CastNode->setEvent(static_cast<chipstar::Event *>(event));
+  static_cast<CHIPGraphNodeEventRecord *>(
+      findExecNode(hGraphExec, hNode, hipGraphNodeTypeEventRecord))
+      ->setEvent(static_cast<chipstar::Event *>(event));
   RETURN(hipSuccess);
   CHIP_CATCH
 }
@@ -2577,20 +2531,9 @@ hipError_t hipGraphExecEventWaitNodeSetEvent(hipGraphExec_t hGraphExec,
   if (NodeType != hipGraphNodeTypeWaitEvent)
     RETURN(hipErrorInvalidValue);
 
-  auto ExecNode =
-      EXEC(hGraphExec)->getOriginalGraphPtr()->nodeLookup(NODE(hNode));
-  if (!ExecNode)
-    CHIPERR_LOG_AND_THROW("Failed to find the node in hipGraphExec_t",
-                          hipErrorInvalidValue);
-
-  // TODO Grahs check all of these - somewhere using hNode instead of ExecNode
-  auto CastNode = static_cast<CHIPGraphNodeWaitEvent *>(ExecNode);
-  if (!CastNode)
-    CHIPERR_LOG_AND_THROW(
-        "Node provided failed to cast to CHIPGraphNodeWaitEvent",
-        hipErrorInvalidValue);
-
-  CastNode->setEvent(static_cast<chipstar::Event *>(event));
+  static_cast<CHIPGraphNodeWaitEvent *>(
+      findExecNode(hGraphExec, hNode, hipGraphNodeTypeWaitEvent))
+      ->setEvent(static_cast<chipstar::Event *>(event));
   RETURN(hipSuccess);
   CHIP_CATCH
 }

--- a/src/CHIPGraph.cc
+++ b/src/CHIPGraph.cc
@@ -359,16 +359,19 @@ void CHIPGraphExec::launch(chipstar::Queue *Queue) {
     }
     logDebug("Executing nodes: {}", NodesInThisLevel);
     for (auto Node : Nodes) {
-      // The schedule is built from the original nodes; the per-exec enabled
-      // switch (hipGraphNodeSetEnabled) lives on their compiled copies. A
-      // disabled node behaves like an empty node.
+      // The schedule is built from the original nodes, but what runs is the
+      // node's copy in the compiled graph: it holds the parameters set through
+      // hipGraphExec*NodeSetParams and the hipGraphNodeSetEnabled switch, and
+      // edits to the original node after instantiation do not reach it. A
+      // node the original graph gained after instantiation has no copy and
+      // runs as it is. A disabled node behaves like an empty node.
       auto *ExecNode = CompiledGraph_.nodeLookup(Node);
       if (ExecNode && !ExecNode->isEnabled()) {
         logDebug("Skipping disabled {}", Node->Msg);
         continue;
       }
       logDebug("Executing {}", Node->Msg);
-      Node->execute(Queue);
+      (ExecNode ? ExecNode : Node)->execute(Queue);
       Queue->finish();
     }
 

--- a/src/CHIPGraph.cc
+++ b/src/CHIPGraph.cc
@@ -253,7 +253,12 @@ void unchainUnnecessaryDeps(std::vector<CHIPGraphNode *> Path,
 
   for (int i = 0; i < SubPath.size(); i++) {
     if (SubPath[i] != Path[i]) {
-      SubPath[i - 1]->removeDependency(SubPath[i]);
+      // Paths were enumerated before any pruning, so several (Path, SubPath)
+      // pairs can single out the same redundant edge; an earlier pair may
+      // already have removed it.
+      auto Deps = SubPath[i - 1]->getDependencies();
+      if (std::find(Deps.begin(), Deps.end(), SubPath[i]) != Deps.end())
+        SubPath[i - 1]->removeDependency(SubPath[i]);
       break;
     }
   }

--- a/src/CHIPGraph.cc
+++ b/src/CHIPGraph.cc
@@ -93,8 +93,10 @@ CHIPGraph::CHIPGraph(const CHIPGraph &OriginalGraph) {
 
 CHIPGraphNodeKernel::CHIPGraphNodeKernel(const CHIPGraphNodeKernel &Other)
     : CHIPGraphNode(Other) {
-  Params_ = Other.Params_;
-  ExecItem_ = Other.ExecItem_->clone();
+  // Other.Params_.kernelParams points into Other's own argument buffer.
+  // Going through setParams() gives the copy its own argument bytes, exec
+  // item and kernel handle, so it does not depend on Other staying alive.
+  setParams(Other.Params_);
 }
 
 CHIPGraphNode *CHIPGraphNodeKernel::clone() const {
@@ -138,22 +140,47 @@ void CHIPGraphNodeKernel::execute(chipstar::Queue *Queue) const {
 
 CHIPGraphNodeKernel::CHIPGraphNodeKernel(const hipKernelNodeParams *TheParams)
     : CHIPGraphNode(hipGraphNodeTypeKernel) {
-  Params_.blockDim = TheParams->blockDim;
-  Params_.extra = TheParams->extra;
-  Params_.func = TheParams->func;
-  Params_.gridDim = TheParams->gridDim;
-  Params_.sharedMemBytes = TheParams->sharedMemBytes;
+  setParams(*TheParams);
+}
 
-  auto Dev = Backend->getActiveDevice();
-  chipstar::Kernel *ChipKernel = Dev->findKernel(HostPtr(Params_.func));
+CHIPGraphNodeKernel::CHIPGraphNodeKernel(const void *HostFunction, dim3 GridDim,
+                                         dim3 BlockDim, void **Args,
+                                         size_t SharedMem)
+    : CHIPGraphNode(hipGraphNodeTypeKernel) {
+  hipKernelNodeParams Params = {};
+  Params.func = const_cast<void *>(HostFunction);
+  Params.gridDim = GridDim;
+  Params.blockDim = BlockDim;
+  Params.sharedMemBytes = SharedMem;
+  Params.kernelParams = Args;
+  Params.extra = nullptr;
+  setParams(Params);
+}
+
+void CHIPGraphNodeKernel::setParams(const hipKernelNodeParams &Params) {
+  auto *Dev = Backend->getActiveDevice();
+  chipstar::Kernel *ChipKernel = Dev->findKernel(HostPtr(Params.func));
   if (!ChipKernel)
     CHIPERR_LOG_AND_THROW("Could not find requested kernel",
                           hipErrorInvalidDeviceFunction);
 
-  copyKernelArgs(ArgList_, ArgData_, TheParams->kernelParams,
+  // Copy into fresh buffers before touching the members: Params may be this
+  // node's own getParams() result, whose kernelParams point into ArgData_.
+  std::vector<char> ArgData;
+  std::vector<void *> ArgList;
+  copyKernelArgs(ArgList, ArgData, Params.kernelParams,
                  *ChipKernel->getFuncInfo());
+  ArgData_.swap(ArgData);
+  ArgList_.swap(ArgList);
+
+  Params_.func = Params.func;
+  Params_.gridDim = Params.gridDim;
+  Params_.blockDim = Params.blockDim;
+  Params_.sharedMemBytes = Params.sharedMemBytes;
+  Params_.extra = Params.extra;
   Params_.kernelParams = ArgList_.data();
 
+  delete ExecItem_;
   ExecItem_ = Backend->createExecItem(Params_.gridDim, Params_.blockDim,
                                       Params_.sharedMemBytes, nullptr);
   ExecItem_->setKernel(ChipKernel);
@@ -161,45 +188,11 @@ CHIPGraphNodeKernel::CHIPGraphNodeKernel(const hipKernelNodeParams *TheParams)
   // launching the same kernel does not clobber this node's argument
   // bindings when both are queued before execution (issue #782).
   ExecItem_->useIndependentKernelHandle();
-  ExecItem_->setArgs(TheParams->kernelParams);
-  // setupAllArgs() binds implicit device-global address arguments, so the
-  // module's device variables must be allocated first. The normal launch path
-  // does this, but graph-node construction happens before any launch.
-  Dev->prepareDeviceVariables(HostPtr(Params_.func));
-  ExecItem_->setupAllArgs();
-}
-
-CHIPGraphNodeKernel::CHIPGraphNodeKernel(const void *HostFunction, dim3 GridDim,
-                                         dim3 BlockDim, void **Args,
-                                         size_t SharedMem)
-    : CHIPGraphNode(hipGraphNodeTypeKernel) {
-  Type_ = hipGraphNodeTypeKernel;
-  Params_.blockDim = BlockDim;
-  Params_.extra = nullptr;
-  Params_.func = const_cast<void *>(HostFunction);
-  Params_.gridDim = GridDim;
-  Params_.sharedMemBytes = SharedMem;
-
-  auto Dev = Backend->getActiveDevice();
-  chipstar::Kernel *ChipKernel = Dev->findKernel(HostPtr(HostFunction));
-  if (!ChipKernel)
-    CHIPERR_LOG_AND_THROW("Could not find requested kernel",
-                          hipErrorInvalidDeviceFunction);
-
-  copyKernelArgs(ArgList_, ArgData_, Args, *ChipKernel->getFuncInfo());
-  Params_.kernelParams = ArgList_.data();
-
-  ExecItem_ = Backend->createExecItem(GridDim, BlockDim, SharedMem, nullptr);
-  ExecItem_->setKernel(ChipKernel);
-  // Give this graph node a private kernel handle so that another node
-  // launching the same kernel does not clobber this node's argument
-  // bindings when both are queued before execution (issue #782).
-  ExecItem_->useIndependentKernelHandle();
   ExecItem_->setArgs(Params_.kernelParams);
   // setupAllArgs() binds implicit device-global address arguments, so the
-  // module's device variables must be allocated first (see the
-  // hipKernelNodeParams constructor above).
-  Dev->prepareDeviceVariables(HostPtr(HostFunction));
+  // module's device variables must be allocated first. The normal launch path
+  // does this, but a graph node is built before any launch.
+  Dev->prepareDeviceVariables(HostPtr(Params_.func));
   ExecItem_->setupAllArgs();
 }
 

--- a/src/CHIPGraph.cc
+++ b/src/CHIPGraph.cc
@@ -108,6 +108,11 @@ std::string CHIPGraphNodeKernel::getKernelName() const {
   return ExecItem_->getKernel()->getName();
 }
 
+// Defined here rather than in the header: CHIPBackend.hh includes CHIPGraph.hh
+// before chipstar::ExecItem is complete, and deleting through an incomplete
+// type would skip ExecItem's virtual destructor.
+CHIPGraphNodeKernel::~CHIPGraphNodeKernel() { delete ExecItem_; }
+
 void CHIPGraphNodeMemset::execute(chipstar::Queue *Queue) const {
   const unsigned int Val = Params_.value;
   size_t Height = std::max<size_t>(1, Params_.height);

--- a/src/CHIPGraph.cc
+++ b/src/CHIPGraph.cc
@@ -558,6 +558,24 @@ void CHIPGraphNodeHost::execute(chipstar::Queue *Queue) const {
   Params_.fn(Params_.userData);
 }
 
+// Defined out of line because CHIPGraph is only declared after this node
+// class in the header. hipGraphAddChildGraphNode documents childGraph as the
+// "Graph to clone into this node", so the node owns a clone rather than
+// aliasing the caller's graph.
+CHIPGraphNodeGraph::CHIPGraphNodeGraph(const CHIPGraph *Graph)
+    : CHIPGraphNode(hipGraphNodeTypeGraph), SubGraph_(new CHIPGraph(*Graph)) {}
+
+CHIPGraphNodeGraph::CHIPGraphNodeGraph(const CHIPGraphNodeGraph &Other)
+    : CHIPGraphNode(Other), SubGraph_(new CHIPGraph(*Other.SubGraph_)) {}
+
+CHIPGraphNodeGraph::~CHIPGraphNodeGraph() { delete SubGraph_; }
+
+void CHIPGraphNodeGraph::setGraph(const CHIPGraph *Graph) {
+  auto *Clone = new CHIPGraph(*Graph);
+  delete SubGraph_;
+  SubGraph_ = Clone;
+}
+
 void CHIPGraphNodeGraph::execute(chipstar::Queue *Queue) const {
   // The schedule runs this node after all of its dependencies and before all
   // of its dependants, so running the child graph to completion here keeps

--- a/src/CHIPGraph.cc
+++ b/src/CHIPGraph.cc
@@ -32,6 +32,8 @@
 
 #include "CHIPBackend.hh"
 #include "CHIPBindingsInternal.hh"
+
+#include <sstream>
 // CHIPGraphNode
 //*************************************************************************************
 void CHIPGraphNode::DFS(std::vector<CHIPGraphNode *> CurrPath,
@@ -98,6 +100,10 @@ CHIPGraphNodeKernel::CHIPGraphNodeKernel(const CHIPGraphNodeKernel &Other)
 CHIPGraphNode *CHIPGraphNodeKernel::clone() const {
   auto NewNode = new CHIPGraphNodeKernel(*this);
   return NewNode;
+}
+
+std::string CHIPGraphNodeKernel::getKernelName() const {
+  return ExecItem_->getKernel()->getName();
 }
 
 void CHIPGraphNodeMemset::execute(chipstar::Queue *Queue) const {
@@ -195,6 +201,137 @@ CHIPGraphNodeKernel::CHIPGraphNodeKernel(const void *HostFunction, dim3 GridDim,
   // hipKernelNodeParams constructor above).
   Dev->prepareDeviceVariables(HostPtr(HostFunction));
   ExecItem_->setupAllArgs();
+}
+
+static std::string dotEscape(const std::string &Str) {
+  std::string Out;
+  for (char C : Str) {
+    if (C == '"' || C == '\\')
+      Out += '\\';
+    Out += C;
+  }
+  return Out;
+}
+
+static std::string dim3ToString(dim3 Dim) {
+  return "(" + std::to_string(Dim.x) + "," + std::to_string(Dim.y) + "," +
+         std::to_string(Dim.z) + ")";
+}
+
+static std::string ptrToString(const void *Ptr) {
+  std::ostringstream Out;
+  Out << Ptr;
+  return Out.str();
+}
+
+/// Emits the nodes and edges of Graph; child graphs become nested clusters.
+static void writeDotBody(CHIPGraph *Graph, std::ostream &Out, unsigned Flags) {
+  const bool Verbose = Flags & hipGraphDebugDotFlagsVerbose;
+  const bool KernelParams =
+      Verbose || (Flags & hipGraphDebugDotFlagsKernelNodeParams);
+  const bool MemsetParams =
+      Verbose || (Flags & hipGraphDebugDotFlagsMemsetNodeParams);
+  const bool HostParams =
+      Verbose || (Flags & hipGraphDebugDotFlagsHostNodeParams);
+  const bool EventParams =
+      Verbose || (Flags & hipGraphDebugDotFlagsEventNodeParams);
+  const bool Handles = Verbose || (Flags & hipGraphDebugDotFlagsHandles);
+
+  for (auto *Node : Graph->getNodes()) {
+    std::string Label;
+    switch (Node->getType()) {
+    case hipGraphNodeTypeKernel: {
+      auto *Kernel = static_cast<CHIPGraphNodeKernel *>(Node);
+      Label = "KERNEL\\n" + dotEscape(Kernel->getKernelName());
+      if (KernelParams) {
+        auto Params = Kernel->getParams();
+        Label += "\\ngrid " + dim3ToString(Params.gridDim) + " block " +
+                 dim3ToString(Params.blockDim) + " sharedMem " +
+                 std::to_string(Params.sharedMemBytes);
+      }
+      break;
+    }
+    case hipGraphNodeTypeMemcpy:
+      Label = "MEMCPY";
+      break;
+    case hipGraphNodeTypeMemset: {
+      Label = "MEMSET";
+      if (MemsetParams) {
+        auto Params = static_cast<CHIPGraphNodeMemset *>(Node)->getParams();
+        Label += "\\ndst " + ptrToString(Params.dst) + " value " +
+                 std::to_string(Params.value) + " elementSize " +
+                 std::to_string(Params.elementSize) + " width " +
+                 std::to_string(Params.width) + " height " +
+                 std::to_string(Params.height);
+      }
+      break;
+    }
+    case hipGraphNodeTypeHost: {
+      Label = "HOST";
+      if (HostParams) {
+        auto Params = static_cast<CHIPGraphNodeHost *>(Node)->getParams();
+        Label += "\\nfn " + ptrToString((const void *)Params.fn) +
+                 " userData " + ptrToString(Params.userData);
+      }
+      break;
+    }
+    case hipGraphNodeTypeGraph:
+      Label = "CHILD_GRAPH";
+      break;
+    case hipGraphNodeTypeEmpty:
+      Label = "EMPTY";
+      break;
+    case hipGraphNodeTypeWaitEvent: {
+      Label = "WAIT_EVENT";
+      if (EventParams)
+        Label += "\\nevent " +
+                 ptrToString(
+                     static_cast<CHIPGraphNodeWaitEvent *>(Node)->getEvent());
+      break;
+    }
+    case hipGraphNodeTypeEventRecord: {
+      Label = "EVENT_RECORD";
+      if (EventParams)
+        Label +=
+            "\\nevent " +
+            ptrToString(
+                static_cast<CHIPGraphNodeEventRecord *>(Node)->getEvent());
+      break;
+    }
+    case hipGraphNodeTypeMemcpyFromSymbol:
+      Label = "MEMCPY_FROM_SYMBOL";
+      break;
+    case hipGraphNodeTypeMemcpyToSymbol:
+      Label = "MEMCPY_TO_SYMBOL";
+      break;
+    default:
+      Label = "NODE_TYPE_" + std::to_string(Node->getType());
+      break;
+    }
+    if (Handles)
+      Label += "\\n" + ptrToString(Node);
+
+    Out << "  \"" << ptrToString(Node) << "\" [label=\"" << Label << "\"];\n";
+
+    if (Node->getType() == hipGraphNodeTypeGraph) {
+      Out << "  subgraph \"cluster_" << ptrToString(Node)
+          << "\" {\n  label=\"CHILD_GRAPH\";\n";
+      writeDotBody(static_cast<CHIPGraphNodeGraph *>(Node)->getGraph(), Out,
+                   Flags);
+      Out << "  }\n";
+    }
+  }
+
+  for (auto *Node : Graph->getNodes())
+    for (auto *Dep : Node->getDependencies())
+      Out << "  \"" << ptrToString(Dep) << "\" -> \"" << ptrToString(Node)
+          << "\";\n";
+}
+
+void CHIPGraph::writeDot(std::ostream &Out, unsigned Flags) {
+  Out << "digraph {\n  node [shape=box];\n";
+  writeDotBody(this, Out, Flags);
+  Out << "}\n";
 }
 
 int NodeCounter = 1;

--- a/src/CHIPGraph.cc
+++ b/src/CHIPGraph.cc
@@ -412,6 +412,14 @@ void CHIPGraphNodeHost::execute(chipstar::Queue *Queue) const {
   Params_.fn(Params_.userData);
 }
 
+void CHIPGraphNodeGraph::execute(chipstar::Queue *Queue) const {
+  // The schedule runs this node after all of its dependencies and before all
+  // of its dependants, so running the child graph to completion here keeps
+  // the ordering the parent graph asked for.
+  CHIPGraphExec SubGraphExec(SubGraph_);
+  SubGraphExec.launch(Queue);
+}
+
 void CHIPGraphNodeEventRecord::execute(chipstar::Queue *Queue) const {
   NULLCHECK(Event_);
   auto Status = hipEventRecordInternal(Event_, Queue);

--- a/src/CHIPGraph.cc
+++ b/src/CHIPGraph.cc
@@ -366,6 +366,14 @@ void CHIPGraphExec::launch(chipstar::Queue *Queue) {
     }
     logDebug("Executing nodes: {}", NodesInThisLevel);
     for (auto Node : Nodes) {
+      // The schedule is built from the original nodes; the per-exec enabled
+      // switch (hipGraphNodeSetEnabled) lives on their compiled copies. A
+      // disabled node behaves like an empty node.
+      auto *ExecNode = CompiledGraph_.nodeLookup(Node);
+      if (ExecNode && !ExecNode->isEnabled()) {
+        logDebug("Skipping disabled {}", Node->Msg);
+        continue;
+      }
       logDebug("Executing {}", Node->Msg);
       Node->execute(Queue);
       Queue->finish();

--- a/src/CHIPGraph.hh
+++ b/src/CHIPGraph.hh
@@ -286,7 +286,7 @@ private:
   std::vector<void *> ArgList_;
 
   hipKernelNodeParams Params_;
-  chipstar::ExecItem *ExecItem_;
+  chipstar::ExecItem *ExecItem_ = nullptr;
 
 public:
   CHIPGraphNodeKernel(const CHIPGraphNodeKernel &Other);
@@ -296,7 +296,7 @@ public:
   CHIPGraphNodeKernel(const void *HostFunction, dim3 GridDim, dim3 BlockDim,
                       void **Args, size_t SharedMem);
 
-  virtual ~CHIPGraphNodeKernel() override {}
+  virtual ~CHIPGraphNodeKernel() override { delete ExecItem_; }
 
   virtual void execute(chipstar::Queue *Queue) const override;
 
@@ -304,7 +304,14 @@ public:
 
   std::string getKernelName() const;
 
-  void setParams(const hipKernelNodeParams Params) { Params_ = Params; }
+  /**
+   * @brief Set the kernel, launch configuration and arguments.
+   *
+   * Copies the argument bytes, so Params.kernelParams only has to stay valid
+   * for the call, and rebuilds the exec item so that the next execute()
+   * launches with these parameters.
+   */
+  void setParams(const hipKernelNodeParams &Params);
   /**
    * @brief Createa a copy of this node
    * Must copy over all the arguments

--- a/src/CHIPGraph.hh
+++ b/src/CHIPGraph.hh
@@ -296,7 +296,7 @@ public:
   CHIPGraphNodeKernel(const void *HostFunction, dim3 GridDim, dim3 BlockDim,
                       void **Args, size_t SharedMem);
 
-  virtual ~CHIPGraphNodeKernel() override { delete ExecItem_; }
+  virtual ~CHIPGraphNodeKernel() override;
 
   virtual void execute(chipstar::Queue *Queue) const override;
 

--- a/src/CHIPGraph.hh
+++ b/src/CHIPGraph.hh
@@ -296,6 +296,8 @@ public:
 
   hipKernelNodeParams getParams() const { return Params_; }
 
+  std::string getKernelName() const;
+
   void setParams(const hipKernelNodeParams Params) { Params_ = Params; }
   /**
    * @brief Createa a copy of this node
@@ -629,6 +631,14 @@ public:
   }
 
   std::vector<CHIPGraphNode *> &getNodes() { return Nodes_; }
+
+  /**
+   * @brief Write the graph in DOT format (hipGraphDebugDotPrint).
+   *
+   * @param Out stream to write to
+   * @param Flags hipGraphDebugDotFlags selecting the per-node details
+   */
+  void writeDot(std::ostream &Out, unsigned Flags);
 
   /**
    * @brief Collect the graph's edges as (from, to) pairs.

--- a/src/CHIPGraph.hh
+++ b/src/CHIPGraph.hh
@@ -439,16 +439,17 @@ public:
 
 class CHIPGraphNodeGraph : public CHIPGraphNode {
 private:
+  /// The node's own copy of the child graph, cloned at construction and by
+  /// setGraph(), so the graph the caller passed in can be edited, destroyed
+  /// or even be the parent graph itself without affecting this node.
   CHIPGraph *SubGraph_;
 
 public:
-  CHIPGraphNodeGraph(CHIPGraph *Graph)
-      : CHIPGraphNode(hipGraphNodeTypeGraph), SubGraph_(Graph) {}
+  CHIPGraphNodeGraph(const CHIPGraph *Graph);
 
-  CHIPGraphNodeGraph(const CHIPGraphNodeGraph &Other)
-      : CHIPGraphNode(Other), SubGraph_(Other.SubGraph_) {}
+  CHIPGraphNodeGraph(const CHIPGraphNodeGraph &Other);
 
-  virtual ~CHIPGraphNodeGraph() override {}
+  virtual ~CHIPGraphNodeGraph() override;
 
   virtual void execute(chipstar::Queue *Queue) const override;
 
@@ -457,7 +458,8 @@ public:
     return NewNode;
   }
 
-  void setGraph(CHIPGraph *Graph) { SubGraph_ = Graph; }
+  /// Replace the embedded graph with a clone of Graph.
+  void setGraph(const CHIPGraph *Graph);
 
   CHIPGraph *getGraph() { return SubGraph_; }
 };

--- a/src/CHIPGraph.hh
+++ b/src/CHIPGraph.hh
@@ -435,9 +435,8 @@ public:
 
   virtual ~CHIPGraphNodeGraph() override {}
 
-  virtual void execute(chipstar::Queue *Queue) const override {
-    CHIPERR_LOG_AND_THROW("Attemped to execute GraphNode", hipErrorTbd);
-  }
+  virtual void execute(chipstar::Queue *Queue) const override;
+
   virtual CHIPGraphNode *clone() const override {
     auto NewNode = new CHIPGraphNodeGraph(*this);
     return NewNode;

--- a/src/CHIPGraph.hh
+++ b/src/CHIPGraph.hh
@@ -50,6 +50,9 @@ class CHIPGraph;
 class CHIPGraphNode : public hipGraphNode {
 protected:
   hipGraphNodeType Type_;
+  /// hipGraphNodeSetEnabled switch. It is consulted on the nodes of a
+  /// CHIPGraphExec's compiled graph: a disabled node is a no-op at launch.
+  bool Enabled_ = true;
   // nodes which depend on this node
   std::vector<CHIPGraphNode *> Dependendants_;
   // nodes on which this node depends
@@ -68,10 +71,13 @@ protected:
 public:
   std::string Msg; // TODO Graphs cleanup
   CHIPGraphNode(const CHIPGraphNode &Other)
-      : Type_(Other.Type_), Dependendants_(Other.Dependendants_),
+      : Type_(Other.Type_), Enabled_(Other.Enabled_),
+        Dependendants_(Other.Dependendants_),
         Dependencies_(Other.Dependencies_), Msg(Other.Msg) {}
 
   hipGraphNodeType getType() { return Type_; }
+  bool isEnabled() const { return Enabled_; }
+  void setEnabled(bool Enabled) { Enabled_ = Enabled; }
   virtual CHIPGraphNode *clone() const = 0;
 
   /**
@@ -713,6 +719,18 @@ public:
   void launch(chipstar::Queue *Queue);
 
   CHIPGraph *getOriginalGraphPtr() const { return OriginalGraph_; }
+
+  /**
+   * @brief Look up the executable copy of a node of the original graph.
+   *
+   * @param OriginalNode handle of a node in the graph this executable graph
+   * was instantiated from
+   * @return CHIPGraphNode* the corresponding node in the compiled graph, or
+   * nullptr if the node was not part of the graph at instantiation
+   */
+  CHIPGraphNode *getExecNode(CHIPGraphNode *OriginalNode) {
+    return CompiledGraph_.nodeLookup(OriginalNode);
+  }
 
   /**
    * @brief Optimize and generate ExecQueues_

--- a/tests/runtime/TestFix1501GraphCompileLoop.hip
+++ b/tests/runtime/TestFix1501GraphCompileLoop.hip
@@ -65,7 +65,9 @@ int main() {
   CHECK(hipGraphAddEmptyNode(&C, Graph, DepsC, 2));
 
   hipGraphNode_t Nodes[3];
-  size_t NumNodes = 0, NumEdges = 0;
+  // numNodes is the capacity of Nodes on entry and the number of entries
+  // written on return.
+  size_t NumNodes = 3, NumEdges = 0;
   CHECK(hipGraphGetNodes(Graph, Nodes, &NumNodes));
   CHECK(hipGraphGetEdges(Graph, nullptr, nullptr, &NumEdges));
   if (NumNodes != 3 || NumEdges != 3) {
@@ -81,6 +83,7 @@ int main() {
     CHECK(hipStreamSynchronize(0));
   }
 
+  NumNodes = 3;
   CHECK(hipGraphGetNodes(Graph, Nodes, &NumNodes));
   CHECK(hipGraphGetEdges(Graph, nullptr, nullptr, &NumEdges));
   if (NumNodes != 3 || NumEdges != 3) {

--- a/tests/runtime/TestFixGraphExecKernelNodeSetParams.hip
+++ b/tests/runtime/TestFixGraphExecKernelNodeSetParams.hip
@@ -1,0 +1,139 @@
+// Reproduces: hipGraphExecKernelNodeSetParams and hipGraphExecMemsetNodeSetParams
+// look the node up in the clone map of the ORIGINAL graph, which is only
+// populated when that graph itself came from hipGraphClone, so on a normally
+// built graph they fail; and where they do resolve a node they update the
+// original graph's node instead of its copy in the executable graph.
+// HIP semantics: the update applies to the instantiated graph only, the
+// original graph is untouched, and the next hipGraphLaunch of that executable
+// graph runs with the new parameters.
+#include <hip/hip_runtime.h>
+#include <iostream>
+
+__global__ void writeKernel(int *Data, int Value) { *Data = Value; }
+
+#define CHECK(Call)                                                            \
+  do {                                                                         \
+    hipError_t Err = (Call);                                                   \
+    if (Err != hipSuccess) {                                                   \
+      std::cout << "FAIL: " #Call " -> " << hipGetErrorString(Err) << "\n";    \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+static int readBack(int *Dev) {
+  int Host = -1;
+  (void)hipMemcpy(&Host, Dev, sizeof(int), hipMemcpyDeviceToHost);
+  return Host;
+}
+
+int main() {
+  int *Dev;
+  CHECK(hipMalloc(&Dev, sizeof(int)));
+
+  // Kernel node: the second argument is the value the kernel writes.
+  int ValueA = 11, ValueB = 22;
+  void *ArgsA[] = {&Dev, &ValueA};
+  hipKernelNodeParams Params = {};
+  Params.func = (void *)writeKernel;
+  Params.gridDim = dim3(1);
+  Params.blockDim = dim3(1);
+  Params.kernelParams = ArgsA;
+
+  hipGraph_t Graph;
+  CHECK(hipGraphCreate(&Graph, 0));
+  hipGraphNode_t Kernel;
+  CHECK(hipGraphAddKernelNode(&Kernel, Graph, nullptr, 0, &Params));
+  hipGraphExec_t Exec;
+  CHECK(hipGraphInstantiate(&Exec, Graph, nullptr, nullptr, 0));
+
+  CHECK(hipMemset(Dev, 0, sizeof(int)));
+  CHECK(hipGraphLaunch(Exec, 0));
+  CHECK(hipDeviceSynchronize());
+  if (int V = readBack(Dev); V != ValueA) {
+    std::cout << "FAIL: first launch wrote " << V << ", expected " << ValueA
+              << "\n";
+    return 2;
+  }
+
+  void *ArgsB[] = {&Dev, &ValueB};
+  hipKernelNodeParams ParamsB = Params;
+  ParamsB.kernelParams = ArgsB;
+  CHECK(hipGraphExecKernelNodeSetParams(Exec, Kernel, &ParamsB));
+
+  CHECK(hipMemset(Dev, 0, sizeof(int)));
+  CHECK(hipGraphLaunch(Exec, 0));
+  CHECK(hipDeviceSynchronize());
+  if (int V = readBack(Dev); V != ValueB) {
+    std::cout << "FAIL: launch after hipGraphExecKernelNodeSetParams wrote "
+              << V << ", expected " << ValueB << "\n";
+    return 3;
+  }
+
+  // The original graph is untouched: its node still carries ValueA and a
+  // fresh instantiation still writes it.
+  hipKernelNodeParams Original = {};
+  CHECK(hipGraphKernelNodeGetParams(Kernel, &Original));
+  if (int V = *static_cast<int *>(Original.kernelParams[1]); V != ValueA) {
+    std::cout << "FAIL: original kernel node argument is " << V
+              << ", expected " << ValueA << "\n";
+    return 4;
+  }
+  hipGraphExec_t Exec2;
+  CHECK(hipGraphInstantiate(&Exec2, Graph, nullptr, nullptr, 0));
+  CHECK(hipMemset(Dev, 0, sizeof(int)));
+  CHECK(hipGraphLaunch(Exec2, 0));
+  CHECK(hipDeviceSynchronize());
+  if (int V = readBack(Dev); V != ValueA) {
+    std::cout << "FAIL: re-instantiated original graph wrote " << V
+              << ", expected " << ValueA << "\n";
+    return 5;
+  }
+
+  // Memset node: the same contract for hipGraphExecMemsetNodeSetParams.
+  hipMemsetParams Memset = {};
+  Memset.dst = Dev;
+  Memset.elementSize = 1;
+  Memset.width = sizeof(int);
+  Memset.height = 1;
+  Memset.value = 0x05;
+  hipGraph_t MemsetGraph;
+  CHECK(hipGraphCreate(&MemsetGraph, 0));
+  hipGraphNode_t MemsetNode;
+  CHECK(hipGraphAddMemsetNode(&MemsetNode, MemsetGraph, nullptr, 0, &Memset));
+  hipGraphExec_t MemsetExec;
+  CHECK(hipGraphInstantiate(&MemsetExec, MemsetGraph, nullptr, nullptr, 0));
+  CHECK(hipGraphLaunch(MemsetExec, 0));
+  CHECK(hipDeviceSynchronize());
+  if (int V = readBack(Dev); V != 0x05050505) {
+    std::cout << "FAIL: memset launch wrote " << std::hex << V
+              << ", expected 0x05050505\n";
+    return 6;
+  }
+
+  Memset.value = 0x06;
+  CHECK(hipGraphExecMemsetNodeSetParams(MemsetExec, MemsetNode, &Memset));
+  CHECK(hipGraphLaunch(MemsetExec, 0));
+  CHECK(hipDeviceSynchronize());
+  if (int V = readBack(Dev); V != 0x06060606) {
+    std::cout << "FAIL: launch after hipGraphExecMemsetNodeSetParams wrote "
+              << std::hex << V << ", expected 0x06060606\n";
+    return 7;
+  }
+
+  hipMemsetParams OriginalMemset = {};
+  CHECK(hipGraphMemsetNodeGetParams(MemsetNode, &OriginalMemset));
+  if (OriginalMemset.value != 0x05) {
+    std::cout << "FAIL: original memset node value is " << std::hex
+              << OriginalMemset.value << ", expected 0x5\n";
+    return 8;
+  }
+
+  CHECK(hipGraphExecDestroy(MemsetExec));
+  CHECK(hipGraphDestroy(MemsetGraph));
+  CHECK(hipGraphExecDestroy(Exec2));
+  CHECK(hipGraphExecDestroy(Exec));
+  CHECK(hipGraphDestroy(Graph));
+  CHECK(hipFree(Dev));
+  std::cout << "PASSED\n";
+  return 0;
+}

--- a/tests/runtime/TestFixKokkosGraphCaptureEagerLaunch.hip
+++ b/tests/runtime/TestFixKokkosGraphCaptureEagerLaunch.hip
@@ -1,0 +1,96 @@
+// Reproduces: a kernel launched into a stream that is under
+// hipStreamBeginCapture runs immediately instead of being recorded into the
+// capture graph, and hipStreamEndCapture hands back an empty graph.
+// Surfaced by Kokkos hip.graph_capture ("0 is not in data used in the
+// captured kernel, got 5"): the captured kernel had already written its value
+// before the graph was ever launched.
+#include <hip/hip_runtime.h>
+#include <iostream>
+
+__global__ void setTo(int *Dst, int Val) { *Dst = Val; }
+
+#define CHECK(Call)                                                            \
+  do {                                                                         \
+    hipError_t Err = (Call);                                                   \
+    if (Err != hipSuccess) {                                                   \
+      std::cout << "FAIL: " #Call " -> " << hipGetErrorString(Err) << "\n";    \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+int main() {
+  hipStream_t Stream;
+  CHECK(hipStreamCreate(&Stream));
+
+  int *Dev;
+  CHECK(hipMalloc(&Dev, sizeof(int)));
+  CHECK(hipMemset(Dev, 0, sizeof(int)));
+  CHECK(hipDeviceSynchronize());
+
+  hipGraph_t Graph;
+  CHECK(hipStreamBeginCapture(Stream, hipStreamCaptureModeGlobal));
+  setTo<<<1, 1, 0, Stream>>>(Dev, 5);
+  CHECK(hipGetLastError());
+  CHECK(hipStreamEndCapture(Stream, &Graph));
+  CHECK(hipStreamSynchronize(Stream));
+
+  // Nothing has been launched yet: the value must still be 0.
+  int Host = -1;
+  CHECK(hipMemcpy(&Host, Dev, sizeof(int), hipMemcpyDeviceToHost));
+  if (Host != 0) {
+    std::cout << "FAIL: kernel ran during capture, value is " << Host << "\n";
+    return 2;
+  }
+
+  // The launch must have been recorded as one kernel node.
+  hipGraphNode_t Nodes[2] = {};
+  size_t NumNodes = 2;
+  CHECK(hipGraphGetNodes(Graph, Nodes, &NumNodes));
+  if (NumNodes != 1) {
+    std::cout << "FAIL: captured graph has " << NumNodes
+              << " nodes, expected 1\n";
+    return 3;
+  }
+
+  // Replaying the captured graph performs the write.
+  hipGraphExec_t GraphExec;
+  CHECK(hipGraphInstantiate(&GraphExec, Graph, nullptr, nullptr, 0));
+  CHECK(hipGraphLaunch(GraphExec, Stream));
+  CHECK(hipStreamSynchronize(Stream));
+  CHECK(hipMemcpy(&Host, Dev, sizeof(int), hipMemcpyDeviceToHost));
+  if (Host != 5) {
+    std::cout << "FAIL: graph launch did not run the captured kernel, value is "
+              << Host << "\n";
+    return 4;
+  }
+
+  // A second capture on the same stream starts a fresh graph: its node must
+  // not be chained behind the node recorded by the previous capture.
+  hipGraph_t Graph2;
+  CHECK(hipStreamBeginCapture(Stream, hipStreamCaptureModeGlobal));
+  setTo<<<1, 1, 0, Stream>>>(Dev, 7);
+  CHECK(hipGetLastError());
+  CHECK(hipStreamEndCapture(Stream, &Graph2));
+  NumNodes = 2;
+  CHECK(hipGraphGetNodes(Graph2, Nodes, &NumNodes));
+  if (NumNodes != 1) {
+    std::cout << "FAIL: second captured graph has " << NumNodes
+              << " nodes, expected 1\n";
+    return 5;
+  }
+  size_t NumDeps = 1;
+  CHECK(hipGraphNodeGetDependencies(Nodes[0], nullptr, &NumDeps));
+  if (NumDeps != 0) {
+    std::cout << "FAIL: node of the second capture has " << NumDeps
+              << " dependencies, expected 0\n";
+    return 6;
+  }
+
+  CHECK(hipGraphDestroy(Graph2));
+  CHECK(hipGraphExecDestroy(GraphExec));
+  CHECK(hipGraphDestroy(Graph));
+  CHECK(hipFree(Dev));
+  CHECK(hipStreamDestroy(Stream));
+  std::cout << "PASSED\n";
+  return 0;
+}

--- a/tests/runtime/TestFixKokkosGraphChildGraphNodeLaunch.hip
+++ b/tests/runtime/TestFixKokkosGraphChildGraphNodeLaunch.hip
@@ -1,0 +1,83 @@
+// Reproduces: hipGraphLaunch on a graph holding a child graph node
+// (hipGraphAddChildGraphNode) fails with hipErrorTbd ("Attemped to execute
+// GraphNode") instead of running the child's nodes in place. Kokkos wraps
+// every stream-captured region in a child graph node
+// (GraphNodeCaptureImpl::capture), so hip.graph_capture cannot submit.
+// The child node is added last and wired afterwards, as Kokkos does.
+#include <hip/hip_runtime.h>
+#include <iostream>
+
+__global__ void setTo(int *Dst, int Val) { *Dst = Val; }
+__global__ void mulBy(int *Dst, int Val) { *Dst *= Val; }
+__global__ void addTo(int *Dst, int Val) { *Dst += Val; }
+
+#define CHECK(Call)                                                            \
+  do {                                                                         \
+    hipError_t Err = (Call);                                                   \
+    if (Err != hipSuccess) {                                                   \
+      std::cout << "FAIL: " #Call " -> " << hipGetErrorString(Err) << "\n";    \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+static hipKernelNodeParams kernelParams(const void *Func, void **Args) {
+  hipKernelNodeParams Params = {};
+  Params.func = const_cast<void *>(Func);
+  Params.gridDim = dim3(1);
+  Params.blockDim = dim3(1);
+  Params.sharedMemBytes = 0;
+  Params.kernelParams = Args;
+  Params.extra = nullptr;
+  return Params;
+}
+
+int main() {
+  int *Dev;
+  CHECK(hipMalloc(&Dev, sizeof(int)));
+  CHECK(hipMemset(Dev, 0, sizeof(int)));
+  CHECK(hipDeviceSynchronize());
+
+  int One = 1, Three = 3, Ten = 10;
+  void *SetArgs[] = {&Dev, &One};
+  void *MulArgs[] = {&Dev, &Three};
+  void *AddArgs[] = {&Dev, &Ten};
+  hipKernelNodeParams SetParams = kernelParams((const void *)setTo, SetArgs);
+  hipKernelNodeParams MulParams = kernelParams((const void *)mulBy, MulArgs);
+  hipKernelNodeParams AddParams = kernelParams((const void *)addTo, AddArgs);
+
+  // Child graph: a single kernel that triples the value.
+  hipGraph_t Child;
+  CHECK(hipGraphCreate(&Child, 0));
+  hipGraphNode_t Mul;
+  CHECK(hipGraphAddKernelNode(&Mul, Child, nullptr, 0, &MulParams));
+
+  // Parent graph: set 1, run the child, add 10. Only 1 * 3 + 10 proves the
+  // child ran, and ran between its predecessor and its successor.
+  hipGraph_t Parent;
+  CHECK(hipGraphCreate(&Parent, 0));
+  hipGraphNode_t Set, Add, ChildNode;
+  CHECK(hipGraphAddKernelNode(&Set, Parent, nullptr, 0, &SetParams));
+  CHECK(hipGraphAddKernelNode(&Add, Parent, nullptr, 0, &AddParams));
+  CHECK(hipGraphAddChildGraphNode(&ChildNode, Parent, nullptr, 0, Child));
+  CHECK(hipGraphAddDependencies(Parent, &Set, &ChildNode, 1));
+  CHECK(hipGraphAddDependencies(Parent, &ChildNode, &Add, 1));
+
+  hipGraphExec_t GraphExec;
+  CHECK(hipGraphInstantiate(&GraphExec, Parent, nullptr, nullptr, 0));
+  CHECK(hipGraphLaunch(GraphExec, 0));
+  CHECK(hipDeviceSynchronize());
+
+  int Host = -1;
+  CHECK(hipMemcpy(&Host, Dev, sizeof(int), hipMemcpyDeviceToHost));
+  if (Host != 13) {
+    std::cout << "FAIL: value is " << Host << ", expected 13\n";
+    return 2;
+  }
+
+  CHECK(hipGraphExecDestroy(GraphExec));
+  CHECK(hipGraphDestroy(Parent));
+  CHECK(hipGraphDestroy(Child));
+  CHECK(hipFree(Dev));
+  std::cout << "PASSED\n";
+  return 0;
+}

--- a/tests/runtime/TestFixKokkosGraphDebugDotPrint.hip
+++ b/tests/runtime/TestFixKokkosGraphDebugDotPrint.hip
@@ -1,0 +1,67 @@
+// Reproduces: hipGraphDebugDotPrint returns hipErrorNotSupported and writes
+// nothing. Kokkos hip.graph_instantiate_and_debug_dot_print expects a DOT
+// file that names the kernel of each kernel node.
+#include <hip/hip_runtime.h>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+__global__ void incrementKernel(int *Data) { ++*Data; }
+
+#define CHECK(Call)                                                            \
+  do {                                                                         \
+    hipError_t Err = (Call);                                                   \
+    if (Err != hipSuccess) {                                                   \
+      std::cout << "FAIL: " #Call " -> " << hipGetErrorString(Err) << "\n";    \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+int main() {
+  int *Dev;
+  CHECK(hipMalloc(&Dev, sizeof(int)));
+
+  void *Args[] = {&Dev};
+  hipKernelNodeParams Params = {};
+  Params.func = (void *)incrementKernel;
+  Params.gridDim = dim3(1);
+  Params.blockDim = dim3(1);
+  Params.sharedMemBytes = 0;
+  Params.kernelParams = Args;
+  Params.extra = nullptr;
+
+  // root (empty) -> kernel
+  hipGraph_t Graph;
+  CHECK(hipGraphCreate(&Graph, 0));
+  hipGraphNode_t Root, Kernel;
+  CHECK(hipGraphAddEmptyNode(&Root, Graph, nullptr, 0));
+  CHECK(hipGraphAddKernelNode(&Kernel, Graph, &Root, 1, &Params));
+
+  const auto DotPath = std::filesystem::temp_directory_path() /
+                       "TestFixKokkosGraphDebugDotPrint.dot";
+  std::filesystem::remove(DotPath);
+
+  CHECK(hipGraphDebugDotPrint(Graph, DotPath.c_str(),
+                              hipGraphDebugDotFlagsVerbose));
+
+  if (!std::filesystem::exists(DotPath)) {
+    std::cout << "FAIL: " << DotPath << " was not written\n";
+    return 2;
+  }
+
+  std::stringstream Buffer;
+  Buffer << std::ifstream(DotPath).rdbuf();
+  const std::string Dot = Buffer.str();
+  std::filesystem::remove(DotPath);
+
+  if (Dot.find("incrementKernel") == std::string::npos) {
+    std::cout << "FAIL: kernel name missing from DOT output:\n" << Dot;
+    return 3;
+  }
+
+  CHECK(hipGraphDestroy(Graph));
+  CHECK(hipFree(Dev));
+  std::cout << "PASSED\n";
+  return 0;
+}

--- a/tests/runtime/TestFixKokkosGraphGetNodesNullBuffer.hip
+++ b/tests/runtime/TestFixKokkosGraphGetNodesNullBuffer.hip
@@ -1,0 +1,80 @@
+// Reproduces: hipGraphGetNodes and hipGraphGetRootNodes write through the
+// output array even when it is null, although a null array is how callers
+// ask for the count only; the process segfaults. Kokkos
+// hip.graph_instantiate_and_debug_dot_print sizes its node query this way.
+// hipGraphGetRootNodes also reports the total node count instead of the
+// number of root nodes, and hipGraphGetNodes fills only the first slot.
+#include <hip/hip_runtime.h>
+#include <iostream>
+
+__global__ void incrementKernel(int *Data) { ++*Data; }
+
+#define CHECK(Call)                                                            \
+  do {                                                                         \
+    hipError_t Err = (Call);                                                   \
+    if (Err != hipSuccess) {                                                   \
+      std::cout << "FAIL: " #Call " -> " << hipGetErrorString(Err) << "\n";    \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+int main() {
+  int *Dev;
+  CHECK(hipMalloc(&Dev, sizeof(int)));
+
+  void *Args[] = {&Dev};
+  hipKernelNodeParams Params = {};
+  Params.func = (void *)incrementKernel;
+  Params.gridDim = dim3(1);
+  Params.blockDim = dim3(1);
+  Params.sharedMemBytes = 0;
+  Params.kernelParams = Args;
+  Params.extra = nullptr;
+
+  // root (empty) -> kernel
+  hipGraph_t Graph;
+  CHECK(hipGraphCreate(&Graph, 0));
+  hipGraphNode_t Root, Kernel;
+  CHECK(hipGraphAddEmptyNode(&Root, Graph, nullptr, 0));
+  CHECK(hipGraphAddKernelNode(&Kernel, Graph, &Root, 1, &Params));
+
+  size_t NumNodes = 0;
+  CHECK(hipGraphGetNodes(Graph, nullptr, &NumNodes));
+  if (NumNodes != 2) {
+    std::cout << "FAIL: hipGraphGetNodes counted " << NumNodes
+              << " nodes, expected 2\n";
+    return 2;
+  }
+
+  hipGraphNode_t Nodes[2] = {};
+  NumNodes = 2;
+  CHECK(hipGraphGetNodes(Graph, Nodes, &NumNodes));
+  if (NumNodes != 2 || !Nodes[0] || !Nodes[1] || Nodes[0] == Nodes[1]) {
+    std::cout << "FAIL: hipGraphGetNodes returned " << NumNodes << " nodes ("
+              << Nodes[0] << ", " << Nodes[1] << ")\n";
+    return 3;
+  }
+
+  size_t NumRoots = 0;
+  CHECK(hipGraphGetRootNodes(Graph, nullptr, &NumRoots));
+  if (NumRoots != 1) {
+    std::cout << "FAIL: hipGraphGetRootNodes counted " << NumRoots
+              << " root nodes, expected 1\n";
+    return 4;
+  }
+
+  hipGraphNode_t Roots[2] = {};
+  NumRoots = 2;
+  CHECK(hipGraphGetRootNodes(Graph, Roots, &NumRoots));
+  if (NumRoots != 1 || Roots[0] != Root) {
+    std::cout << "FAIL: hipGraphGetRootNodes returned " << NumRoots
+              << " root nodes, first " << Roots[0] << ", expected " << Root
+              << "\n";
+    return 5;
+  }
+
+  CHECK(hipGraphDestroy(Graph));
+  CHECK(hipFree(Dev));
+  std::cout << "PASSED\n";
+  return 0;
+}

--- a/tests/runtime/TestFixKokkosGraphMixedHostDeviceNodes.hip
+++ b/tests/runtime/TestFixKokkosGraphMixedHostDeviceNodes.hip
@@ -1,0 +1,106 @@
+// Reproduces: hipLaunchHostFunc on a capturing stream runs the host function
+// right away instead of recording a host node, so a captured chain of kernel
+// launches and host functions runs its host steps during capture and the
+// graph replays only the kernels.
+// The motivating case is Kokkos hip.mixed_then_host_device_nodes, which
+// chains then (kernel) -> then_host -> then on a hipMallocManaged counter,
+// each node adding 2, and reads 4 instead of 6 on Aurora. Kokkos then_host
+// uses hipGraphAddHostNode, so that chain is checked here as well, built
+// the way Kokkos builds it.
+#include <hip/hip_runtime.h>
+#include <iostream>
+
+// Each step appends its own digit to the counter, so the final value spells
+// out the order in which the nodes actually ran: K H K H K H reads 121212.
+__global__ void deviceStep(unsigned *Counter) { *Counter = *Counter * 10 + 1; }
+
+static void hostStep(void *Data) {
+  unsigned *Counter = static_cast<unsigned *>(Data);
+  *Counter = *Counter * 10 + 2;
+}
+
+#define CHECK(Call)                                                            \
+  do {                                                                         \
+    hipError_t Err = (Call);                                                   \
+    if (Err != hipSuccess) {                                                   \
+      std::cout << "FAIL: " #Call " -> " << hipGetErrorString(Err) << "\n";    \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+static constexpr unsigned Expected = 121212;
+
+int main() {
+  unsigned *Counter;
+  CHECK(hipMallocManaged(&Counter, sizeof(unsigned)));
+  hipStream_t Stream;
+  CHECK(hipStreamCreate(&Stream));
+
+  void *Args[] = {&Counter};
+  hipKernelNodeParams KernelParams = {};
+  KernelParams.func = (void *)deviceStep;
+  KernelParams.gridDim = dim3(1);
+  KernelParams.blockDim = dim3(1);
+  KernelParams.kernelParams = Args;
+  hipHostNodeParams HostParams = {};
+  HostParams.fn = hostStep;
+  HostParams.userData = Counter;
+
+  // root (empty) -> K -> H -> K -> H -> K -> H, every node added without
+  // dependencies and chained afterwards through hipGraphAddDependencies, the
+  // way Kokkos builds its graphs.
+  *Counter = 0;
+  hipGraph_t Graph;
+  CHECK(hipGraphCreate(&Graph, 0));
+  hipGraphNode_t Prev;
+  CHECK(hipGraphAddEmptyNode(&Prev, Graph, nullptr, 0));
+  for (int I = 0; I < 3; ++I) {
+    hipGraphNode_t Kernel, Host;
+    CHECK(hipGraphAddKernelNode(&Kernel, Graph, nullptr, 0, &KernelParams));
+    CHECK(hipGraphAddDependencies(Graph, &Prev, &Kernel, 1));
+    CHECK(hipGraphAddHostNode(&Host, Graph, nullptr, 0, &HostParams));
+    CHECK(hipGraphAddDependencies(Graph, &Kernel, &Host, 1));
+    Prev = Host;
+  }
+  hipGraphExec_t GraphExec;
+  CHECK(hipGraphInstantiate(&GraphExec, Graph, nullptr, nullptr, 0));
+  CHECK(hipGraphLaunch(GraphExec, Stream));
+  CHECK(hipStreamSynchronize(Stream));
+  if (*Counter != Expected) {
+    std::cout << "FAIL: explicit graph ran the nodes as " << *Counter
+              << ", expected " << Expected << "\n";
+    return 2;
+  }
+  CHECK(hipGraphExecDestroy(GraphExec));
+  CHECK(hipGraphDestroy(Graph));
+
+  // The same chain recorded by stream capture.
+  *Counter = 0;
+  CHECK(hipStreamBeginCapture(Stream, hipStreamCaptureModeGlobal));
+  for (int I = 0; I < 3; ++I) {
+    deviceStep<<<1, 1, 0, Stream>>>(Counter);
+    CHECK(hipLaunchHostFunc(Stream, hostStep, Counter));
+  }
+  CHECK(hipStreamEndCapture(Stream, &Graph));
+  CHECK(hipStreamSynchronize(Stream));
+  if (*Counter != 0) {
+    std::cout << "FAIL: captured work ran during capture, counter is "
+              << *Counter << "\n";
+    return 3;
+  }
+  CHECK(hipGraphInstantiate(&GraphExec, Graph, nullptr, nullptr, 0));
+  CHECK(hipGraphLaunch(GraphExec, Stream));
+  CHECK(hipStreamSynchronize(Stream));
+  if (*Counter != Expected) {
+    std::cout << "FAIL: captured graph ran the nodes as " << *Counter
+              << ", expected " << Expected << "\n";
+    return 4;
+  }
+  CHECK(hipGraphExecDestroy(GraphExec));
+  CHECK(hipGraphDestroy(Graph));
+
+  CHECK(hipStreamDestroy(Stream));
+  CHECK(hipFree(Counter));
+  std::cout << "PASSED\n";
+  return 0;
+}

--- a/tests/runtime/TestFixKokkosGraphNodeEnabled.hip
+++ b/tests/runtime/TestFixKokkosGraphNodeEnabled.hip
@@ -1,0 +1,109 @@
+// Reproduces: hipGraphNodeSetEnabled and hipGraphNodeGetEnabled return
+// hipErrorNotSupported. Kokkos hip.interact_with_hip_node disables the kernel
+// node of an instantiated graph, submits, expects the kernel not to have run,
+// re-enables it, submits again and expects it to have run.
+// The flag belongs to the executable graph: only kernel, memcpy and memset
+// nodes accept it, and a disabled node is a no-op at hipGraphLaunch.
+#include <hip/hip_runtime.h>
+#include <iostream>
+
+__global__ void incrementKernel(int *Data) { ++*Data; }
+
+#define CHECK(Call)                                                            \
+  do {                                                                         \
+    hipError_t Err = (Call);                                                   \
+    if (Err != hipSuccess) {                                                   \
+      std::cout << "FAIL: " #Call " -> " << hipGetErrorString(Err) << "\n";    \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+static int readBack(int *Dev) {
+  int Host = -1;
+  (void)hipMemcpy(&Host, Dev, sizeof(int), hipMemcpyDeviceToHost);
+  return Host;
+}
+
+int main() {
+  int *Dev;
+  CHECK(hipMalloc(&Dev, sizeof(int)));
+  CHECK(hipMemset(Dev, 0, sizeof(int)));
+  CHECK(hipDeviceSynchronize());
+
+  void *Args[] = {&Dev};
+  hipKernelNodeParams Params = {};
+  Params.func = (void *)incrementKernel;
+  Params.gridDim = dim3(1);
+  Params.blockDim = dim3(1);
+  Params.sharedMemBytes = 0;
+  Params.kernelParams = Args;
+  Params.extra = nullptr;
+
+  // root (empty) -> kernel, the shape Kokkos builds for one then_parallel_for
+  hipGraph_t Graph;
+  CHECK(hipGraphCreate(&Graph, 0));
+  hipGraphNode_t Root, Kernel;
+  CHECK(hipGraphAddEmptyNode(&Root, Graph, nullptr, 0));
+  CHECK(hipGraphAddKernelNode(&Kernel, Graph, &Root, 1, &Params));
+
+  hipGraphExec_t GraphExec;
+  CHECK(hipGraphInstantiate(&GraphExec, Graph, nullptr, nullptr, 0));
+
+  unsigned Enabled = 0;
+  CHECK(hipGraphNodeGetEnabled(GraphExec, Kernel, &Enabled));
+  if (Enabled != 1) {
+    std::cout << "FAIL: fresh kernel node reports enabled=" << Enabled << "\n";
+    return 2;
+  }
+
+  CHECK(hipGraphLaunch(GraphExec, 0));
+  CHECK(hipDeviceSynchronize());
+  if (int V = readBack(Dev); V != 1) {
+    std::cout << "FAIL: enabled node did not run, value is " << V << "\n";
+    return 3;
+  }
+
+  CHECK(hipGraphNodeSetEnabled(GraphExec, Kernel, 0));
+  CHECK(hipGraphNodeGetEnabled(GraphExec, Kernel, &Enabled));
+  if (Enabled != 0) {
+    std::cout << "FAIL: disabled kernel node reports enabled=" << Enabled
+              << "\n";
+    return 4;
+  }
+
+  CHECK(hipGraphLaunch(GraphExec, 0));
+  CHECK(hipDeviceSynchronize());
+  if (int V = readBack(Dev); V != 1) {
+    std::cout << "FAIL: disabled node ran, value is " << V << "\n";
+    return 5;
+  }
+
+  CHECK(hipGraphNodeSetEnabled(GraphExec, Kernel, 1));
+  CHECK(hipGraphNodeGetEnabled(GraphExec, Kernel, &Enabled));
+  if (Enabled != 1) {
+    std::cout << "FAIL: re-enabled kernel node reports enabled=" << Enabled
+              << "\n";
+    return 6;
+  }
+
+  CHECK(hipGraphLaunch(GraphExec, 0));
+  CHECK(hipDeviceSynchronize());
+  if (int V = readBack(Dev); V != 2) {
+    std::cout << "FAIL: re-enabled node did not run, value is " << V << "\n";
+    return 7;
+  }
+
+  // The flag is only defined for kernel, memcpy and memset nodes.
+  if (hipError_t Err = hipGraphNodeSetEnabled(GraphExec, Root, 0);
+      Err != hipErrorInvalidValue) {
+    std::cout << "FAIL: hipGraphNodeSetEnabled on an empty node -> "
+              << hipGetErrorString(Err) << ", expected hipErrorInvalidValue\n";
+    return 8;
+  }
+
+  CHECK(hipGraphExecDestroy(GraphExec));
+  CHECK(hipGraphDestroy(Graph));
+  CHECK(hipFree(Dev));
+  std::cout << "PASSED\n";
+  return 0;
+}

--- a/tests/runtime/TestFixKokkosGraphRepeatedLaunch.hip
+++ b/tests/runtime/TestFixKokkosGraphRepeatedLaunch.hip
@@ -1,0 +1,60 @@
+// Reproduces: the N-th hipGraphLaunch of the same hipGraphExec_t executes
+// the graph N times. Every launch recompiles the execution schedule and
+// appends it to the schedule of the previous launches instead of replacing
+// it. Kokkos hip_graph.repeat_chain submits one graph ten times.
+#include <hip/hip_runtime.h>
+#include <iostream>
+
+__global__ void addOne(int *Dst) { atomicAdd(Dst, 1); }
+
+#define CHECK(Call)                                                            \
+  do {                                                                         \
+    hipError_t Err = (Call);                                                   \
+    if (Err != hipSuccess) {                                                   \
+      std::cout << "FAIL: " #Call " -> " << hipGetErrorString(Err) << "\n";    \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+int main() {
+  int *Count;
+  CHECK(hipMalloc(&Count, sizeof(int)));
+  CHECK(hipMemset(Count, 0, sizeof(int)));
+  CHECK(hipDeviceSynchronize());
+
+  void *Args[] = {&Count};
+  hipKernelNodeParams Params = {};
+  Params.func = (void *)addOne;
+  Params.gridDim = dim3(1);
+  Params.blockDim = dim3(1);
+  Params.sharedMemBytes = 0;
+  Params.kernelParams = Args;
+  Params.extra = nullptr;
+
+  hipGraph_t Graph;
+  CHECK(hipGraphCreate(&Graph, 0));
+  hipGraphNode_t Node;
+  CHECK(hipGraphAddKernelNode(&Node, Graph, nullptr, 0, &Params));
+
+  hipGraphExec_t GraphExec;
+  CHECK(hipGraphInstantiate(&GraphExec, Graph, nullptr, nullptr, 0));
+
+  const int Launches = 3;
+  for (int i = 0; i < Launches; i++)
+    CHECK(hipGraphLaunch(GraphExec, 0));
+  CHECK(hipDeviceSynchronize());
+
+  int Host = -1;
+  CHECK(hipMemcpy(&Host, Count, sizeof(int), hipMemcpyDeviceToHost));
+  if (Host != Launches) {
+    std::cout << "FAIL: kernel node ran " << Host << " times over "
+              << Launches << " launches\n";
+    return 2;
+  }
+
+  CHECK(hipGraphExecDestroy(GraphExec));
+  CHECK(hipGraphDestroy(Graph));
+  CHECK(hipFree(Count));
+  std::cout << "PASSED\n";
+  return 0;
+}

--- a/tests/runtime/TestFixKokkosGraphWhenAllRedundantEdges.hip
+++ b/tests/runtime/TestFixKokkosGraphWhenAllRedundantEdges.hip
@@ -1,0 +1,92 @@
+// Reproduces: hipGraphLaunch fails with hipErrorTbd ("Failed to find" from
+// CHIPGraphNode::removeDependency) on a graph whose redundant edges are
+// reachable through more than one path. Surfaced by Kokkos
+// hip_graph.when_all_cycle, which wires exactly this shape:
+//
+//   root -> f1 -> f2 -> f3
+//   agg1 depends on {f2, f3};  f4 depends on agg1
+//   agg2 depends on {f1, f4, f3};  f5 depends on agg2
+//
+// The edges agg2->f1, agg2->f3 and agg1->f2 are all implied by longer paths.
+#include <hip/hip_runtime.h>
+#include <iostream>
+
+__global__ void setTo(int *Dst, int Val) { *Dst = Val; }
+__global__ void addOne(int *Dst) { atomicAdd(Dst, 1); }
+
+#define CHECK(Call)                                                            \
+  do {                                                                         \
+    hipError_t Err = (Call);                                                   \
+    if (Err != hipSuccess) {                                                   \
+      std::cout << "FAIL: " #Call " -> " << hipGetErrorString(Err) << "\n";    \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+static hipKernelNodeParams kernelParams(const void *Func, void **Args,
+                                        unsigned Grid) {
+  hipKernelNodeParams Params = {};
+  Params.func = const_cast<void *>(Func);
+  Params.gridDim = dim3(Grid);
+  Params.blockDim = dim3(1);
+  Params.sharedMemBytes = 0;
+  Params.kernelParams = Args;
+  Params.extra = nullptr;
+  return Params;
+}
+
+int main() {
+  int *Count;
+  CHECK(hipMalloc(&Count, sizeof(int)));
+  CHECK(hipMemset(Count, 0xff, sizeof(int)));
+  CHECK(hipDeviceSynchronize());
+
+  hipGraph_t Graph;
+  CHECK(hipGraphCreate(&Graph, 0));
+
+  int Zero = 0;
+  void *SetArgs[] = {&Count, &Zero};
+  void *AddArgs[] = {&Count};
+  hipKernelNodeParams SetParams = kernelParams((const void *)setTo, SetArgs, 1);
+  hipKernelNodeParams AddParams = kernelParams((const void *)addOne, AddArgs, 1);
+  hipKernelNodeParams Add5Params =
+      kernelParams((const void *)addOne, AddArgs, 5);
+
+  // Kokkos adds every node without dependencies and wires the edges afterwards
+  // with hipGraphAddDependencies, one edge per call.
+  hipGraphNode_t Root, F1, F2, F3, Agg1, F4, Agg2, F5;
+  CHECK(hipGraphAddEmptyNode(&Root, Graph, nullptr, 0));
+  CHECK(hipGraphAddKernelNode(&F1, Graph, nullptr, 0, &SetParams));
+  CHECK(hipGraphAddKernelNode(&F2, Graph, nullptr, 0, &AddParams));
+  CHECK(hipGraphAddKernelNode(&F3, Graph, nullptr, 0, &Add5Params));
+  CHECK(hipGraphAddEmptyNode(&Agg1, Graph, nullptr, 0));
+  CHECK(hipGraphAddKernelNode(&F4, Graph, nullptr, 0, &AddParams));
+  CHECK(hipGraphAddEmptyNode(&Agg2, Graph, nullptr, 0));
+  CHECK(hipGraphAddKernelNode(&F5, Graph, nullptr, 0, &AddParams));
+
+  const hipGraphNode_t Edges[][2] = {
+      {Root, F1}, {F1, F2},   {F2, F3},   {F2, Agg1}, {F3, Agg1}, {Agg1, F4},
+      {F1, Agg2}, {F4, Agg2}, {F3, Agg2}, {Agg2, F5},
+  };
+  for (const auto &Edge : Edges)
+    CHECK(hipGraphAddDependencies(Graph, &Edge[0], &Edge[1], 1));
+
+  hipGraphExec_t GraphExec;
+  CHECK(hipGraphInstantiate(&GraphExec, Graph, nullptr, nullptr, 0));
+  CHECK(hipGraphLaunch(GraphExec, 0));
+  CHECK(hipDeviceSynchronize());
+
+  // set 0, +1 (f2), +5 (f3), +1 (f4), +1 (f5)
+  int Host = -1;
+  CHECK(hipMemcpy(&Host, Count, sizeof(int), hipMemcpyDeviceToHost));
+  if (Host != 8) {
+    std::cout << "FAIL: count is " << Host << ", expected 8\n";
+    return 2;
+  }
+
+  CHECK(hipGraphExecDestroy(GraphExec));
+  CHECK(hipGraphDestroy(Graph));
+  CHECK(hipFree(Count));
+  std::cout << "PASSED\n";
+  return 0;
+}


### PR DESCRIPTION
Found running the Kokkos::HIP unit tests (Kokkos::Graph, stream capture) on Aurora PVC. Stream capture executed work eagerly, `hipGraphLaunch` failed on redundant edges and on child graph nodes, repeated launches re-ran the graph N times, `hipGraphGetNodes` segfaulted on a null array, `hipGraphDebugDotPrint` and `hipGraphNodeSetEnabled` were unimplemented, `hipGraphExec*NodeSetParams` updated the wrong graph, and `hipLaunchHostFunc` under capture ran immediately. Each fix has its reproducer test committed before it. Three follow-up commits from review of the series define the kernel node destructor where `chipstar::ExecItem` is complete, make `hipGraphExecHostNodeSetParams` reject null host params, and make child graph nodes own a clone of the child graph as the HIP header documents, which stops a graph added as its own child from recursing at launch.

Fixes #1490
Fixes #1491
Fixes #1492
Fixes #1493
Fixes #1494
Fixes #1495
Fixes #1496
Fixes #1498
Fixes #1502
