### PR TITLE
OpenCL: keep coarse grained SVM managed allocations mapped for the host while idle

### DIFF
--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -802,6 +802,8 @@ bool CHIPEventOpenCL::wait() {
   clStatus = clWaitForEvents(1, &ClEvent);
 
   CHIPERR_CHECK_LOG_AND_THROW_TABLE(clWaitForEvents);
+  // Control returns to the host, which may now dereference managed memory.
+  static_cast<CHIPContextOpenCL *>(getContext())->mapManagedForHost();
   return true;
 }
 
@@ -1375,13 +1377,15 @@ bool CHIPContextOpenCL::allDevicesSupportFineGrainSVMorUSM() {
 
 void CHIPContextOpenCL::freeImpl(void *Ptr) {
   LOCK(ContextMtx); // CHIPContextOpenCL::MemManager_
+  if (keepsManagedMapped())
+    untrackManagedAllocation(Ptr);
   MemManager_.free(Ptr);
 }
 
 cl::Context *CHIPContextOpenCL::get() { return &ClContext; }
 CHIPContextOpenCL::CHIPContextOpenCL(cl::Context CtxIn, cl::Device Dev,
                                      cl::Platform Plat)
-    : Platform_(Plat), ClContext(CtxIn) {
+    : Platform_(Plat), ClContext(CtxIn), ClDevice_(Dev) {
   logTrace("CHIPContextOpenCL Initialized via OpenCL Context pointer.");
 }
 
@@ -1392,7 +1396,122 @@ void *CHIPContextOpenCL::allocateImpl(size_t Size, size_t Alignment,
   LOCK(ContextMtx); // CHIPContextOpenCL::MemManager_
 
   Retval = MemManager_.allocate(Size, Alignment, MemType);
+  // hipMallocManaged allocates hipMemoryTypeUnified; hipMemoryTypeManaged is
+  // the hipHostRegister backing store, which the host never dereferences.
+  if (Retval && MemType == hipMemoryTypeUnified && keepsManagedMapped())
+    trackManagedAllocation(Retval, Size);
   return Retval;
+}
+
+cl::CommandQueue &CHIPContextOpenCL::getManagedMapQueue() {
+  if (!ManagedMapQueue_()) {
+    cl_int Err = CL_SUCCESS;
+    ManagedMapQueue_ = cl::CommandQueue(ClContext, ClDevice_, 0, &Err);
+    if (Err != CL_SUCCESS)
+      CHIPERR_LOG_AND_THROW("Failed to create the managed memory map queue: " +
+                                std::to_string(Err),
+                            hipErrorRuntimeMemory);
+  }
+  return ManagedMapQueue_;
+}
+
+void CHIPContextOpenCL::trackManagedAllocation(void *Ptr, size_t Size) {
+  std::lock_guard<std::mutex> Lock(ManagedMapMtx_);
+  // Nothing on the device can reference a brand new allocation, so the map
+  // needs no wait list.
+  cl_int Err = clEnqueueSVMMap(getManagedMapQueue()(), CL_TRUE,
+                               CL_MAP_READ | CL_MAP_WRITE, Ptr, Size, 0,
+                               nullptr, nullptr);
+  if (Err != CL_SUCCESS)
+    CHIPERR_LOG_AND_THROW("clEnqueueSVMMap failed for a managed allocation: " +
+                              std::to_string(Err),
+                          hipErrorRuntimeMemory);
+  ManagedMaps_[Ptr] = ManagedMapEntry{Size, true};
+}
+
+void CHIPContextOpenCL::untrackManagedAllocation(void *Ptr) {
+  std::lock_guard<std::mutex> Lock(ManagedMapMtx_);
+  auto It = ManagedMaps_.find(Ptr);
+  if (It == ManagedMaps_.end())
+    return;
+  if (It->second.Mapped) {
+    // clSVMFree does not wait for enqueued commands, so the unmap has to be
+    // complete before the memory goes back to the allocator.
+    cl_command_queue Queue = getManagedMapQueue()();
+    cl_int Err = clEnqueueSVMUnmap(Queue, Ptr, 0, nullptr, nullptr);
+    if (Err == CL_SUCCESS)
+      Err = clFinish(Queue);
+    if (Err != CL_SUCCESS)
+      logWarn("clEnqueueSVMUnmap failed for managed allocation {}: {}", Ptr,
+              Err);
+  }
+  ManagedMaps_.erase(It);
+}
+
+void CHIPContextOpenCL::unmapManagedForDevice(cl_command_queue Queue) {
+  if (!keepsManagedMapped())
+    return;
+  std::lock_guard<std::mutex> Lock(ManagedMapMtx_);
+  for (auto &[Ptr, Entry] : ManagedMaps_) {
+    if (!Entry.Mapped)
+      continue;
+    // Queue is in-order, so the unmap completes before the command the
+    // caller enqueues next; the map it undoes was blocking and is done.
+    cl_int Err = clEnqueueSVMUnmap(Queue, Ptr, 0, nullptr, nullptr);
+    if (Err != CL_SUCCESS)
+      CHIPERR_LOG_AND_THROW(
+          "clEnqueueSVMUnmap failed for a managed allocation: " +
+              std::to_string(Err),
+          hipErrorRuntimeMemory);
+    Entry.Mapped = false;
+    logTrace("Unmapped managed allocation {} for the device", Ptr);
+  }
+}
+
+void CHIPContextOpenCL::mapManagedForHost() {
+  if (!keepsManagedMapped())
+    return;
+  std::lock_guard<std::mutex> Lock(ManagedMapMtx_);
+  bool AnyUnmapped = false;
+  for (const auto &[Ptr, Entry] : ManagedMaps_)
+    AnyUnmapped |= !Entry.Mapped;
+  if (!AnyUnmapped)
+    return;
+
+  // A coarse grained SVM buffer must not be mapped while a kernel that uses
+  // it executes, and a kernel on another stream may still be running, so the
+  // map waits for the work in flight on every queue of the device. Queues
+  // that have had nothing submitted since their last finish() are skipped.
+  std::vector<cl_event> Markers;
+  auto AddMarkers = [&](chipstar::Queue *Q) {
+    if (Q && !Q->isEmptyQueue())
+      static_cast<CHIPQueueOpenCL *>(Q)->enqueueIdleMarkers(Markers);
+  };
+  for (auto *Q : ChipDevice_->getQueuesNoLock())
+    AddMarkers(Q);
+  AddMarkers(ChipDevice_->getLegacyDefaultQueue());
+  if (ChipDevice_->isPerThreadStreamUsedNoLock())
+    AddMarkers(ChipDevice_->getPerThreadDefaultQueueNoLock());
+
+  cl_command_queue MapQueue = getManagedMapQueue()();
+  cl_int Err = CL_SUCCESS;
+  for (auto &[Ptr, Entry] : ManagedMaps_) {
+    if (Entry.Mapped)
+      continue;
+    Err = clEnqueueSVMMap(MapQueue, CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, Ptr,
+                          Entry.Size, Markers.size(),
+                          Markers.empty() ? nullptr : Markers.data(), nullptr);
+    if (Err != CL_SUCCESS)
+      break;
+    Entry.Mapped = true;
+    logTrace("Mapped managed allocation {} for the host", Ptr);
+  }
+  for (cl_event Marker : Markers)
+    clReleaseEvent(Marker);
+  if (Err != CL_SUCCESS)
+    CHIPERR_LOG_AND_THROW("clEnqueueSVMMap failed for a managed allocation: " +
+                              std::to_string(Err),
+                          hipErrorRuntimeMemory);
 }
 
 // CHIPQueueOpenCL
@@ -1641,6 +1760,8 @@ CHIPQueueOpenCL::launchImpl(chipstar::ExecItem *ExecItem) {
   auto AllocationsToKeepAlive = annotateIndirectPointers(
       *OclContext, Kernel->getModule()->getInfo(), KernelHandle);
 
+  OclContext->unmapManagedForDevice(get()->get());
+
   auto [SyncQueuesEventHandles, EventLocks] =
       addDependenciesQueueSync(LaunchEvent);
 
@@ -1855,6 +1976,7 @@ CHIPQueueOpenCL::memCopyAsyncImpl(void *Dst, const void *Src, size_t Size,
   } else {
     auto [SyncQueuesEventHandles, EventLocks] = addDependenciesQueueSync(Event);
     auto *Ctx = getContext();
+    Ctx->unmapManagedForDevice(get()->get());
 
     switch (Ctx->getAllocStrategy()) {
     default:
@@ -2001,6 +2123,23 @@ void CHIPQueueOpenCL::finish() {
   
   // After finish() completes, queue is empty again
   IsEmptyQueue_.store(true);
+
+  // Control returns to the host, which may now dereference managed memory.
+  static_cast<CHIPContextOpenCL *>(ChipContext_)->mapManagedForHost();
+}
+
+void CHIPQueueOpenCL::enqueueIdleMarkers(std::vector<cl_event> &Markers) {
+  for (cl::CommandQueue *Q : {&ClRegularQueue_, &ClProfilingQueue_}) {
+    if (!Q->get())
+      continue;
+    cl_event Marker = nullptr;
+    clStatus = clEnqueueMarkerWithWaitList(Q->get(), 0, nullptr, &Marker);
+    CHIPERR_CHECK_LOG_AND_THROW_TABLE(clEnqueueMarkerWithWaitList);
+    Markers.push_back(Marker);
+    // Mali deadlocks when a wait targets an unflushed queue.
+    clStatus = clFlush(Q->get());
+    CHIPERR_CHECK_LOG_AND_THROW_TABLE(clFlush);
+  }
 }
 
 std::shared_ptr<chipstar::Event>
@@ -2039,6 +2178,7 @@ CHIPQueueOpenCL::memFillAsyncImpl(void *Dst, size_t Size, const void *Pattern,
     }
   } else {
     logTrace("clSVMmemfill {} / {} B\n", Dst, Size);
+    Ctx->unmapManagedForDevice(get()->get());
     int Retval = ::clEnqueueSVMMemFill(
         get()->get(), Dst, Pattern, PatternSize, Size,
         SyncQueuesEventHandles.size(), SyncQueuesEventHandles.data(),
@@ -2212,6 +2352,7 @@ CHIPQueueOpenCL::memPrefetchImpl(const void *Ptr, size_t Count, int DstDevId) {
   case AllocationStrategy::CoarseGrainSVM:
   case AllocationStrategy::FineGrainSVM: {
     logTrace("clEnqueueSVMMigrateMem {} / {} B, flags: {}\n", Ptr, Count, MigrationFlags);
+    Ctx->unmapManagedForDevice(get()->get());
     const void *SvmPtrs[] = {Ptr};
     const size_t Sizes[] = {Count};
     {

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -55,6 +55,7 @@
 #pragma GCC diagnostic pop
 
 #include <atomic>
+#include <unordered_map>
 #include "../../CHIPBackend.hh"
 #include "exceptions.hh"
 #include "spirv.hh"
@@ -251,8 +252,30 @@ class CHIPContextOpenCL : public chipstar::Context {
 private:
   cl::Platform Platform_;
   cl::Context ClContext;
+  cl::Device ClDevice_;
   mutable clSetKernelArgDevicePointerEXT_fn clSetKernelArgDevicePointerEXT_ =
       nullptr;
+
+  /// Coarse grained SVM only: HIP lets the host dereference hipMallocManaged
+  /// memory whenever the device is idle, but the OpenCL spec only defines host
+  /// access to a coarse grained SVM buffer between clEnqueueSVMMap and
+  /// clEnqueueSVMUnmap. The runtime therefore keeps every managed allocation
+  /// mapped for the host while no work is in flight: unmapped on the queue
+  /// before a device side command, mapped again (blocking) when a stream, the
+  /// device or an event synchronises with the host.
+  struct ManagedMapEntry {
+    size_t Size;
+    bool Mapped;
+  };
+  /// Managed allocations by base pointer and their current map state.
+  /// Guarded by ManagedMapMtx_.
+  std::unordered_map<void *, ManagedMapEntry> ManagedMaps_;
+  std::mutex ManagedMapMtx_;
+  /// In-order queue that carries the host side map commands so that a new
+  /// allocation or a synchronising stream never waits behind unrelated work
+  /// on a user stream. Created on first use, guarded by ManagedMapMtx_.
+  cl::CommandQueue ManagedMapQueue_;
+  cl::CommandQueue &getManagedMapQueue();
 
 public:
   MemoryManager MemManager_;
@@ -312,6 +335,23 @@ public:
   }
 
   const cl::Platform &getPlatform() const { return Platform_; }
+
+  /// True when managed allocations need explicit SVM map/unmap for host
+  /// access (AllocationStrategy::CoarseGrainSVM).
+  bool keepsManagedMapped() const noexcept {
+    return getAllocStrategy() == AllocationStrategy::CoarseGrainSVM;
+  }
+  /// Record a new managed allocation and map it for the host so the
+  /// application can initialise it right after hipMallocManaged.
+  void trackManagedAllocation(void *Ptr, size_t Size);
+  /// Unmap (if mapped) and forget a managed allocation before it is freed.
+  void untrackManagedAllocation(void *Ptr);
+  /// Enqueue an unmap on Queue for every managed allocation that is mapped;
+  /// call before any command on Queue that may touch managed memory.
+  void unmapManagedForDevice(cl_command_queue Queue);
+  /// Map every unmapped managed allocation for the host (blocking), after
+  /// waiting for the work in flight on all of the device's queues.
+  void mapManagedForHost();
 };
 
 class CHIPDeviceOpenCL : public chipstar::Device {
@@ -450,6 +490,9 @@ public:
   virtual ~CHIPQueueOpenCL() override;
   virtual void recordEvent(chipstar::Event *ChipEvent) override;
   bool isEmptyQueue() override { return IsEmptyQueue_.load(); }
+  /// Enqueue and flush a marker on each of this stream's OpenCL queues and
+  /// append the marker events to Markers; the caller releases them.
+  void enqueueIdleMarkers(std::vector<cl_event> &Markers);
   virtual std::shared_ptr<chipstar::Event>
   launchImpl(chipstar::ExecItem *ExecItem) override;
   virtual void addCallback(hipStreamCallback_t Callback,

--- a/tests/runtime/TestFix1535ManagedHostStoreBetweenLaunches.hip
+++ b/tests/runtime/TestFix1535ManagedHostStoreBetweenLaunches.hip
@@ -1,0 +1,80 @@
+// Reproduces: on OpenCL devices that only support coarse grained SVM (Mali G52,
+// rusticl) hipMallocManaged memory is undefined for the host outside of a
+// clEnqueueSVMMap/Unmap pair, so a plain host store made between two kernel
+// launches never reaches the device and a host read after synchronisation may
+// return stale cache contents. https://github.com/CHIP-SPV/chipStar/issues/1535
+//
+// HIP allows the host to dereference a managed pointer whenever the device is
+// idle, even when concurrentManagedAccess == 0, so the runtime has to keep the
+// allocation mapped for the host between the synchronisation point and the next
+// device side command. The host touches the pointer after hipStreamSynchronize,
+// hipDeviceSynchronize and a blocking hipMemcpy, the three ways this test
+// returns control to the host.
+
+#include <hip/hip_runtime.h>
+#include <cstdio>
+
+#define CHECK(Expr)                                                            \
+  do {                                                                         \
+    hipError_t Err = (Expr);                                                   \
+    if (Err != hipSuccess) {                                                   \
+      printf("FAIL: %s returned %s\n", #Expr, hipGetErrorString(Err));         \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+__global__ void observe(const int *Managed, int *Out, int Slot) {
+  Out[Slot] = *Managed;
+}
+
+__global__ void bump(int *Managed) { *Managed += 100; }
+
+int main() {
+  hipDeviceProp_t Props;
+  CHECK(hipGetDeviceProperties(&Props, 0));
+  if (!Props.managedMemory) {
+    printf("HIP_SKIP_THIS_TEST: managedMemory == 0\n");
+    return 0;
+  }
+
+  int *Managed = nullptr;
+  int *Out = nullptr;
+  CHECK(hipMallocManaged(&Managed, sizeof(int)));
+  CHECK(hipMalloc(&Out, 3 * sizeof(int)));
+  CHECK(hipMemset(Out, 0xff, 3 * sizeof(int)));
+
+  // Host initialisation right after the allocation, before any launch.
+  *Managed = 1;
+  observe<<<1, 1>>>(Managed, Out, 0);
+  CHECK(hipStreamSynchronize(0));
+
+  // Host store between two launches: the store lost on coarse grained SVM.
+  *Managed = 2;
+  observe<<<1, 1>>>(Managed, Out, 1);
+  bump<<<1, 1>>>(Managed);
+  CHECK(hipDeviceSynchronize());
+
+  // Host read after a device synchronisation sees the device write.
+  int HostSeen = *Managed;
+
+  // Host store after a device synchronisation is visible to the next launch.
+  *Managed = 3;
+  observe<<<1, 1>>>(Managed, Out, 2);
+
+  // A blocking copy is a synchronisation point too: the host may read the
+  // managed pointer right after it.
+  int Seen[3] = {-1, -1, -1};
+  CHECK(hipMemcpy(Seen, Out, sizeof(Seen), hipMemcpyDeviceToHost));
+  int HostSeenAfterCopy = *Managed;
+
+  bool Pass = Seen[0] == 1 && Seen[1] == 2 && Seen[2] == 3 && HostSeen == 102 &&
+              HostSeenAfterCopy == 3;
+  printf("device saw %d %d %d (expected 1 2 3), host saw %d then %d (expected "
+         "102 then 3): %s\n",
+         Seen[0], Seen[1], Seen[2], HostSeen, HostSeenAfterCopy,
+         Pass ? "PASS" : "FAIL");
+
+  CHECK(hipFree(Out));
+  CHECK(hipFree(Managed));
+  return Pass ? 0 : 1;
+}


### PR DESCRIPTION
On OpenCL devices with only coarse grained SVM (Mali G52, rusticl) the host may only touch hipMallocManaged memory between clEnqueueSVMMap and clEnqueueSVMUnmap, so plain host stores between launches were lost. With AllocationStrategy::CoarseGrainSVM the context now keeps every managed allocation mapped while no work is in flight: unmapped on the queue before a kernel launch, SVM memcpy, memfill or migrate, mapped again (blocking, read/write) when a stream, the device or an event synchronises with the host. Fine grained SVM and Intel USM are untouched. Adds TestFix1535ManagedHostStoreBetweenLaunches, verified on rusticl (W6400) and Mali G52.

Fixes #1535