### PR TITLE
Honour the array capacity in hipGraphGetEdges

### DIFF
--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -1200,14 +1200,22 @@ hipError_t hipGraphGetEdges(hipGraph_t graph, hipGraphNode_t *from,
     *numEdges = Edges.size();
     RETURN(hipSuccess);
   }
+  if (!to || !from)
+    RETURN(hipErrorInvalidValue);
 
-  for (int i = 0; i < Edges.size(); i++) {
-    auto Edge = Edges[i];
-    auto FromNode = Edge.first;
-    auto ToNode = Edge.second;
-    from[i] = FromNode;
-    to[i] = ToNode;
+  // On entry *numEdges is the capacity of from/to. Fill at most that many
+  // entries, null the surplus ones and report how many were written.
+  size_t Capacity = *numEdges;
+  size_t NumWritten = std::min(Capacity, Edges.size());
+  for (size_t i = 0; i < NumWritten; i++) {
+    from[i] = Edges[i].first;
+    to[i] = Edges[i].second;
   }
+  for (size_t i = NumWritten; i < Capacity; i++) {
+    from[i] = nullptr;
+    to[i] = nullptr;
+  }
+  *numEdges = NumWritten;
   RETURN(hipSuccess);
   CHIP_CATCH
 }

--- a/src/CHIPGraph.hh
+++ b/src/CHIPGraph.hh
@@ -619,12 +619,17 @@ public:
 
   std::vector<CHIPGraphNode *> &getNodes() { return Nodes_; }
 
