### PR TITLE
Answer hipMemRangeAttributeCoherencyMode for every tracked allocation

### DIFF
--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -488,6 +488,10 @@ struct AllocationInfo {
   bool ReadMostly = false; ///< Whether memory range is marked as read-mostly
   int PreferredLocation = -2; ///< Preferred device location, -2 (hipInvalidDeviceId) if not set
   std::vector<int> AccessedBy; ///< List of device IDs that access this memory
+  /// hipMemAdviseSetCoarseGrain is in effect on a managed allocation. Only
+  /// hipMemRangeAttributeCoherencyMode reads it; the backends keep the range
+  /// coherent regardless.
+  bool CoarseGrain = false;
 
   /// True if the allocation is accessible from device.
   bool isDeviceAccessible() const {

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -604,6 +604,32 @@ hipError_t hipDrvPointerGetAttributes(unsigned int numAttributes,
   CHIP_CATCH
 }
 
+/// Coherency mode of an allocation, following the ROCm answer for the same
+/// allocation kinds: device memory is coarse grained, host memory is fine
+/// grained unless allocated with hipHostMallocNonCoherent, managed memory
+/// (hipMallocManaged, hipHostRegister) is fine grained unless
+/// hipMemAdviseSetCoarseGrain is in effect.
+static hipMemRangeCoherencyMode
+getCoherencyMode(const chipstar::AllocationInfo &AllocInfo) {
+  switch (AllocInfo.MemoryType) {
+  case hipMemoryTypeHost:
+    return AllocInfo.Flags.isNonCoherent() ? hipMemRangeCoherencyModeCoarseGrain
+                                           : hipMemRangeCoherencyModeFineGrain;
+  case hipMemoryTypeManaged:
+  case hipMemoryTypeUnified:
+    return AllocInfo.CoarseGrain ? hipMemRangeCoherencyModeCoarseGrain
+                                 : hipMemRangeCoherencyModeFineGrain;
+  default:
+    return hipMemRangeCoherencyModeCoarseGrain;
+  }
+}
+
+/// True for the attributes that only managed or unified allocations carry.
+/// hipMemRangeAttributeCoherencyMode is answered for every tracked allocation.
+static bool isManagedOnlyMemRangeAttribute(hipMemRangeAttribute Attribute) {
+  return Attribute != hipMemRangeAttributeCoherencyMode;
+}
+
 hipError_t hipMemRangeGetAttributes(void **data, size_t *data_sizes,
                                     hipMemRangeAttribute *attributes,
                                     size_t num_attributes, const void *dev_ptr,
@@ -635,11 +661,8 @@ hipError_t hipMemRangeGetAttributes(void **data, size_t *data_sizes,
     RETURN(hipErrorInvalidValue);
   }
 
-  // Only managed/unified memory supports these attributes
-  if (AllocInfo->MemoryType != hipMemoryTypeManaged &&
-      AllocInfo->MemoryType != hipMemoryTypeUnified) {
-    RETURN(hipErrorInvalidValue);
-  }
+  bool IsManaged = AllocInfo->MemoryType == hipMemoryTypeManaged ||
+                   AllocInfo->MemoryType == hipMemoryTypeUnified;
 
   // Process each attribute
   for (size_t i = 0; i < num_attributes; ++i) {
@@ -649,6 +672,10 @@ hipError_t hipMemRangeGetAttributes(void **data, size_t *data_sizes,
 
     // Validate data size for each attribute
     if (AttrDataSize == 0) {
+      RETURN(hipErrorInvalidValue);
+    }
+
+    if (!IsManaged && isManagedOnlyMemRangeAttribute(Attr)) {
       RETURN(hipErrorInvalidValue);
     }
 
@@ -699,7 +726,7 @@ hipError_t hipMemRangeGetAttributes(void **data, size_t *data_sizes,
       }
       hipMemRangeCoherencyMode *Mode =
           static_cast<hipMemRangeCoherencyMode *>(AttrData);
-      *Mode = hipMemRangeCoherencyModeFineGrain;
+      *Mode = getCoherencyMode(*AllocInfo);
       break;
     }
     default:
@@ -2689,9 +2716,9 @@ hipError_t hipMemRangeGetAttribute(void *Data, size_t DataSize,
     RETURN(hipErrorInvalidValue);
   }
 
-  // Only managed/unified memory supports these attributes
-  if (AllocInfo->MemoryType != hipMemoryTypeManaged &&
-      AllocInfo->MemoryType != hipMemoryTypeUnified) {
+  bool IsManaged = AllocInfo->MemoryType == hipMemoryTypeManaged ||
+                   AllocInfo->MemoryType == hipMemoryTypeUnified;
+  if (!IsManaged && isManagedOnlyMemRangeAttribute(Attribute)) {
     RETURN(hipErrorInvalidValue);
   }
 
@@ -2745,7 +2772,7 @@ hipError_t hipMemRangeGetAttribute(void *Data, size_t DataSize,
       RETURN(hipErrorInvalidValue);
     }
     hipMemRangeCoherencyMode *Mode = static_cast<hipMemRangeCoherencyMode *>(Data);
-    *Mode = hipMemRangeCoherencyModeFineGrain;
+    *Mode = getCoherencyMode(*AllocInfo);
     break;
   }
   default:
@@ -4385,8 +4412,12 @@ hipError_t hipMemAdvise(const void *Ptr, size_t Count, hipMemoryAdvise Advice,
         AllocInfo->AccessedBy.end());
     break;
   case hipMemAdviseSetCoarseGrain:
+    // Recorded for hipMemRangeAttributeCoherencyMode only; the backends keep
+    // the range coherent either way.
+    AllocInfo->CoarseGrain = true;
+    break;
   case hipMemAdviseUnsetCoarseGrain:
-    // Coarse grain hints are accepted but not acted upon
+    AllocInfo->CoarseGrain = false;
     break;
   default:
     RETURN(hipErrorInvalidValue);

--- a/tests/runtime/TestFix1530MemRangeCoherencyMode.hip
+++ b/tests/runtime/TestFix1530MemRangeCoherencyMode.hip
@@ -1,0 +1,158 @@
+// Regression test for https://github.com/CHIP-SPV/chipStar/issues/1530
+//
+// hipMemRangeGetAttribute(hipMemRangeAttributeCoherencyMode) must answer for
+// every tracked allocation, the way ROCm does (rocclr Device::GetSvmAttributes
+// reads the HSA pool flags of the pointer): device memory and non coherent
+// host memory are coarse grained, coherent host memory and managed memory are
+// fine grained, and hipMemAdviseSetCoarseGrain flips a managed range to
+// coarse grained. Kokkos hip.memory_requirements relies on all three of its
+// memory spaces (hipMalloc, hipHostMalloc(hipHostMallocNonCoherent) and
+// hipMallocManaged + hipMemAdviseSetCoarseGrain) reporting coarse grain.
+
+#include <hip/hip_runtime.h>
+#include <cstdio>
+
+static int Failures = 0;
+
+static const char *modeName(hipMemRangeCoherencyMode Mode) {
+  switch (Mode) {
+  case hipMemRangeCoherencyModeFineGrain:
+    return "FineGrain";
+  case hipMemRangeCoherencyModeCoarseGrain:
+    return "CoarseGrain";
+  case hipMemRangeCoherencyModeIndeterminate:
+    return "Indeterminate";
+  }
+  return "?";
+}
+
+static void checkMode(const char *Kind, const void *Ptr, size_t Size,
+                      hipMemRangeCoherencyMode Expected) {
+  hipMemRangeCoherencyMode Mode = hipMemRangeCoherencyModeIndeterminate;
+  hipError_t Err = hipMemRangeGetAttribute(
+      &Mode, sizeof(Mode), hipMemRangeAttributeCoherencyMode, Ptr, Size);
+  if (Err != hipSuccess) {
+    printf("FAIL: %s: hipMemRangeGetAttribute(CoherencyMode) returned %s, "
+           "expected hipSuccess\n",
+           Kind, hipGetErrorName(Err));
+    Failures++;
+    return;
+  }
+  if (Mode != Expected) {
+    printf("FAIL: %s: coherency mode %s, expected %s\n", Kind, modeName(Mode),
+           modeName(Expected));
+    Failures++;
+    return;
+  }
+
+  // The plural entry point shares the attribute switch.
+  hipMemRangeCoherencyMode Mode2 = hipMemRangeCoherencyModeIndeterminate;
+  void *Data[1] = {&Mode2};
+  size_t DataSizes[1] = {sizeof(Mode2)};
+  hipMemRangeAttribute Attrs[1] = {hipMemRangeAttributeCoherencyMode};
+  Err = hipMemRangeGetAttributes(Data, DataSizes, Attrs, 1, Ptr, Size);
+  if (Err != hipSuccess || Mode2 != Expected) {
+    printf("FAIL: %s: hipMemRangeGetAttributes(CoherencyMode) returned %s, "
+           "mode %s, expected hipSuccess and %s\n",
+           Kind, hipGetErrorName(Err), modeName(Mode2), modeName(Expected));
+    Failures++;
+    return;
+  }
+  printf("OK: %s: %s\n", Kind, modeName(Mode));
+}
+
+static void checkError(const char *What, hipError_t Err, hipError_t Expected) {
+  if (Err != Expected) {
+    printf("FAIL: %s returned %s, expected %s\n", What, hipGetErrorName(Err),
+           hipGetErrorName(Expected));
+    Failures++;
+  } else {
+    printf("OK: %s returned %s\n", What, hipGetErrorName(Err));
+  }
+}
+
+int main() {
+  const size_t N = 1024;
+  const size_t Size = N * sizeof(int);
+
+  void *DevPtr = nullptr;
+  checkError("hipMalloc", hipMalloc(&DevPtr, Size), hipSuccess);
+  void *HostPtr = nullptr;
+  checkError("hipHostMalloc(default)",
+             hipHostMalloc(&HostPtr, Size, hipHostMallocDefault), hipSuccess);
+  void *HostNcPtr = nullptr;
+  checkError("hipHostMalloc(hipHostMallocNonCoherent)",
+             hipHostMalloc(&HostNcPtr, Size, hipHostMallocNonCoherent),
+             hipSuccess);
+  void *ManagedPtr = nullptr;
+  checkError("hipMallocManaged", hipMallocManaged(&ManagedPtr, Size),
+             hipSuccess);
+  if (Failures)
+    return 1;
+
+  checkMode("hipMalloc", DevPtr, Size, hipMemRangeCoherencyModeCoarseGrain);
+  checkMode("hipHostMalloc(default)", HostPtr, Size,
+            hipMemRangeCoherencyModeFineGrain);
+  checkMode("hipHostMalloc(hipHostMallocNonCoherent)", HostNcPtr, Size,
+            hipMemRangeCoherencyModeCoarseGrain);
+  checkMode("hipMallocManaged", ManagedPtr, Size,
+            hipMemRangeCoherencyModeFineGrain);
+
+  // Kokkos::HIPManagedSpace: hipMallocManaged followed by
+  // hipMemAdviseSetCoarseGrain must report coarse grain.
+  checkError("hipMemAdvise(hipMemAdviseSetCoarseGrain)",
+             hipMemAdvise(ManagedPtr, Size, hipMemAdviseSetCoarseGrain, 0),
+             hipSuccess);
+  checkMode("hipMallocManaged + SetCoarseGrain", ManagedPtr, Size,
+            hipMemRangeCoherencyModeCoarseGrain);
+  checkError("hipMemAdvise(hipMemAdviseUnsetCoarseGrain)",
+             hipMemAdvise(ManagedPtr, Size, hipMemAdviseUnsetCoarseGrain, 0),
+             hipSuccess);
+  checkMode("hipMallocManaged + UnsetCoarseGrain", ManagedPtr, Size,
+            hipMemRangeCoherencyModeFineGrain);
+
+  // A DataSize other than sizeof(hipMemRangeCoherencyMode) is still rejected.
+  hipMemRangeCoherencyMode Modes[2];
+  checkError("CoherencyMode with DataSize 2*sizeof(mode) on hipMalloc",
+             hipMemRangeGetAttribute(Modes, sizeof(Modes),
+                                     hipMemRangeAttributeCoherencyMode, DevPtr,
+                                     Size),
+             hipErrorInvalidValue);
+  checkError("CoherencyMode with DataSize 2*sizeof(mode) on hipMallocManaged",
+             hipMemRangeGetAttribute(Modes, sizeof(Modes),
+                                     hipMemRangeAttributeCoherencyMode,
+                                     ManagedPtr, Size),
+             hipErrorInvalidValue);
+
+  // The prefetch attribute keeps its managed only behaviour: hipInvalidDeviceId
+  // before any prefetch on managed memory, hipErrorInvalidValue elsewhere.
+  int Loc = 12345;
+  checkError("LastPrefetchLocation on hipMallocManaged",
+             hipMemRangeGetAttribute(&Loc, sizeof(Loc),
+                                     hipMemRangeAttributeLastPrefetchLocation,
+                                     ManagedPtr, Size),
+             hipSuccess);
+  if (Loc != hipInvalidDeviceId) {
+    printf("FAIL: LastPrefetchLocation on hipMallocManaged is %d, expected "
+           "hipInvalidDeviceId (%d)\n",
+           Loc, hipInvalidDeviceId);
+    Failures++;
+  }
+  checkError("LastPrefetchLocation on hipMalloc",
+             hipMemRangeGetAttribute(&Loc, sizeof(Loc),
+                                     hipMemRangeAttributeLastPrefetchLocation,
+                                     DevPtr, Size),
+             hipErrorInvalidValue);
+
+  (void)hipFree(ManagedPtr);
+  (void)hipHostFree(HostNcPtr);
+  (void)hipHostFree(HostPtr);
+  (void)hipFree(DevPtr);
+
+  if (Failures) {
+    printf("FAILED: %d check(s)\n", Failures);
+    return 1;
+  }
+  printf("PASSED\n");
+  return 0;
+}

--- a/tests/runtime/TestFix1530MemRangeCoherencyMode.hip
+++ b/tests/runtime/TestFix1530MemRangeCoherencyMode.hip
@@ -8,6 +8,12 @@
 // coarse grained. Kokkos hip.memory_requirements relies on all three of its
 // memory spaces (hipMalloc, hipHostMalloc(hipHostMallocNonCoherent) and
 // hipMallocManaged + hipMemAdviseSetCoarseGrain) reporting coarse grain.
+//
+// The kind of memory behind each pointer depends on the backend: hipMalloc is
+// device memory on Level Zero and on OpenCL with Intel USM, but unified (SVM)
+// memory on macOS (clvk). The expectations are therefore derived from the
+// hipMemoryType hipPointerGetAttributes reports for the pointer, not from the
+// allocating call.
 
 #include <hip/hip_runtime.h>
 #include <cstdio>
@@ -24,6 +30,62 @@ static const char *modeName(hipMemRangeCoherencyMode Mode) {
     return "Indeterminate";
   }
   return "?";
+}
+
+static const char *typeName(hipMemoryType Type) {
+  switch (Type) {
+  case hipMemoryTypeHost:
+    return "hipMemoryTypeHost";
+  case hipMemoryTypeDevice:
+    return "hipMemoryTypeDevice";
+  case hipMemoryTypeManaged:
+    return "hipMemoryTypeManaged";
+  case hipMemoryTypeUnified:
+    return "hipMemoryTypeUnified";
+  default:
+    return "?";
+  }
+}
+
+// Managed and unified memory carry the prefetch, read mostly, preferred
+// location and accessed by attributes and honour hipMemAdviseSetCoarseGrain.
+static bool isManagedType(hipMemoryType Type) {
+  return Type == hipMemoryTypeManaged || Type == hipMemoryTypeUnified;
+}
+
+// The memory type behind Ptr as the runtime tracks it.
+static hipMemoryType pointerType(const char *Kind, const void *Ptr) {
+  hipPointerAttribute_t Attr = {};
+  hipError_t Err = hipPointerGetAttributes(&Attr, Ptr);
+  if (Err != hipSuccess) {
+    printf("FAIL: %s: hipPointerGetAttributes returned %s, expected "
+           "hipSuccess\n",
+           Kind, hipGetErrorName(Err));
+    Failures++;
+    return hipMemoryTypeUnregistered;
+  }
+  printf("INFO: %s is %s\n", Kind, typeName(Attr.type));
+  return Attr.type;
+}
+
+// The coherency mode ROCm reports for a pointer of the given kind: device
+// memory is coarse grained, host memory is fine grained unless allocated with
+// hipHostMallocNonCoherent, managed and unified memory is fine grained unless
+// hipMemAdviseSetCoarseGrain is in effect.
+static hipMemRangeCoherencyMode expectedMode(hipMemoryType Type,
+                                             bool NonCoherentHost,
+                                             bool CoarseGrainAdvised) {
+  switch (Type) {
+  case hipMemoryTypeHost:
+    return NonCoherentHost ? hipMemRangeCoherencyModeCoarseGrain
+                           : hipMemRangeCoherencyModeFineGrain;
+  case hipMemoryTypeManaged:
+  case hipMemoryTypeUnified:
+    return CoarseGrainAdvised ? hipMemRangeCoherencyModeCoarseGrain
+                              : hipMemRangeCoherencyModeFineGrain;
+  default:
+    return hipMemRangeCoherencyModeCoarseGrain;
+  }
 }
 
 static void checkMode(const char *Kind, const void *Ptr, size_t Size,
@@ -71,6 +133,24 @@ static void checkError(const char *What, hipError_t Err, hipError_t Expected) {
   }
 }
 
+// The prefetch attribute keeps its managed only behaviour: hipInvalidDeviceId
+// before any prefetch on managed or unified memory, hipErrorInvalidValue on
+// everything else.
+static void checkPrefetchLocation(const char *Kind, const void *Ptr,
+                                  size_t Size, bool Managed) {
+  char What[128];
+  snprintf(What, sizeof(What), "LastPrefetchLocation on %s", Kind);
+  int Loc = 12345;
+  hipError_t Err = hipMemRangeGetAttribute(
+      &Loc, sizeof(Loc), hipMemRangeAttributeLastPrefetchLocation, Ptr, Size);
+  checkError(What, Err, Managed ? hipSuccess : hipErrorInvalidValue);
+  if (Managed && Err == hipSuccess && Loc != hipInvalidDeviceId) {
+    printf("FAIL: %s is %d, expected hipInvalidDeviceId (%d)\n", What, Loc,
+           hipInvalidDeviceId);
+    Failures++;
+  }
+}
+
 int main() {
   const size_t N = 1024;
   const size_t Size = N * sizeof(int);
@@ -90,13 +170,27 @@ int main() {
   if (Failures)
     return 1;
 
-  checkMode("hipMalloc", DevPtr, Size, hipMemRangeCoherencyModeCoarseGrain);
+  hipMemoryType DevType = pointerType("hipMalloc", DevPtr);
+  hipMemoryType HostType = pointerType("hipHostMalloc(default)", HostPtr);
+  hipMemoryType HostNcType =
+      pointerType("hipHostMalloc(hipHostMallocNonCoherent)", HostNcPtr);
+  hipMemoryType ManagedType = pointerType("hipMallocManaged", ManagedPtr);
+  if (Failures)
+    return 1;
+  if (!isManagedType(ManagedType)) {
+    printf("FAIL: hipMallocManaged memory is %s, expected managed or "
+           "unified\n",
+           typeName(ManagedType));
+    return 1;
+  }
+
+  checkMode("hipMalloc", DevPtr, Size, expectedMode(DevType, false, false));
   checkMode("hipHostMalloc(default)", HostPtr, Size,
-            hipMemRangeCoherencyModeFineGrain);
+            expectedMode(HostType, false, false));
   checkMode("hipHostMalloc(hipHostMallocNonCoherent)", HostNcPtr, Size,
-            hipMemRangeCoherencyModeCoarseGrain);
+            expectedMode(HostNcType, true, false));
   checkMode("hipMallocManaged", ManagedPtr, Size,
-            hipMemRangeCoherencyModeFineGrain);
+            expectedMode(ManagedType, false, false));
 
   // Kokkos::HIPManagedSpace: hipMallocManaged followed by
   // hipMemAdviseSetCoarseGrain must report coarse grain.
@@ -104,12 +198,12 @@ int main() {
              hipMemAdvise(ManagedPtr, Size, hipMemAdviseSetCoarseGrain, 0),
              hipSuccess);
   checkMode("hipMallocManaged + SetCoarseGrain", ManagedPtr, Size,
-            hipMemRangeCoherencyModeCoarseGrain);
+            expectedMode(ManagedType, false, true));
   checkError("hipMemAdvise(hipMemAdviseUnsetCoarseGrain)",
              hipMemAdvise(ManagedPtr, Size, hipMemAdviseUnsetCoarseGrain, 0),
              hipSuccess);
   checkMode("hipMallocManaged + UnsetCoarseGrain", ManagedPtr, Size,
-            hipMemRangeCoherencyModeFineGrain);
+            expectedMode(ManagedType, false, false));
 
   // A DataSize other than sizeof(hipMemRangeCoherencyMode) is still rejected.
   hipMemRangeCoherencyMode Modes[2];
