### PR TITLE
cmake: order HIP device compiles after the pass plugin link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,11 +544,25 @@ unset(_hip_ver_major)
 unset(_hip_ver_minor)
 unset(_hip_ver_patch)
 
-# Make CHIP depend on devicelib_bc and LLVMHipPasses for
-# convenience. The CHIP module itself does not depend on these but
-# HIP program compilation does.
-add_dependencies(CHIP devicelib_bc LLVMHipPasses)
-add_dependencies(CHIP hipcc.bin hipconfig.bin)
+# Everything a HIP compile against the build tree needs from the in-tree
+# toolchain: hipcc, the device bitcode library, and the pass plugin that
+# clang loads from <hip-path>/lib while emitting device code.
+#
+# This is a utility target rather than a plain add_dependencies() on
+# LLVMHipPasses because of how the Ninja generator orders object compiles.
+# A dependency on a library target only orders a consumer's objects after
+# that library's own objects, not after its link, so a test TU could be
+# compiled, and its device link could dlopen lib/libLLVMHipSpvPasses.so,
+# while the plugin was still being relinked (CHIP-SPV/chipStar#1488). A
+# utility target is waited on completely, and so is every target it
+# depends on.
+add_custom_target(hip_device_toolchain)
+add_dependencies(hip_device_toolchain LLVMHipPasses devicelib_bc hipcc.bin)
+
+# The CHIP module itself needs none of this, but HIP program compilation
+# does, and everything that compiles HIP code against the build tree
+# links CHIP: the ordering reaches their object compiles through CHIP.
+add_dependencies(CHIP hip_device_toolchain hipconfig.bin)
 
 file(MAKE_DIRECTORY ${HIPCC_BUILD_PATH})
 if(NOT EXISTS "${HIPCC_BUILD_PATH}/hipcc")
@@ -1137,6 +1151,16 @@ if(CHIP_BUILD_TESTS)
   else()
     add_subdirectory(HIP/tests/catch catch)
   endif()
+  # The catch tree sets hipcc.bin as its compiler and never links CHIP, so
+  # it inherits none of the ordering that CHIP carries. Every catch
+  # executable is built on these object libraries, and the Ninja generator
+  # orders an executable's objects after those of the object libraries it
+  # consumes, so this reaches all of them.
+  foreach(CATCH_OBJECT_LIB KERNELS Main_Object Main_Object_Standalone)
+    if(TARGET ${CATCH_OBJECT_LIB})
+      add_dependencies(${CATCH_OBJECT_LIB} hip_device_toolchain)
+    endif()
+  endforeach()
   add_subdirectory(tests)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,3 +25,26 @@ add_subdirectory(libraries)
 add_subdirectory(benchmarks)
 add_subdirectory(regression)
 add_subdirectory(hipcc-verify)
+
+# Reproducer for CHIP-SPV/chipStar#1488. clang loads lib/libLLVMHipSpvPasses.so
+# as a pass plugin (through --hip-path) while compiling HIP device code, so
+# every object compiled from a HIP source has to be ordered after that link.
+# The walk follows order-only inputs, which is where the Ninja generator puts
+# target-level dependencies. One probe per registration path: the Test* glob
+# in runtime/, add_hip_test(), and the catch suite, whose own CMake tree
+# compiles with hipcc.bin and never links CHIP.
+if(CMAKE_GENERATOR MATCHES "Ninja")
+  find_package(Python3 COMPONENTS Interpreter)
+endif()
+if(CMAKE_GENERATOR MATCHES "Ninja" AND Python3_Interpreter_FOUND)
+  set(BUILD_ORDER_PROBES
+    $<TARGET_OBJECTS:TestKernelArgs>
+    $<TARGET_OBJECTS:TestFixUmul64hi>)
+  if(TARGET ErrorHandlingTest)
+    list(APPEND BUILD_ORDER_PROBES $<TARGET_OBJECTS:ErrorHandlingTest>)
+  endif()
+  add_test(NAME TestFix1488PassPluginBuildOrder
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_build_order.py
+      --ninja ${CMAKE_MAKE_PROGRAM} --build-dir ${CMAKE_BINARY_DIR}
+      --required $<TARGET_FILE:LLVMHipPasses> ${BUILD_ORDER_PROBES})
+endif()