+  /**
+   * @brief Collect the graph's edges as (from, to) pairs.
+   * A node's dependencies are the nodes it runs after, so each dependency
+   * is the from end of an edge that ends at the node.
+   */
   std::vector<std::pair<CHIPGraphNode *, CHIPGraphNode *>> getEdges() {
     std::set<std::pair<CHIPGraphNode *, CHIPGraphNode *>> Edges;
     for (auto Node : Nodes_) {
       for (auto Dep : Node->getDependencies()) {
         auto FromToPair =
-            std::pair<CHIPGraphNode *, CHIPGraphNode *>(Node, Dep);
+            std::pair<CHIPGraphNode *, CHIPGraphNode *>(Dep, Node);
         Edges.insert(FromToPair);
       }
     }

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -116,8 +116,6 @@ ANY:
     Unit_hipGraphExecUpdate_Functional: ''
     Unit_hipGraphExecUpdate_Negative_Basic: ''
     Unit_hipGraphExecUpdate_Negative_TypeChange: ''
-    Unit_hipGraphGetEdges_Functionality: ''
-    Unit_hipGraphGetEdges_Negative: ''
     Unit_hipGraphGetNodes_CapturedStream: ''
     Unit_hipGraphGetNodes_Functional: ''
     Unit_hipGraphGetNodes_ParamValidation: ''

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -85,6 +85,11 @@ foreach(RUNTIME_TEST_SOURCE IN LISTS RUNTIME_TEST_SOURCES)
   add_hip_runtime_test(${RUNTIME_TEST_SOURCE})
 endforeach()
 
+# hipGraphGetEdges overflowing the caller's arrays must abort at the free
+# instead of depending on the heap layout to surface it.
+set_tests_properties(TestFix1524GetEdgesCapacity PROPERTIES
+  ENVIRONMENT "MALLOC_CHECK_=3")
+
 # Names that the Test* glob does not match.
 add_hip_runtime_test(RegressionTest302.hip)
 add_hip_runtime_test(host-math-funcs.hip)

--- a/tests/runtime/TestFix1524GetEdgesCapacity.hip
+++ b/tests/runtime/TestFix1524GetEdgesCapacity.hip
@@ -1,0 +1,136 @@
+// Reproduces #1524: hipGraphGetEdges ignores the caller's *numEdges capacity
+// and writes every edge of the graph into from/to, overflowing arrays that are
+// smaller than the edge count (Unit_hipGraphGetEdges_Functionality then aborts
+// with "double free or corruption" when it frees them). It also never writes
+// the actual edge count back, leaves the surplus entries untouched instead of
+// null, returns every edge with from and to swapped, and accepts a null from
+// with a non-null to.
+//
+// The test name deliberately avoids the word "graph": the '.*[Gg]raph.*' mask
+// in tests/known_failures.yaml would otherwise exclude it from check.py runs.
+#include <hip/hip_runtime_api.h>
+#include <cstdio>
+
+#define CHECK(x)                                                               \
+  do {                                                                         \
+    hipError_t Err = (x);                                                      \
+    if (Err != hipSuccess) {                                                   \
+      printf("FAIL: %s returned %d (%s)\n", #x, Err, hipGetErrorName(Err));    \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+constexpr size_t NumEdges = 4;
+
+// Graph: A -> C, B -> C, C -> D, A -> D.
+static hipGraphNode_t From[NumEdges];
+static hipGraphNode_t To[NumEdges];
+
+static bool isExpectedEdge(hipGraphNode_t F, hipGraphNode_t T) {
+  for (size_t I = 0; I < NumEdges; I++)
+    if (From[I] == F && To[I] == T)
+      return true;
+  return false;
+}
+
+int main() {
+  hipGraph_t Graph;
+  CHECK(hipGraphCreate(&Graph, 0));
+  hipGraphNode_t A, B, C, D;
+  CHECK(hipGraphAddEmptyNode(&A, Graph, nullptr, 0));
+  CHECK(hipGraphAddEmptyNode(&B, Graph, nullptr, 0));
+  CHECK(hipGraphAddEmptyNode(&C, Graph, nullptr, 0));
+  CHECK(hipGraphAddEmptyNode(&D, Graph, nullptr, 0));
+  From[0] = A;
+  To[0] = C;
+  From[1] = B;
+  To[1] = C;
+  From[2] = C;
+  To[2] = D;
+  From[3] = A;
+  To[3] = D;
+  CHECK(hipGraphAddDependencies(Graph, From, To, NumEdges));
+
+  // Size query: both arrays null.
+  size_t Count = 0;
+  CHECK(hipGraphGetEdges(Graph, nullptr, nullptr, &Count));
+  if (Count != NumEdges) {
+    printf("FAIL: size query returned %zu edges, expected %zu\n", Count,
+           NumEdges);
+    return 1;
+  }
+
+  // Arrays smaller than the edge count: only *numEdges entries may be written.
+  // Exactly sized heap arrays so an overflow corrupts the heap and glibc aborts
+  // on delete[] (MALLOC_CHECK_=3 in the ctest environment makes that certain).
+  {
+    size_t Cap = NumEdges - 1;
+    hipGraphNode_t *F = new hipGraphNode_t[Cap]();
+    hipGraphNode_t *T = new hipGraphNode_t[Cap]();
+    CHECK(hipGraphGetEdges(Graph, F, T, &Cap));
+    if (Cap != NumEdges - 1) {
+      printf("FAIL: numEdges changed to %zu on a short array, expected %zu\n",
+             Cap, NumEdges - 1);
+      return 1;
+    }
+    for (size_t I = 0; I < Cap; I++)
+      if (!isExpectedEdge(F[I], T[I])) {
+        printf("FAIL: short array entry %zu (%p -> %p) is not an edge\n", I,
+               (void *)F[I], (void *)T[I]);
+        return 1;
+      }
+    delete[] T;
+    delete[] F;
+  }
+
+  // Arrays larger than the edge count: surplus entries become null and the
+  // actual count is written back.
+  {
+    size_t Cap = NumEdges + 2;
+    hipGraphNode_t Sentinel = reinterpret_cast<hipGraphNode_t>(0x1);
+    hipGraphNode_t F[NumEdges + 2], T[NumEdges + 2];
+    for (size_t I = 0; I < Cap; I++)
+      F[I] = T[I] = Sentinel;
+    CHECK(hipGraphGetEdges(Graph, F, T, &Cap));
+    if (Cap != NumEdges) {
+      printf("FAIL: numEdges left at %zu on a large array, expected %zu\n", Cap,
+             NumEdges);
+      return 1;
+    }
+    for (size_t I = 0; I < NumEdges; I++)
+      if (!isExpectedEdge(F[I], T[I])) {
+        printf("FAIL: large array entry %zu (%p -> %p) is not an edge\n", I,
+               (void *)F[I], (void *)T[I]);
+        return 1;
+      }
+    for (size_t I = 0; I < NumEdges; I++) {
+      bool Found = false;
+      for (size_t J = 0; J < NumEdges; J++)
+        Found |= (F[J] == From[I] && T[J] == To[I]);
+      if (!Found) {
+        printf("FAIL: edge %zu (%p -> %p) missing from the result\n", I,
+               (void *)From[I], (void *)To[I]);
+        return 1;
+      }
+    }
+    for (size_t I = NumEdges; I < NumEdges + 2; I++)
+      if (F[I] != nullptr || T[I] != nullptr) {
+        printf("FAIL: surplus entry %zu not null (%p -> %p)\n", I, (void *)F[I],
+               (void *)T[I]);
+        return 1;
+      }
+  }
+
+  // Only one of the arrays null is invalid.
+  hipGraphNode_t Scratch[NumEdges] = {};
+  size_t N = NumEdges;
+  if (hipGraphGetEdges(Graph, nullptr, Scratch, &N) != hipErrorInvalidValue ||
+      hipGraphGetEdges(Graph, Scratch, nullptr, &N) != hipErrorInvalidValue) {
+    printf("FAIL: null from or null to alone must be hipErrorInvalidValue\n");
+    return 1;
+  }
+
+  CHECK(hipGraphDestroy(Graph));
+  printf("PASSED\n");
+  return 0;
+}


### PR DESCRIPTION
hipGraphGetEdges ignored the `*numEdges` capacity the caller passed in and wrote every edge of the graph into from/to, so arrays smaller than the edge count were overflowed and Unit_hipGraphGetEdges_Functionality aborted with `double free or corruption` when it freed them. The call now fills at most `*numEdges` entries, nulls the surplus ones, writes back the number returned, and rejects a null from with a non-null to; CHIPGraph::getEdges also paired each node with its dependency as (node, dep), so every edge came back with from and to swapped. Both Unit_hipGraphGetEdges tests pass on the Intel CPU OpenCL runtime and leave known_failures.yaml, and the new tests/runtime/TestFix1524GetEdgesCapacity.hip covers the contract (named without the word graph so the `.*[Gg]raph.*` mask does not exclude it from check.py).

Fixes #1524