@@ -124,25 +218,10 @@ int main() {
                                      ManagedPtr, Size),
              hipErrorInvalidValue);
 
-  // The prefetch attribute keeps its managed only behaviour: hipInvalidDeviceId
-  // before any prefetch on managed memory, hipErrorInvalidValue elsewhere.
-  int Loc = 12345;
-  checkError("LastPrefetchLocation on hipMallocManaged",
-             hipMemRangeGetAttribute(&Loc, sizeof(Loc),
-                                     hipMemRangeAttributeLastPrefetchLocation,
-                                     ManagedPtr, Size),
-             hipSuccess);
-  if (Loc != hipInvalidDeviceId) {
-    printf("FAIL: LastPrefetchLocation on hipMallocManaged is %d, expected "
-           "hipInvalidDeviceId (%d)\n",
-           Loc, hipInvalidDeviceId);
-    Failures++;
-  }
-  checkError("LastPrefetchLocation on hipMalloc",
-             hipMemRangeGetAttribute(&Loc, sizeof(Loc),
-                                     hipMemRangeAttributeLastPrefetchLocation,
-                                     DevPtr, Size),
-             hipErrorInvalidValue);
+  checkPrefetchLocation("hipMallocManaged", ManagedPtr, Size, true);
+  checkPrefetchLocation("hipMalloc", DevPtr, Size, isManagedType(DevType));
+  checkPrefetchLocation("hipHostMalloc(default)", HostPtr, Size,
+                        isManagedType(HostType));
 
   (void)hipFree(ManagedPtr);
   (void)hipHostFree(HostNcPtr);


### PR DESCRIPTION
`hipMemRangeGetAttribute` and `hipMemRangeGetAttributes` rejected every allocation that was not managed with `hipErrorInvalidValue` before looking at the attribute, and answered fine grain for the rest, so `hipMemRangeAttributeCoherencyMode` was unusable on `hipMalloc` and `hipHostMalloc` memory. Found with Kokkos `hip.memory_requirements` on Aurora PVC, which queries the mode of `hipMalloc`, `hipHostMalloc(hipHostMallocNonCoherent)` and `hipMallocManaged` + `hipMemAdviseSetCoarseGrain` memory and expects coarse grain for all three, the answer ROCm derives from the HSA pool flags of the pointer.

The coherency mode is now answered for every tracked allocation from its record (device memory coarse grain, host memory fine grain unless `hipHostMallocNonCoherent`, managed and unified memory fine grain unless `hipMemAdviseSetCoarseGrain` is in effect, which `hipMemAdvise` now records), while the managed only gate stays on the prefetch, read mostly, preferred location and accessed by attributes. `tests/runtime/TestFix1530MemRangeCoherencyMode.hip` covers each kind, the wrong `DataSize` rejection and the unchanged prefetch attribute.

Fixes #1530
