### PR TITLE
OpenCL: fail the module when the built program lacks a source kernel

### DIFF
--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <chrono>
 #include <map>
+#include <unordered_set>
 #include <thread>
 #include <fstream>
 #include <unistd.h>
@@ -1226,8 +1227,6 @@ void CHIPModuleOpenCL::compile(chipstar::Device *ChipDev) {
         CHIPERR_LOG_AND_THROW("Program build failed.",
                               hipErrorInitializationError);
     }
-
-    storeProgram(Program_, *ChipDevOcl, CacheKey);
   }
 
   std::vector<cl::Kernel> Kernels;
@@ -1241,10 +1240,12 @@ void CHIPModuleOpenCL::compile(chipstar::Device *ChipDev) {
   CHIPERR_CHECK_LOG_AND_THROW_TABLE(clCreateKernelsInProgram);
 
   logTrace("Kernels in CHIPModuleOpenCL: {} \n", Kernels.size());
+  std::unordered_set<std::string> BuiltKernelNames;
   for (auto &Krnl : Kernels) {
     std::string HostFName;
     clStatus = Krnl.getInfo(CL_KERNEL_FUNCTION_NAME, &HostFName);
     CHIPERR_CHECK_LOG_AND_THROW_TABLE(clGetKernelInfo);
+    BuiltKernelNames.insert(HostFName);
     auto *FuncInfo = findFunctionInfo(HostFName);
     if (!FuncInfo) {
       continue;
@@ -1253,6 +1254,29 @@ void CHIPModuleOpenCL::compile(chipstar::Device *ChipDev) {
         new CHIPKernelOpenCL(Krnl, ChipDevOcl, HostFName, FuncInfo, this);
     addKernel(ChipKernel);
   }
+
+  // A successful build is not proof that every kernel of the source module
+  // made it into the program: the Arm Mali driver accepts a module with an
+  // unresolved function import, reports CL_SUCCESS with an empty build log,
+  // and leaves out the kernels that call the import. The host side later
+  // binds every registered __global__ function of the source module to a
+  // program kernel by name, so a program lacking one is a module that failed
+  // to load, not a module with a faulting kernel.
+  std::string MissingKernels;
+  for (const auto &Info : Src_->Kernels)
+    if (!BuiltKernelNames.count(Info.Name))
+      MissingKernels += (MissingKernels.empty() ? "" : ", ") + Info.Name;
+  if (!MissingKernels.empty())
+    CHIPERR_LOG_AND_THROW(
+        "Built program lacks kernel(s) of the source module (unresolved "
+        "device function?): " +
+            MissingKernels,
+        hipErrorSharedObjectInitFailed);
+
+  // Persist only a program known to hold every kernel; a cached copy of an
+  // incomplete one would fail the same check on every later process anyway.
+  if (!cached)
+    storeProgram(Program_, *ChipDevOcl, CacheKey);
 
   auto end = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> elapsed = end - start;

--- a/tests/runtime/TestFix1539MissingKernelAfterBuild.hip
+++ b/tests/runtime/TestFix1539MissingKernelAfterBuild.hip
@@ -1,0 +1,114 @@
+// Reproducer for https://github.com/CHIP-SPV/chipStar/issues/1539: a device
+// compiler that accepts a module with an unresolved extern __device__ function
+// (Mali) builds the program with an empty log but leaves out the kernel that
+// calls the function. The runtime then treated the module as compiled and
+// failed later, in the kernel binding of Device::getOrCreateModule, with
+// hipErrorLaunchFailure ("Failed to find kernel via kernel name"), a code
+// meant for a faulting kernel, and retried the whole lookup on every launch.
+//
+// Where the device compiler rejects the module instead (Intel OpenCL fails
+// clBuildProgram, Level Zero fails zeModuleCreate) the launch already fails
+// with a module load error, so the exact code is not asserted. What is
+// asserted on every backend: both launches fail, the second the same way as
+// the first, neither with hipErrorLaunchFailure, the runtime log names the
+// unresolved symbol, and the kernel lookup failure never appears.
+#include <hip/hip_runtime.h>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+#include <unistd.h>
+
+extern __device__ void undefinedFn(int);
+
+__global__ void kernel(int X) { undefinedFn(X); }
+
+static bool logHas(const std::string &Path, const char *Needle) {
+  std::ifstream In(Path);
+  std::string Line;
+  while (std::getline(In, Line))
+    if (Line.find(Needle) != std::string::npos)
+      return true;
+  return false;
+}
+
+int main(int argc, char **argv) {
+  // The unresolved symbol is reported at warn level, so re-exec once with
+  // the log level pinned in case the environment lowered it.
+  if (!getenv("TESTFIX1539_CHILD")) {
+    setenv("TESTFIX1539_CHILD", "1", 1);
+    setenv("CHIP_LOGLEVEL", "warn", 1);
+    execv(argv[0], argv);
+    perror("execv");
+    return 1;
+  }
+
+  // Divert the runtime log into a file for the duration of the launches.
+  char LogPath[] = "/tmp/TestFix1539.XXXXXX";
+  int LogFd = mkstemp(LogPath);
+  if (LogFd < 0) {
+    perror("mkstemp");
+    return 1;
+  }
+  fflush(stderr);
+  int SavedStderr = dup(STDERR_FILENO);
+  dup2(LogFd, STDERR_FILENO);
+
+  (void)hipFree(nullptr);
+
+  using Clock = std::chrono::steady_clock;
+  kernel<<<1, 1>>>(1);
+  hipError_t Err1 = hipGetLastError();
+  auto T1 = Clock::now();
+  kernel<<<1, 1>>>(2);
+  hipError_t Err2 = hipGetLastError();
+  auto T2 = Clock::now();
+
+  fflush(stderr);
+  dup2(SavedStderr, STDERR_FILENO);
+  close(LogFd);
+
+  double SecondMs = std::chrono::duration<double, std::milli>(T2 - T1).count();
+  bool NamesSymbol = logHas(LogPath, "_Z11undefinedFni");
+  bool LookupFailed = logHas(LogPath, "Failed to find kernel via kernel name");
+  unlink(LogPath);
+
+  printf("first launch: %s\n", hipGetErrorName(Err1));
+  printf("second launch: %s in %.1f ms\n", hipGetErrorName(Err2), SecondMs);
+
+  bool Ok = true;
+  if (Err1 == hipSuccess) {
+    printf("FAILED: first launch succeeded, expected a module load error\n");
+    Ok = false;
+  }
+  if (Err1 == hipErrorLaunchFailure) {
+    printf("FAILED: first launch reported hipErrorLaunchFailure for a module "
+           "that never loaded\n");
+    Ok = false;
+  }
+  if (Err2 != Err1) {
+    printf("FAILED: second launch returned %s, expected the first launch's "
+           "%s\n",
+           hipGetErrorName(Err2), hipGetErrorName(Err1));
+    Ok = false;
+  }
+  if (SecondMs > 5000.0) {
+    printf("FAILED: second launch took %.1f ms\n", SecondMs);
+    Ok = false;
+  }
+  if (!NamesSymbol) {
+    printf("FAILED: runtime log does not name the unresolved symbol "
+           "_Z11undefinedFni\n");
+    Ok = false;
+  }
+  if (LookupFailed) {
+    printf("FAILED: runtime log reports a kernel lookup failure, the module "
+           "should have failed to load instead\n");
+    Ok = false;
+  }
+  if (Ok)
+    printf("PASSED\n");
+  return Ok ? 0 : 1;
+}


### PR DESCRIPTION
Fixes #1539

On Mali the driver accepts a SPIR-V module with an unresolved `__device__` function import: `clBuildProgram` returns `CL_SUCCESS` with an empty log but the kernel calling the import is left out of the program, so the runtime registered the module as compiled and then failed in the kernel binding with `hipErrorLaunchFailure` on every launch. After `clCreateKernelsInProgram`, `CHIPModuleOpenCL::compile` now compares the program's kernels with the source module's registered kernels and throws `hipErrorSharedObjectInitFailed` naming the missing ones, the same path a rejected build takes, so the module gets remembered as failed by https://github.com/CHIP-SPV/chipStar/pull/1525 (this complements that PR). The program is stored in the module cache only after the check passes.

Validated on Mali G52 (salami: both launches now return `hipErrorSharedObjectInitFailed`, warm and cold module cache) and on the Intel CPU OpenCL runtime (unchanged, `clBuildProgram` rejects the module). New test: `tests/runtime/TestFix1539MissingKernelAfterBuild.hip`.