--- a/tests/check_build_order.py
+++ b/tests/check_build_order.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Assert that build outputs are ordered after a file in the Ninja build graph.
+
+usage: check_build_order.py --ninja NINJA --build-dir DIR --required FILE OUTPUT...
+
+Each OUTPUT (or `;`-joined list of outputs, as $<TARGET_OBJECTS:...> expands
+to) must reach FILE through the transitive inputs of its build edge. Explicit,
+implicit and order-only inputs are all followed, because CMake's Ninja
+generator expresses target-level dependencies as order-only edges through
+phony cmake_object_order_depends_target_* nodes, and it is those edges that
+decide whether an object compile may start before FILE has been produced.
+
+Exit status is 1 when any output can be built without FILE existing first.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+def query_inputs(ninja, build_dir, nodes):
+    """Map each node in `nodes` to the inputs of the edge that produces it."""
+    result = subprocess.run(
+        [ninja, "-t", "query", *nodes],
+        cwd=build_dir, capture_output=True, text=True)
+    if result.returncode != 0:
+        sys.exit(f"ninja -t query failed:\n{result.stdout}{result.stderr}")
+
+    inputs = {}
+    current = None
+    in_inputs = False
+    for line in result.stdout.splitlines():
+        if line and not line.startswith(" ") and line.endswith(":"):
+            current = line[:-1]
+            inputs[current] = []
+            in_inputs = False
+        elif line.startswith("  input:"):
+            in_inputs = True
+        elif line.startswith("  outputs:"):
+            in_inputs = False
+        elif in_inputs and line.startswith("    "):
+            dep = line.strip()
+            for marker in ("|| ", "| "):  # order-only and implicit inputs
+                if dep.startswith(marker):
+                    dep = dep[len(marker):]
+                    break
+            inputs[current].append(dep)
+    return inputs
+
+
+def transitive_inputs(ninja, build_dir, root, cache):
+    """Every node reachable from `root` through inputs, one query per level."""
+    seen = {root}
+    frontier = [root]
+    while frontier:
+        unknown = [n for n in frontier if n not in cache]
+        if unknown:
+            cache.update(query_inputs(ninja, build_dir, unknown))
+        next_frontier = []
+        for node in frontier:
+            for dep in cache.get(node, []):
+                if dep not in seen:
+                    seen.add(dep)
+                    next_frontier.append(dep)
+        frontier = next_frontier
+    return seen
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--ninja", required=True)
+    parser.add_argument("--build-dir", required=True)
+    parser.add_argument("--required", required=True,
+                        help="file every OUTPUT must be ordered after")
+    parser.add_argument("outputs", nargs="+")
+    args = parser.parse_args()
+
+    build_dir = os.path.abspath(args.build_dir)
+
+    def ninja_name(path):
+        # CMake writes paths under the build directory relative to it.
+        if os.path.isabs(path) and path.startswith(build_dir + os.sep):
+            return os.path.relpath(path, build_dir)
+        return path
+
+    required = ninja_name(args.required)
+    outputs = [ninja_name(o) for arg in args.outputs for o in arg.split(";") if o]
+
+    cache = {}
+    missing = []
+    for output in outputs:
+        closure = {ninja_name(n) for n in
+                   transitive_inputs(args.ninja, build_dir, output, cache)}
+        ordered = required in closure
+        print(f"{output}: {'ordered' if ordered else 'NOT ordered'} after {required}")
+        if not ordered:
+            missing.append(output)
+
+    if missing:
+        print(f"\n{len(missing)} of {len(outputs)} outputs may be built before "
+              f"{required} exists", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Under the Ninja generator a dependency on a library target only orders a consumer's object compiles after that library's objects, not after its link, so `add_dependencies(CHIP LLVMHipPasses)` let test TUs compile while `lib/libLLVMHipSpvPasses.so` was being relinked and their device link failed with `file too short` or `invalid ELF header`. The in-tree toolchain (`LLVMHipPasses`, `devicelib_bc`, `hipcc.bin`) now goes through a utility target, `hip_device_toolchain`, which Ninja waits on completely; CHIP and the catch object libraries (`KERNELS`, `Main_Object`) depend on it, so every target that compiles HIP code against the build tree is ordered after the plugin link. `TestFix1488PassPluginBuildOrder` walks the Ninja graph for one object per registration path (runtime glob, `add_hip_test`, catch) and fails on main.

Fixes #1488
