### PR TITLE
Capture work forked onto other streams during stream capture

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -2208,18 +2208,75 @@ void chipstar::Queue::memCopy3DAsync(void *Dst, size_t DPitch, size_t DSPitch,
   ChipEvent->Msg = "memCopy3DAsync";
 }
 
-void chipstar::Queue::updateLastNode(CHIPGraphNode *NewNode) {
-  if (LastNode_ != nullptr) {
-    NewNode->addDependency(LastNode_);
-  }
-  LastNode_ = NewNode;
+void chipstar::Queue::chainCaptureNode(CHIPGraphNode *NewNode) {
+  NewNode->addDependencies(CaptureDeps_);
+  CaptureDeps_ = {NewNode};
 }
 
-void chipstar::Queue::initCaptureGraph() {
+void chipstar::Queue::addCaptureDependencies(
+    const std::vector<CHIPGraphNode *> &Nodes) {
+  for (auto *Node : Nodes)
+    if (std::find(CaptureDeps_.begin(), CaptureDeps_.end(), Node) ==
+        CaptureDeps_.end())
+      CaptureDeps_.push_back(Node);
+}
+
+void chipstar::Queue::beginCapture(hipStreamCaptureMode Mode) {
   CaptureGraph_ = new CHIPGraph();
+  CaptureMode_ = Mode;
+  CaptureStatus_ = hipStreamCaptureStatusActive;
+  CaptureOrigin_ = true;
+  CaptureParent_ = nullptr;
   // The first node recorded into the new graph is a root; a node left over
   // from an earlier capture on this stream belongs to another graph.
-  LastNode_ = nullptr;
+  CaptureDeps_.clear();
+  CaptureForks_.clear();
+  CaptureEvents_.clear();
+}
+
+void chipstar::Queue::joinCapture(Queue *Parent) {
+  CaptureGraph_ = Parent->CaptureGraph_;
+  CaptureMode_ = Parent->CaptureMode_;
+  CaptureStatus_ = hipStreamCaptureStatusActive;
+  CaptureOrigin_ = false;
+  CaptureParent_ = Parent;
+  CaptureDeps_.clear();
+  CaptureForks_.clear();
+  CaptureEvents_.clear();
+  Parent->CaptureForks_.insert(this);
+}
+
+void chipstar::Queue::captureEvent(chipstar::Event *Event) {
+  if (auto *Previous = Event->getCaptureQueue())
+    Previous->releaseCaptureEvent(Event);
+  Event->setCapture(this, CaptureDeps_);
+  CaptureEvents_.insert(Event);
+}
+
+void chipstar::Queue::releaseCaptureEvent(chipstar::Event *Event) {
+  CaptureEvents_.erase(Event);
+  Event->clearCapture();
+}
+
+void chipstar::Queue::endCapture() {
+  for (auto *Event : CaptureEvents_)
+    Event->clearCapture();
+  CaptureEvents_.clear();
+  // Detach from the parent first so that a fork ending its capture does not
+  // erase itself from the set being iterated here.
+  if (CaptureParent_)
+    CaptureParent_->CaptureForks_.erase(this);
+  CaptureParent_ = nullptr;
+  auto Forks = std::move(CaptureForks_);
+  CaptureForks_.clear();
+  for (auto *Fork : Forks) {
+    Fork->CaptureParent_ = nullptr;
+    Fork->endCapture();
+  }
+  CaptureOrigin_ = false;
+  CaptureDeps_.clear();
+  CaptureGraph_ = nullptr;
+  CaptureStatus_ = hipStreamCaptureStatusNone;
 }
 
 std::shared_ptr<chipstar::Event>

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -732,6 +732,13 @@ protected:
    */
   chipstar::Context *ChipContext_;
 
+  /// The capturing stream this event was last recorded on, while that
+  /// capture is active; null when the event is not part of a capture.
+  Queue *CaptureQueue_ = nullptr;
+  /// The capture dependencies of CaptureQueue_ at the time of the record.
+  /// A stream that waits on this event continues from these nodes.
+  std::vector<CHIPGraphNode *> CaptureNodes_;
+
   /**
    * @brief hidden default constructor for Event. Only derived class
    * constructor should be called.
@@ -745,6 +752,22 @@ public:
   virtual ~Event() { logTrace("~Event() {}", (void *)this); };
 
   std::vector<std::shared_ptr<chipstar::Event>> DependsOnList;
+
+  /// Mark this event as recorded on capturing stream Queue at the point where
+  /// the capture's next node would depend on Nodes.
+  void setCapture(Queue *Q, const std::vector<CHIPGraphNode *> &Nodes) {
+    CaptureQueue_ = Q;
+    CaptureNodes_ = Nodes;
+  }
+  void clearCapture() {
+    CaptureQueue_ = nullptr;
+    CaptureNodes_.clear();
+  }
+  /// The capturing stream that recorded this event, or null.
+  Queue *getCaptureQueue() const { return CaptureQueue_; }
+  const std::vector<CHIPGraphNode *> &getCaptureNodes() const {
+    return CaptureNodes_;
+  }
   void setRecording() {
     isDeletedSanityCheck();
     EventStatus_ = EVENT_STATUS_RECORDING;
@@ -2176,10 +2199,22 @@ class Queue : public ihipStream_t {
 protected:
   hipStreamCaptureStatus CaptureStatus_ = hipStreamCaptureStatusNone;
   hipStreamCaptureMode CaptureMode_ = hipStreamCaptureModeGlobal;
-  hipGraph_t CaptureGraph_;
-  /// @brief  node for creating a dependency chain between subsequent record
-  /// events when in graph capture mode
-  CHIPGraphNode *LastNode_ = nullptr;
+  hipGraph_t CaptureGraph_ = nullptr;
+  /// The nodes the next node recorded on this stream depends on: the node
+  /// recorded last on this stream plus the nodes joined in by waiting on
+  /// events recorded by other streams of the same capture.
+  std::vector<CHIPGraphNode *> CaptureDeps_;
+  /// True for the stream hipStreamBeginCapture was called on; only that
+  /// stream may end the capture.
+  bool CaptureOrigin_ = false;
+  /// The capturing stream whose event this stream waited on to enter the
+  /// capture; null for the origin stream.
+  Queue *CaptureParent_ = nullptr;
+  /// Streams that entered this stream's capture by waiting on its events.
+  std::set<Queue *> CaptureForks_;
+  /// Events recorded on this stream during the capture. Waiting on one of
+  /// them from another stream joins that stream into the capture.
+  std::set<chipstar::Event *> CaptureEvents_;
   int Priority_;
   /**
    * @brief Maximum priority that can be had by a queue is 0; Priority range is
@@ -2321,22 +2356,48 @@ public:
     if (getCaptureStatus() == hipStreamCaptureStatusActive) {
       auto Graph = getCaptureGraph();
       auto Node = new GraphNodeType(ArgsPack...);
-      updateLastNode(Node);
+      chainCaptureNode(Node);
       Graph->addNode(Node);
       return true;
     }
     return false;
   }
 
-  void updateLastNode(CHIPGraphNode *NewNode);
-  void initCaptureGraph();
+  /// Make NewNode depend on the current capture dependencies and become the
+  /// sole dependency of whatever is recorded on this stream next.
+  void chainCaptureNode(CHIPGraphNode *NewNode);
+  /// Add Nodes to the current capture dependencies (a join from an event
+  /// recorded by another stream of the capture).
+  void addCaptureDependencies(const std::vector<CHIPGraphNode *> &Nodes);
+  const std::vector<CHIPGraphNode *> &getCaptureDependencies() const {
+    return CaptureDeps_;
+  }
+  /// Start a capture into a fresh graph with this stream as its origin.
+  void beginCapture(hipStreamCaptureMode Mode);
+  /// Enter the capture Parent is part of: record into the same graph,
+  /// starting with no dependencies (the caller adds the event's nodes).
+  void joinCapture(Queue *Parent);
+  /// Record Event as captured on this stream at the current dependencies.
+  void captureEvent(chipstar::Event *Event);
+  /// Forget Event (it was recorded outside the capture or destroyed).
+  void releaseCaptureEvent(chipstar::Event *Event);
+  /// Leave the capture: reset this stream's capture state, the state of every
+  /// stream forked from it, and the events recorded on them. Does not touch
+  /// the graph.
+  void endCapture();
+  bool isCaptureOrigin() const { return CaptureOrigin_; }
+  Queue *getCaptureParent() const { return CaptureParent_; }
 
   hipStreamCaptureStatus getCaptureStatus() const {
     return CaptureStatus_;
   }
 
+  /// An invalidated fork invalidates the whole capture, so the status is
+  /// propagated up to the origin stream.
   void setCaptureStatus(hipStreamCaptureStatus CaptureMode) {
     CaptureStatus_ = CaptureMode;
+    if (CaptureMode == hipStreamCaptureStatusInvalidated && CaptureParent_)
+      CaptureParent_->setCaptureStatus(CaptureMode);
   }
   hipStreamCaptureMode getCaptureMode() const { return CaptureMode_; }
   void setCaptureMode(hipStreamCaptureMode CaptureMode) {

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2605,10 +2605,7 @@ hipError_t hipStreamBeginCapture(hipStream_t stream,
       hipStreamCaptureStatus::hipStreamCaptureStatusActive)
     RETURN(hipErrorIllegalState);
 
-  ChipQueue->initCaptureGraph();
-  ChipQueue->setCaptureMode(mode);
-  ChipQueue->setCaptureStatus(
-      hipStreamCaptureStatus::hipStreamCaptureStatusActive);
+  ChipQueue->beginCapture(mode);
   RETURN(hipSuccess);
   CHIP_CATCH
 }
@@ -2640,14 +2637,30 @@ hipError_t hipStreamEndCapture(hipStream_t stream, hipGraph_t *pGraph) {
       hipStreamCaptureStatus::hipStreamCaptureStatusActive)
     RETURN(hipErrorInvalidValue);
 
-  ChipQueue->setCaptureStatus(
-      hipStreamCaptureStatus::hipStreamCaptureStatusNone);
+  // A stream that entered the capture through hipStreamWaitEvent cannot end
+  // it; only the stream hipStreamBeginCapture was called on can.
+  if (!ChipQueue->isCaptureOrigin())
+    RETURN(hipErrorStreamCaptureUnmatched);
 
-  if (ChipQueue->getCaptureGraph())
-    *pGraph = ChipQueue->getCaptureGraph();
-  else
+  CHIPGraph *Graph = ChipQueue->getCaptureGraph();
+  if (!Graph)
     RETURN(hipErrorContextIsDestroyed);
 
+  // Every leaf of the graph must be something the origin stream waits for:
+  // a leaf outside the origin's dependency set is work on a forked stream
+  // that was never joined back.
+  const auto &Deps = ChipQueue->getCaptureDependencies();
+  for (auto *Leaf : Graph->getLeafNodes()) {
+    if (std::find(Deps.begin(), Deps.end(), Leaf) == Deps.end()) {
+      ChipQueue->endCapture();
+      delete Graph;
+      *pGraph = nullptr;
+      RETURN(hipErrorStreamCaptureUnjoined);
+    }
+  }
+
+  ChipQueue->endCapture();
+  *pGraph = Graph;
   RETURN(hipSuccess);
   CHIP_CATCH
 }
@@ -3763,11 +3776,10 @@ hipError_t hipStreamDestroy(hipStream_t Stream) {
   if (!ChipQueue->getContext())
     RETURN(hipErrorContextIsDestroyed);
 
+  // Leave any capture so that neither the capture's origin stream nor the
+  // events recorded here keep a pointer to the destroyed queue.
   if (ChipQueue->getCaptureStatus() != hipStreamCaptureStatusNone)
-    ChipQueue->setCaptureStatus(hipStreamCaptureStatusNone);
-
-  if (ChipQueue->getCaptureStatus() == hipStreamCaptureStatusInvalidated)
-    RETURN(hipErrorStreamCaptureInvalidated);
+    ChipQueue->endCapture();
 
   chipstar::Device *Dev = Backend->getActiveDevice();
 
@@ -3843,12 +3855,31 @@ hipError_t hipStreamWaitEventInternal(hipStream_t Stream, hipEvent_t Event,
   auto ChipEvent = static_cast<chipstar::Event *>(Event);
 
   auto ChipQueue = Backend->findQueue(static_cast<chipstar::Queue *>(Stream));
+  ERROR_IF((!ChipQueue), hipErrorInvalidResourceHandle);
+  ERROR_IF((!Event), hipErrorInvalidResourceHandle);
+
+  // An event recorded by a stream of an active capture carries the capture's
+  // dependencies at that point. Waiting on it is not a graph node: it joins
+  // this stream into that capture (cross-stream capture) and makes the next
+  // node recorded here depend on those nodes. hipEventWaitExternal keeps the
+  // wait as an event wait node instead.
+  if (Flags != hipEventWaitExternal && ChipEvent->getCaptureQueue()) {
+    auto *EventQueue = ChipEvent->getCaptureQueue();
+    if (ChipQueue->getCaptureStatus() != hipStreamCaptureStatusActive) {
+      if (ChipQueue->isDefaultLegacyQueue())
+        return hipErrorStreamCaptureImplicit;
+      ChipQueue->joinCapture(EventQueue);
+    } else if (ChipQueue->getCaptureGraph() != EventQueue->getCaptureGraph()) {
+      ChipQueue->setCaptureStatus(hipStreamCaptureStatusInvalidated);
+      return hipErrorStreamCaptureMerge;
+    }
+    ChipQueue->addCaptureDependencies(ChipEvent->getCaptureNodes());
+    return hipSuccess;
+  }
 
   if (ChipQueue->captureIntoGraph<CHIPGraphNodeWaitEvent>(ChipEvent)) {
     return hipSuccess;
   }
-  ERROR_IF((!ChipQueue), hipErrorInvalidResourceHandle);
-  ERROR_IF((!Event), hipErrorInvalidResourceHandle);
 
   if (ChipEvent->getEventStatus() == EVENT_STATUS_INIT)
     RETURN(hipSuccess);
@@ -4045,9 +4076,17 @@ hipError_t hipEventRecordInternal(hipEvent_t Event, hipStream_t Stream) {
   auto ChipQueue = Backend->findQueue(static_cast<chipstar::Queue *>(Stream));
   LOCK(ChipQueue->QueueMtx);
 
-  if (ChipQueue->captureIntoGraph<CHIPGraphNodeEventRecord>(ChipEvent)) {
+  // Recording during capture adds no node: the event stands for the nodes
+  // the stream's next node would depend on, so that another stream waiting
+  // on it can continue from them (see hipStreamWaitEventInternal).
+  if (ChipQueue->getCaptureStatus() == hipStreamCaptureStatusActive) {
+    ChipQueue->captureEvent(ChipEvent);
     return hipSuccess;
   }
+
+  // A record outside a capture ends the event's association with it.
+  if (auto *CaptureQueue = ChipEvent->getCaptureQueue())
+    CaptureQueue->releaseCaptureEvent(ChipEvent);
 
   ChipQueue->recordEvent(ChipEvent);
   return hipSuccess;
@@ -4068,10 +4107,13 @@ hipError_t hipEventDestroy(hipEvent_t Event) {
   LOCK(ApiMtx);
   CHIPInitialize();
   NULLCHECK(Event);
+  auto *ChipEvent = static_cast<chipstar::Event *>(Event);
+  if (auto *CaptureQueue = ChipEvent->getCaptureQueue())
+    CaptureQueue->releaseCaptureEvent(ChipEvent);
   // Delete through chipstar::Event*: hipEvent_t is ihipEvent_t*, a
   // non-polymorphic empty base, so `delete Event` would skip the virtual
   // destructor and leak the backend cl_event/ze_event handle.
-  delete static_cast<chipstar::Event *>(Event);
+  delete ChipEvent;
 
   RETURN(hipSuccess);
 

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -244,8 +244,6 @@ ANY:
     Unit_hipStreamBeginCapture_captureEmptyStreams: ''
     Unit_hipStreamBeginCapture_hipStreamPerThread: ''
     Unit_hipStreamBeginCapture_multiplestrms: ''
-    Unit_hipStreamBeginCapture_nestedStreamCapture: ''
-    Unit_hipStreamBeginCapture_streamReuse: ''
     Unit_hipStreamEndCapture_Negative: ''
     Unit_hipStreamEndCapture_Thread_Negative: ''
     Unit_hipStreamGetCaptureInfo_ArgValidation: ''

--- a/tests/runtime/TestFix1523CrossStreamCapture.hip
+++ b/tests/runtime/TestFix1523CrossStreamCapture.hip
@@ -1,0 +1,114 @@
+// Reproduces: work forked onto another stream during stream capture is not
+// captured. With capture active on Stream0, hipEventRecord(Ev, Stream0) plus
+// hipStreamWaitEvent(Stream1, Ev) must pull Stream1 into the same capture so
+// that kernels launched on Stream1 become graph nodes, and joining back with
+// another event must make the origin stream depend on them. Surfaced by the
+// catch tests Unit_hipStreamBeginCapture_nestedStreamCapture and
+// Unit_hipStreamBeginCapture_streamReuse (2 == 7): only the kernels launched
+// on the origin stream were recorded.
+#include <hip/hip_runtime.h>
+#include <iostream>
+
+__global__ void setSlot(int *Dst, int Slot) { Dst[Slot] = 1; }
+
+#define CHECK(Call)                                                            \
+  do {                                                                         \
+    hipError_t Err = (Call);                                                   \
+    if (Err != hipSuccess) {                                                   \
+      std::cout << "FAIL: " #Call " -> " << hipGetErrorString(Err) << "\n";    \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+int main() {
+  hipStream_t Streams[3];
+  hipEvent_t Fork, JoinA, JoinB;
+  for (auto &S : Streams)
+    CHECK(hipStreamCreate(&S));
+  CHECK(hipEventCreate(&Fork));
+  CHECK(hipEventCreate(&JoinA));
+  CHECK(hipEventCreate(&JoinB));
+
+  int *Dev;
+  CHECK(hipMalloc(&Dev, 3 * sizeof(int)));
+  CHECK(hipMemset(Dev, 0, 3 * sizeof(int)));
+  CHECK(hipDeviceSynchronize());
+
+  // Fork Streams[1] and Streams[2] off the capturing Streams[0], launch one
+  // kernel on each of the three streams, then join both forks back.
+  hipGraph_t Graph;
+  CHECK(hipStreamBeginCapture(Streams[0], hipStreamCaptureModeGlobal));
+  CHECK(hipEventRecord(Fork, Streams[0]));
+  CHECK(hipStreamWaitEvent(Streams[1], Fork, 0));
+  CHECK(hipStreamWaitEvent(Streams[2], Fork, 0));
+  setSlot<<<1, 1, 0, Streams[0]>>>(Dev, 0);
+  CHECK(hipGetLastError());
+  setSlot<<<1, 1, 0, Streams[1]>>>(Dev, 1);
+  CHECK(hipGetLastError());
+  setSlot<<<1, 1, 0, Streams[2]>>>(Dev, 2);
+  CHECK(hipGetLastError());
+  CHECK(hipEventRecord(JoinA, Streams[1]));
+  CHECK(hipEventRecord(JoinB, Streams[2]));
+  CHECK(hipStreamWaitEvent(Streams[0], JoinA, 0));
+  CHECK(hipStreamWaitEvent(Streams[0], JoinB, 0));
+  CHECK(hipStreamEndCapture(Streams[0], &Graph));
+  CHECK(hipDeviceSynchronize());
+
+  // Nothing may have run yet, on any of the three streams.
+  int Host[3] = {-1, -1, -1};
+  CHECK(hipMemcpy(Host, Dev, sizeof(Host), hipMemcpyDeviceToHost));
+  if (Host[0] != 0 || Host[1] != 0 || Host[2] != 0) {
+    std::cout << "FAIL: work ran during capture, slots are " << Host[0] << " "
+              << Host[1] << " " << Host[2] << "\n";
+    return 2;
+  }
+
+  // All three kernel launches must have been recorded as nodes.
+  size_t NumNodes = 0;
+  CHECK(hipGraphGetNodes(Graph, nullptr, &NumNodes));
+  if (NumNodes != 3) {
+    std::cout << "FAIL: captured graph has " << NumNodes
+              << " nodes, expected 3\n";
+    return 3;
+  }
+
+  // Replaying the graph performs all three writes.
+  hipGraphExec_t GraphExec;
+  CHECK(hipGraphInstantiate(&GraphExec, Graph, nullptr, nullptr, 0));
+  CHECK(hipGraphLaunch(GraphExec, Streams[0]));
+  CHECK(hipStreamSynchronize(Streams[0]));
+  CHECK(hipMemcpy(Host, Dev, sizeof(Host), hipMemcpyDeviceToHost));
+  if (Host[0] != 1 || Host[1] != 1 || Host[2] != 1) {
+    std::cout << "FAIL: graph launch did not run the forked kernels, slots are "
+              << Host[0] << " " << Host[1] << " " << Host[2] << "\n";
+    return 4;
+  }
+  CHECK(hipGraphExecDestroy(GraphExec));
+  CHECK(hipGraphDestroy(Graph));
+
+  // A fork that is never joined back must be rejected at the end of capture.
+  hipGraph_t Unjoined = nullptr;
+  CHECK(hipStreamBeginCapture(Streams[0], hipStreamCaptureModeGlobal));
+  setSlot<<<1, 1, 0, Streams[0]>>>(Dev, 0);
+  CHECK(hipGetLastError());
+  CHECK(hipEventRecord(Fork, Streams[0]));
+  CHECK(hipStreamWaitEvent(Streams[1], Fork, 0));
+  setSlot<<<1, 1, 0, Streams[1]>>>(Dev, 1);
+  CHECK(hipGetLastError());
+  hipError_t Err = hipStreamEndCapture(Streams[0], &Unjoined);
+  if (Err != hipErrorStreamCaptureUnjoined) {
+    std::cout << "FAIL: hipStreamEndCapture with an unjoined fork returned "
+              << hipGetErrorString(Err) << ", expected "
+              << hipGetErrorString(hipErrorStreamCaptureUnjoined) << "\n";
+    return 5;
+  }
+
+  CHECK(hipFree(Dev));
+  CHECK(hipEventDestroy(Fork));
+  CHECK(hipEventDestroy(JoinA));
+  CHECK(hipEventDestroy(JoinB));
+  for (auto &S : Streams)
+    CHECK(hipStreamDestroy(S));
+  std::cout << "PASSED\n";
+  return 0;
+}


### PR DESCRIPTION
Stream capture now follows event dependencies onto other streams, following the ROCm clr implementation in `hip_event.cpp`, `hip_stream.cpp` and `hip_graph.cpp`. `hipEventRecord` on a capturing stream tags the event with the stream's current capture dependencies instead of adding a node, `hipStreamWaitEvent` on such an event joins the waiting stream into the same capture (or, for a stream already in it, merges the event's nodes into its dependencies, which is how a fork joins back), and `hipStreamEndCapture` returns `hipErrorStreamCaptureUnmatched` on a forked stream and `hipErrorStreamCaptureUnjoined` when a fork was never joined. The reproducer `TestFix1523CrossStreamCapture` forks two streams, launches one kernel on each of three streams, joins, replays the graph and checks the unjoined error; it failed with `work ran during capture, slots are 0 1 1` before the fix. On OpenCL CPU the fix also makes `Unit_hipStreamBeginCapture_nestedStreamCapture`, `Unit_hipStreamBeginCapture_streamReuse` and 12 further catch graph tests pass with no new failures.

Supersedes #1529, which was stacked on the now merged #1522 and could not be retargeted to `main`.

Fixes #1523
