### PR TITLE
OpenCL: release the switchModeTo barrier event instead of leaking it

### DIFF
--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -2519,11 +2519,10 @@ void CHIPQueueOpenCL::switchModeTo(QueueMode ToMode) {
   clStatus = clFlush(FromQ.get());
   CHIPERR_CHECK_LOG_AND_THROW_TABLE(clFlush);
 
-  // Use the barrier event from the TO queue, not the marker from FROM queue
-  auto *ChipEv = new CHIPEventOpenCL(
-      static_cast<CHIPContextOpenCL *>(ChipContext_), BarrierEv);
-  
-  // Release the marker event since we're tracking the barrier instead
+  // Neither event is waited on later: the barrier keeps the switched-to
+  // queue ordered after the marker on its own, so both references go back
+  // to the runtime here.
+  clReleaseEvent(BarrierEv);
   clReleaseEvent(SwitchEv);
   
  QueueMode_ = ToMode;

--- a/tests/run_barrier_event_leak_test.cmake
+++ b/tests/run_barrier_event_leak_test.cmake
@@ -1,0 +1,59 @@
+# Driver for TestFix1543SwitchModeEventLeak.
+#
+# Runs the test binary with the interposer preloaded and maps the outcomes
+# onto a verdict:
+#
+#   the process failed                        -> fail
+#   no barrier event was ever enqueued        -> nothing was exercised, skip
+#   every barrier event was released          -> pass
+#   some barrier event still has references   -> the #1543 leak, fail
+
+if(NOT CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
+  message("HIP_SKIP_THIS_TEST: LD_PRELOAD interposition is Linux only")
+  return()
+endif()
+
+set(LOG_FILE "${TEST_EXECUTABLE}_output.txt")
+
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -E env "LD_PRELOAD=${INTERPOSER}" ${TEST_EXECUTABLE}
+  OUTPUT_FILE "${LOG_FILE}"
+  ERROR_FILE "${LOG_FILE}"
+  TIMEOUT ${TEST_TIMEOUT}
+  RESULT_VARIABLE RESULT)
+
+file(READ "${LOG_FILE}" TEST_OUTPUT)
+message("${TEST_OUTPUT}")
+
+if(NOT RESULT EQUAL 0)
+  message(FATAL_ERROR "test program failed (result: ${RESULT})")
+endif()
+
+# The test process reports last, so the final report is the one that counts
+# should a subprocess have printed one as well.
+set(REPORT_REGEX "interposer: barrier events observed: ([0-9]+), leaked: ([0-9]+)")
+string(REGEX MATCHALL "${REPORT_REGEX}" REPORTS "${TEST_OUTPUT}")
+if(NOT REPORTS)
+  message(FATAL_ERROR "the interposer did not report; was it preloaded?")
+endif()
+list(GET REPORTS -1 REPORT)
+string(REGEX MATCH "${REPORT_REGEX}" _unused "${REPORT}")
+set(OBSERVED "${CMAKE_MATCH_1}")
+set(LEAKED "${CMAKE_MATCH_2}")
+
+if(OBSERVED EQUAL 0)
+  message("HIP_SKIP_THIS_TEST: no clEnqueueBarrierWithWaitList call was made, "
+          "so there was nothing to leak")
+  return()
+endif()
+
+if(LEAKED EQUAL 0)
+  message("PASS")
+  return()
+endif()
+
+message(FATAL_ERROR
+  "${LEAKED} of ${OBSERVED} barrier events still had references at exit. "
+  "CHIPQueueOpenCL::switchModeTo wraps the mode switch barrier event in a "
+  "CHIPEventOpenCL it never stores or deletes, so the wrapper and the "
+  "cl_event reference it retained are lost. See issue #1543.")

--- a/tests/runtime/BarrierEventLeakInterposer.cpp
+++ b/tests/runtime/BarrierEventLeakInterposer.cpp
@@ -1,0 +1,118 @@
+// LD_PRELOAD interposer for TestFix1543SwitchModeEventLeak.
+//
+// Tracks the reference balance of every cl_event handed out by
+// clEnqueueBarrierWithWaitList: the enqueue itself counts as one reference,
+// clRetainEvent adds one and clReleaseEvent removes one, and an entry is
+// forgotten once its count reaches zero. At process exit it prints how many
+// barrier events were observed and how many still have references, which is
+// the number of barrier events that leaked.
+//
+// Every entry point chains to the real implementation, so preloading this
+// library only adds bookkeeping. The chaining prototypes take plain integers
+// and pointers instead of the OpenCL types: each argument is in the same ABI
+// class as the real one, and using them keeps the interposer buildable whether
+// or not the OpenCL headers are present.
+//
+// The report runs from a shared library destructor so that it comes after
+// chipStar's own teardown, which is an atexit handler; a balance taken before
+// that would count events the runtime is still about to release.
+
+#include <dlfcn.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <map>
+#include <mutex>
+
+namespace {
+
+// Function-local statics so the table is usable from the first interposed call
+// regardless of static initialisation order. They are heap allocated and never
+// freed: a static object would be destroyed by its __cxa_atexit handler before
+// the library destructor that reads it runs.
+std::mutex &tableMutex() {
+  static std::mutex *Mutex = new std::mutex;
+  return *Mutex;
+}
+
+std::map<void *, int> &barrierRefs() {
+  static std::map<void *, int> *Table = new std::map<void *, int>;
+  return *Table;
+}
+
+unsigned &numObserved() {
+  static unsigned Count = 0;
+  return Count;
+}
+
+template <typename FnTy> FnTy realSymbol(const char *Name) {
+  void *Symbol = dlsym(RTLD_NEXT, Name);
+  if (!Symbol) {
+    // Reached only if something calls an interposed entry point that the real
+    // runtime does not provide. Say so instead of jumping through a null.
+    std::fprintf(stderr, "interposer: no real %s to chain to\n", Name);
+    std::fflush(stderr);
+    std::abort();
+  }
+  return reinterpret_cast<FnTy>(Symbol);
+}
+
+// Child processes must not inherit the interposer: pocl compiles kernels
+// through clang and lld subprocesses, and each of them would print an empty
+// report of its own at exit.
+__attribute__((constructor)) void dropFromChildren() { unsetenv("LD_PRELOAD"); }
+
+__attribute__((destructor)) void reportAtExit() {
+  std::lock_guard<std::mutex> Lock(tableMutex());
+  unsigned Leaked = 0;
+  for (const auto &Entry : barrierRefs())
+    if (Entry.second > 0)
+      ++Leaked;
+  std::fprintf(stderr, "interposer: barrier events observed: %u, leaked: %u\n",
+               numObserved(), Leaked);
+  std::fflush(stderr);
+}
+
+} // namespace
+
+extern "C" {
+
+int clEnqueueBarrierWithWaitList(void *Queue, unsigned NumEvents,
+                                 const void *WaitList, void **Event) {
+  using FnTy = int (*)(void *, unsigned, const void *, void **);
+  int Status = realSymbol<FnTy>("clEnqueueBarrierWithWaitList")(
+      Queue, NumEvents, WaitList, Event);
+  if (Status == 0 && Event && *Event) {
+    std::lock_guard<std::mutex> Lock(tableMutex());
+    barrierRefs()[*Event] = 1;
+    ++numObserved();
+  }
+  return Status;
+}
+
+int clRetainEvent(void *Event) {
+  using FnTy = int (*)(void *);
+  int Status = realSymbol<FnTy>("clRetainEvent")(Event);
+  if (Status == 0) {
+    std::lock_guard<std::mutex> Lock(tableMutex());
+    auto It = barrierRefs().find(Event);
+    if (It != barrierRefs().end())
+      ++It->second;
+  }
+  return Status;
+}
+
+int clReleaseEvent(void *Event) {
+  {
+    // Drop the entry before the real release so a handle the runtime recycles
+    // for a later barrier starts from a fresh count.
+    std::lock_guard<std::mutex> Lock(tableMutex());
+    auto It = barrierRefs().find(Event);
+    if (It != barrierRefs().end() && --It->second == 0)
+      barrierRefs().erase(It);
+  }
+  using FnTy = int (*)(void *);
+  return realSymbol<FnTy>("clReleaseEvent")(Event);
+}
+
+} // extern "C"

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -70,6 +70,7 @@ set(RUNTIME_TESTS_MANUAL
   TestDeviceAbortStderr.hip       # SIGABRT death + stderr checked by a driver script
   TestEnvVars.hip                 # driven by ../run_testenvvars.sh, not by ctest
   TestFix1393ExitDuringModuleBuild.hip # run under an interposer by a driver script
+  TestFix1543SwitchModeEventLeak.hip # run under an interposer by a driver script
   TestFixFunctionLocalStaticDeviceVar.hip # multi-TU, second TU under inputs/
   TestFixLlvmUsedAddrspace.hip    # not registered as a test
   TestModuleCacheInvalidation.hip # run several times through a driver script
@@ -361,4 +362,34 @@ set_tests_properties(TestFixFunctionLocalStaticDeviceVar PROPERTIES
   SKIP_RETURN_CODE ${CHIP_SKIP_TEST}
   SKIP_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST"
   TIMEOUT 120)
+endif()
+
+# The OpenCL backend's queue mode switch must not leak the barrier event it
+# enqueues (#1543). The leak cannot be seen through the HIP API, so an
+# LD_PRELOAD interposer keeps the reference balance of every barrier event and
+# a driver script turns its report into the verdict.
+if(UNIX AND NOT APPLE)
+  set_source_files_properties(TestFix1543SwitchModeEventLeak.hip
+    PROPERTIES LANGUAGE CXX)
+  add_executable(TestFix1543SwitchModeEventLeak
+    TestFix1543SwitchModeEventLeak.hip)
+  set_target_properties(TestFix1543SwitchModeEventLeak PROPERTIES
+    CXX_STANDARD_REQUIRED ON)
+  target_link_libraries(TestFix1543SwitchModeEventLeak CHIP deviceInternal)
+  target_include_directories(TestFix1543SwitchModeEventLeak
+    PRIVATE $<TARGET_PROPERTY:CHIP,INCLUDE_DIRECTORIES>)
+
+  add_library(BarrierEventLeakInterposer MODULE
+    BarrierEventLeakInterposer.cpp)
+  target_link_libraries(BarrierEventLeakInterposer ${CMAKE_DL_LIBS})
+
+  add_test(NAME TestFix1543SwitchModeEventLeak
+    COMMAND ${CMAKE_COMMAND}
+      -DTEST_EXECUTABLE=$<TARGET_FILE:TestFix1543SwitchModeEventLeak>
+      -DINTERPOSER=$<TARGET_FILE:BarrierEventLeakInterposer>
+      -DTEST_TIMEOUT=60
+      -P ${CMAKE_SOURCE_DIR}/tests/run_barrier_event_leak_test.cmake)
+  set_tests_properties(TestFix1543SwitchModeEventLeak PROPERTIES
+    SKIP_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST"
+    TIMEOUT 120)
 endif()

--- a/tests/runtime/TestFix1543SwitchModeEventLeak.hip
+++ b/tests/runtime/TestFix1543SwitchModeEventLeak.hip
@@ -1,0 +1,54 @@
+// Reproduces #1543: CHIPQueueOpenCL::switchModeTo leaks the barrier event it
+// enqueues on the queue being switched to, once per stream that switches to
+// the profiling queue.
+//
+// The first hipEventRecord on a stream is what triggers the switch, so this
+// program only has to record an event on one stream, wait for it and tear
+// everything down. The leak is invisible through the HIP API: an LD_PRELOAD
+// interposer counts the reference balance of every cl_event that
+// clEnqueueBarrierWithWaitList returned and reports it at process exit.
+// tests/run_barrier_event_leak_test.cmake drives the run and owns the verdict.
+
+#include <hip/hip_runtime.h>
+
+#include <cstdio>
+
+#define CHECK(Call)                                                            \
+  do {                                                                         \
+    hipError_t Err = (Call);                                                   \
+    if (Err != hipSuccess) {                                                   \
+      std::printf("%s failed: %s\n", #Call, hipGetErrorString(Err));           \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+__global__ void touch(int *Out) { Out[threadIdx.x] = threadIdx.x; }
+
+int main() {
+  int *Buf = nullptr;
+  hipStream_t Stream = nullptr;
+  hipEvent_t Start = nullptr;
+  hipEvent_t Stop = nullptr;
+  CHECK(hipMalloc(&Buf, 64 * sizeof(int)));
+  CHECK(hipStreamCreate(&Stream));
+  CHECK(hipEventCreate(&Start));
+  CHECK(hipEventCreate(&Stop));
+
+  // Switches Stream to its profiling queue.
+  CHECK(hipEventRecord(Start, Stream));
+  hipLaunchKernelGGL(touch, dim3(1), dim3(64), 0, Stream, Buf);
+  CHECK(hipEventRecord(Stop, Stream));
+  CHECK(hipEventSynchronize(Stop));
+
+  float Ms = 0.0f;
+  CHECK(hipEventElapsedTime(&Ms, Start, Stop));
+
+  CHECK(hipEventDestroy(Stop));
+  CHECK(hipEventDestroy(Start));
+  CHECK(hipStreamDestroy(Stream));
+  CHECK(hipFree(Buf));
+
+  std::printf("recorded, elapsed %f ms\n", Ms);
+  std::fflush(stdout);
+  return 0;
+}


### PR DESCRIPTION
Fixes #1543

`CHIPQueueOpenCL::switchModeTo` wrapped the mode switch barrier event in a `CHIPEventOpenCL` it never stored or deleted, leaking the wrapper and a `cl_event` reference per stream that records an event. The wrapper is dropped and the barrier event is released right after the enqueue. `TestFix1543SwitchModeEventLeak` reproduces the leak through an LD_PRELOAD interposer that tracks the reference balance of every barrier event.