### PR TITLE
graph: reject unschedulable graphs at instantiation and stop pruning the caller's graph

### DIFF
--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -1394,6 +1394,14 @@ hipError_t hipGraphInstantiate(hipGraphExec_t *pGraphExec, hipGraph_t graph,
     RETURN(hipErrorInvalidValue);
 
   CHIPGraphExec *GraphExec = new CHIPGraphExec(GRAPH(graph));
+  // Build the schedule now so that a graph no launch could ever schedule is
+  // rejected here instead of at hipGraphLaunch.
+  try {
+    GraphExec->compile();
+  } catch (...) {
+    delete GraphExec;
+    throw;
+  }
   *pGraphExec = GraphExec;
 
   RETURN(hipSuccess);

--- a/src/CHIPGraph.cc
+++ b/src/CHIPGraph.cc
@@ -271,7 +271,10 @@ std::vector<CHIPGraphNode *> CHIPGraph::getLeafNodes() {
 }
 
 void CHIPGraphExec::pruneGraph_() {
-  std::vector<CHIPGraphNode *> LeafNodes_ = OriginalGraph_->getLeafNodes();
+  // Prune the executable's own copy of the graph. The caller keeps using the
+  // original hipGraph_t, and hipGraphGetEdges on it has to keep reporting the
+  // edges the caller added.
+  std::vector<CHIPGraphNode *> LeafNodes_ = CompiledGraph_.getLeafNodes();
 
   for (auto LeafNode : LeafNodes_) {
     // Generate all paths from leaf to root

--- a/src/CHIPGraph.cc
+++ b/src/CHIPGraph.cc
@@ -328,7 +328,6 @@ std::vector<CHIPGraphNode *> CHIPGraph::getRootNodes() {
 }
 
 void CHIPGraphExec::compile() {
-  ExtractSubGraphs_();
   pruneGraph_();
   logDebug("{} CHIPGraphExec::compile()", (void *)this);
   std::vector<CHIPGraphNode *> Nodes = OriginalGraph_->getNodes();
@@ -387,40 +386,6 @@ void CHIPGraphExec::compile() {
 void CHIPGraphNodeHost::execute(chipstar::Queue *Queue) const {
   Queue->finish();
   Params_.fn(Params_.userData);
-}
-
-void CHIPGraphExec::ExtractSubGraphs_() {
-  auto Nodes = CompiledGraph_.getNodes();
-  for (int i = 0; i < Nodes.size(); i++) {
-    auto Node = Nodes[i];
-    if (Node->getType() == hipGraphNodeTypeGraph) {
-      auto SubGraphNode = static_cast<CHIPGraphNodeGraph *>(Node);
-      auto SubGraph = SubGraphNode->getGraph();
-
-      // 1. get all the root nodes
-      auto RootNodes = SubGraph->getRootNodes();
-      if (i > 0) {
-        // 2. make them dependants of prev nodes
-        auto PrevNode = Nodes[i - 1];
-        PrevNode->addDependencies(RootNodes);
-      }
-
-      // 3. get all the leaf nodes
-      auto LeafNodes = SubGraph->getLeafNodes();
-      if (i < Nodes.size()) {
-        // 4. add dependency on next node
-        auto NextNode = Nodes[i + 1];
-        NextNode->addDependants(LeafNodes);
-      }
-
-      // 5. Erase the original subgraph node
-      Nodes.erase(Nodes.begin() + i);
-      // 6. replace it with nodes from the subgraph
-      for (auto SubGraphNode : SubGraph->getNodes()) {
-        Nodes.push_back(SubGraphNode);
-      }
-    }
-  }
 }
 
 void CHIPGraphNodeEventRecord::execute(chipstar::Queue *Queue) const {

--- a/src/CHIPGraph.cc
+++ b/src/CHIPGraph.cc
@@ -36,6 +36,12 @@
 //*************************************************************************************
 void CHIPGraphNode::DFS(std::vector<CHIPGraphNode *> CurrPath,
                         std::vector<std::vector<CHIPGraphNode *>> &Paths) {
+  // A node that is already on the path depends on itself through a cycle;
+  // the walk would never reach a root.
+  if (std::find(CurrPath.begin(), CurrPath.end(), this) != CurrPath.end())
+    CHIPERR_LOG_AND_THROW("Graph node " + Msg +
+                              " depends on itself through a cycle",
+                          hipErrorInvalidValue);
   CurrPath.push_back(this);
   for (auto &Dep : Dependencies_) {
     Dep->DFS(CurrPath, Paths);
@@ -328,6 +334,9 @@ std::vector<CHIPGraphNode *> CHIPGraph::getRootNodes() {
 }
 
 void CHIPGraphExec::compile() {
+  // Every launch rebuilds the schedule from scratch; the levels queued by the
+  // previous launch would otherwise run again in front of the new ones.
+  ExecQueues_ = {};
   pruneGraph_();
   logDebug("{} CHIPGraphExec::compile()", (void *)this);
   std::vector<CHIPGraphNode *> Nodes = OriginalGraph_->getNodes();
@@ -375,6 +384,13 @@ void CHIPGraphExec::compile() {
     }
 
     if (NodeIter == Nodes.end()) {
+      // A pass that places no node would repeat forever: every remaining node
+      // waits on a node outside this graph or on a node that is itself still
+      // waiting (a cycle, or a graph without a root).
+      if (NextSet.empty())
+        CHIPERR_LOG_AND_THROW("Graph node " + Nodes.front()->Msg +
+                                  " depends on a node that can never run",
+                              hipErrorInvalidValue);
       PrevLevelNodes.insert(NextSet.begin(), NextSet.end());
       ExecQueues_.push(NextSet);
       NextSet.clear();

--- a/src/CHIPGraph.hh
+++ b/src/CHIPGraph.hh
@@ -664,13 +664,6 @@ protected:
   std::queue<std::set<CHIPGraphNode *>> ExecQueues_;
 
   /**
-   * @brief For every CHIPGraphNodeGraph in CompiledGraph_, replace this node
-   * with its contents.
-   *
-   */
-  void ExtractSubGraphs_();
-
-  /**
    * @brief remove unnecessary dependencies
    * for leaf node in graph:
    *   for each dependency in node:

--- a/src/CHIPGraph.hh
+++ b/src/CHIPGraph.hh
@@ -207,7 +207,14 @@ public:
   void updateDependencies(std::map<CHIPGraphNode *, CHIPGraphNode *> CloneMap) {
     std::vector<CHIPGraphNode *> NewDeps;
     for (auto Dep : Dependencies_) {
-      auto ClonedDep = CloneMap[Dep];
+      auto Found = CloneMap.find(Dep);
+      // A dependency on a node of another graph has no clone here, and a
+      // graph with such a node can never be scheduled.
+      if (Found == CloneMap.end())
+        CHIPERR_LOG_AND_THROW("Graph node " + Msg +
+                                  " depends on a node outside its graph",
+                              hipErrorInvalidValue);
+      auto ClonedDep = Found->second;
       logDebug("{} {} Replacing dependency {} with {}", (void *)this, this->Msg,
                (void *)Dep, (void *)ClonedDep);
       NewDeps.push_back(ClonedDep);
@@ -232,7 +239,12 @@ public:
   void updateDependants(std::map<CHIPGraphNode *, CHIPGraphNode *> CloneMap) {
     std::vector<CHIPGraphNode *> NewDeps;
     for (auto Dep : Dependendants_) {
-      auto ClonedDep = CloneMap[Dep];
+      auto Found = CloneMap.find(Dep);
+      // A dependant in another graph is not part of this graph; the clone
+      // keeps only the edges inside it.
+      if (Found == CloneMap.end())
+        continue;
+      auto ClonedDep = Found->second;
       logDebug("{} {} Replacing dependant {} with {}", (void *)this, this->Msg,
                (void *)Dep, (void *)ClonedDep);
       NewDeps.push_back(ClonedDep);

--- a/tests/runtime/TestFix1501GraphCompileLoop.hip
+++ b/tests/runtime/TestFix1501GraphCompileLoop.hip
@@ -1,0 +1,121 @@
+// Reproduces: CHIPGraphExec::compile() spins forever, growing its execution
+// queue, when no schedule pass can place a node (the only node of a graph
+// depends on a node of another graph, or the graph has a cycle and thus no
+// root), and pruneGraph_() removes the redundant edges of the caller's graph
+// on every hipGraphLaunch, so hipGraphGetEdges under reports after a launch.
+#include <hip/hip_runtime_api.h>
+#include <csignal>
+#include <iostream>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define CHECK(Call)                                                            \
+  do {                                                                         \
+    hipError_t Err = (Call);                                                   \
+    if (Err != hipSuccess) {                                                   \
+      std::cout << "FAIL: " #Call " -> " << hipGetErrorString(Err) << "\n";    \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+static void onAlarm(int) {
+  static const char Msg[] = "FAIL: the graph launch did not return\n";
+  write(STDOUT_FILENO, Msg, sizeof(Msg) - 1);
+  _exit(1);
+}
+
+// Instantiate Graph in a child process, so that a launch that never returns
+// only costs this case, and report whether instantiation was rejected.
+static int expectRejected(hipGraph_t Graph, const char *What) {
+  pid_t Child = fork();
+  if (Child < 0) {
+    std::cout << "FAIL: fork\n";
+    return 1;
+  }
+  if (Child == 0) {
+    signal(SIGALRM, onAlarm);
+    alarm(5);
+    hipGraphExec_t Exec = nullptr;
+    hipError_t Err = hipGraphInstantiate(&Exec, Graph, nullptr, nullptr, 0);
+    if (Err == hipErrorInvalidValue)
+      _exit(0);
+    std::cout << "FAIL: hipGraphInstantiate of " << What << " returned "
+              << hipGetErrorString(Err) << ", expected hipErrorInvalidValue\n";
+    if (Err == hipSuccess)
+      hipGraphLaunch(Exec, 0); // never returns without the fix
+    _exit(1);
+  }
+  int Status = 0;
+  waitpid(Child, &Status, 0);
+  return WIFEXITED(Status) && WEXITSTATUS(Status) == 0 ? 0 : 1;
+}
+
+int main() {
+  int Failed = 0;
+  std::cout << std::unitbuf; // keep the output when a child _exit()s
+
+  // A -> B -> C plus the redundant edge A -> C. Instantiating and launching
+  // the graph twice must leave its nodes and edges as the caller built them.
+  hipGraph_t Graph;
+  CHECK(hipGraphCreate(&Graph, 0));
+  hipGraphNode_t A, B, C;
+  CHECK(hipGraphAddEmptyNode(&A, Graph, nullptr, 0));
+  CHECK(hipGraphAddEmptyNode(&B, Graph, &A, 1));
+  hipGraphNode_t DepsC[] = {A, B};
+  CHECK(hipGraphAddEmptyNode(&C, Graph, DepsC, 2));
+
+  hipGraphNode_t Nodes[3];
+  size_t NumNodes = 0, NumEdges = 0;
+  CHECK(hipGraphGetNodes(Graph, Nodes, &NumNodes));
+  CHECK(hipGraphGetEdges(Graph, nullptr, nullptr, &NumEdges));
+  if (NumNodes != 3 || NumEdges != 3) {
+    std::cout << "FAIL: built " << NumNodes << " nodes and " << NumEdges
+              << " edges, expected 3 and 3\n";
+    return 1;
+  }
+
+  hipGraphExec_t Exec;
+  CHECK(hipGraphInstantiate(&Exec, Graph, nullptr, nullptr, 0));
+  for (int Launch = 0; Launch < 2; Launch++) {
+    CHECK(hipGraphLaunch(Exec, 0));
+    CHECK(hipStreamSynchronize(0));
+  }
+
+  CHECK(hipGraphGetNodes(Graph, Nodes, &NumNodes));
+  CHECK(hipGraphGetEdges(Graph, nullptr, nullptr, &NumEdges));
+  if (NumNodes != 3 || NumEdges != 3) {
+    std::cout << "FAIL: after two launches the graph has " << NumNodes
+              << " nodes and " << NumEdges << " edges, expected 3 and 3\n";
+    Failed = 1;
+  }
+  CHECK(hipGraphExecDestroy(Exec));
+  CHECK(hipGraphDestroy(Graph));
+
+  // A graph whose only node depends on a node of another graph can never be
+  // scheduled. hipGraphInstantiate must reject it instead of leaving the
+  // launch to spin forever.
+  hipGraph_t Other, Foreign;
+  CHECK(hipGraphCreate(&Other, 0));
+  CHECK(hipGraphCreate(&Foreign, 0));
+  hipGraphNode_t OtherNode, ForeignNode;
+  CHECK(hipGraphAddEmptyNode(&OtherNode, Other, nullptr, 0));
+  CHECK(hipGraphAddEmptyNode(&ForeignNode, Foreign, &OtherNode, 1));
+  Failed |= expectRejected(Foreign, "the graph with a foreign dependency");
+  CHECK(hipGraphDestroy(Foreign));
+  CHECK(hipGraphDestroy(Other));
+
+  // A graph whose every node has a dependency has no root, so no node can go
+  // first. Here X and Y depend on each other and Z waits on X.
+  hipGraph_t Cyclic;
+  CHECK(hipGraphCreate(&Cyclic, 0));
+  hipGraphNode_t X, Y, Z;
+  CHECK(hipGraphAddEmptyNode(&X, Cyclic, nullptr, 0));
+  CHECK(hipGraphAddEmptyNode(&Y, Cyclic, &X, 1));
+  CHECK(hipGraphAddEmptyNode(&Z, Cyclic, &X, 1));
+  CHECK(hipGraphAddDependencies(Cyclic, &Y, &X, 1));
+  Failed |= expectRejected(Cyclic, "the cyclic graph");
+  CHECK(hipGraphDestroy(Cyclic));
+
+  std::cout << (Failed ? "FAILED\n" : "PASSED\n");
+  return Failed;
+}


### PR DESCRIPTION
Found while running Kokkos::Graph on chipStar. `CHIPGraphExec::compile()` had no progress guard, so a graph whose node depends on a node of another graph, or whose dependencies form a cycle, made `hipGraphLaunch` spin forever with unbounded memory growth; such graphs are now rejected with `hipErrorInvalidValue`, from `hipGraphInstantiate` up front. `pruneGraph_()` also removed the redundant edges of the caller's `hipGraph_t` on every launch, so `hipGraphGetEdges` under reported afterwards; it now prunes the executable's own copy. `ExtractSubGraphs_` is dropped: the scheduler never saw the nodes it spliced in, it read past the end of its node list, and it looped forever on a graph that contains itself. The reproducer `TestFix1501GraphCompileLoop` covers all three cases.

Fixes #1501
