### PR TITLE
llvm-patches: permit SPV_INTEL_masked_gather_scatter on the HIPSPV device path

### DIFF
--- a/llvm-patches/llvm-23/llvm/0001-hipspv-in-tree-spirv-backend.patch
+++ b/llvm-patches/llvm-23/llvm/0001-hipspv-in-tree-spirv-backend.patch
@@ -124,7 +124,12 @@ index d6900c7..98bec18 100644
 +                       ",+SPV_INTEL_function_pointers"
 +                       ",+SPV_INTEL_subgroups"
 +                       ",+SPV_KHR_bit_instructions"
-+                       ",+SPV_EXT_shader_atomic_float_add");
++                       ",+SPV_EXT_shader_atomic_float_add"
++                       // A vector of pointers (e.g. rocPRIM's
++                       // test_device_reduce_by_key) is untranslatable without
++                       // this: llvm-spirv refuses with RequiresExtension. IGC
++                       // accepts the result (ocloc -device pvc).
++                       ",+SPV_INTEL_masked_gather_scatter");
 +
 +      // Preserve debug info in the NonSemantic.Shader.DebugInfo form.
 +      // These flags are passed unconditionally instead of gating on -g: in
@@ -170,7 +175,8 @@ index d6900c7..98bec18 100644
 +                      ",+SPV_KHR_bit_instructions"
 +                      ",+SPV_EXT_shader_atomic_float_add"
 +                      ",+SPV_KHR_non_semantic_info"
-+                      ",+SPV_INTEL_optnone");
++                      ",+SPV_INTEL_optnone"
++                      ",+SPV_INTEL_masked_gather_scatter");
 +
 +    Cc1Args.push_back(TempFile);
 +    Cc1Args.push_back("-o");

--- a/llvm-patches/llvm-23/llvm/0001-hipspv-in-tree-spirv-backend.patch
+++ b/llvm-patches/llvm-23/llvm/0001-hipspv-in-tree-spirv-backend.patch
@@ -84,7 +84,7 @@ index d6900c7..98bec18 100644
  void HIPSPV::Linker::constructLinkAndEmitSpirvCommand(
      Compilation &C, const JobAction &JA, const InputInfoList &Inputs,
      const InputInfo &Output, const llvm::opt::ArgList &Args) const {
-@@ -73,44 +102,100 @@ void HIPSPV::Linker::constructLinkAndEmitSpirvCommand(
+@@ -73,44 +102,106 @@ void HIPSPV::Linker::constructLinkAndEmitSpirvCommand(
    tools::constructLLVMLinkCommand(C, *this, JA, Inputs, LinkArgs, Output, Args,
                                    TempFile);
  
@@ -224,7 +224,7 @@ index d6900c7..98bec18 100644
  
    InputInfo TrInput = InputInfo(types::TY_LLVM_BC, TempFile, "");
    SPIRV::constructTranslateCommand(C, *this, JA, Output, TrInput, TrArgs);
-@@ -150,6 +235,11 @@ HIPSPVToolChain::HIPSPVToolChain(const Driver &D, const llvm::Triple &Triple,
+@@ -150,6 +241,11 @@ HIPSPVToolChain::HIPSPVToolChain(const Driver &D, const llvm::Triple &Triple,
    getProgramPaths().push_back(getDriver().Dir);
  }
  

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -172,6 +172,7 @@ add_shell_test(TestPrintfStaticString.bash)
 # fails. This skips when the in-tree SPIR-V backend is used
 # (LLVM_SPIRV=NOT_NEEDED), since the patch targets the external translator.
 add_shell_test(TestSpirvDuplicatePhiHip.bash)
+add_shell_test(TestFix1454VectorOfPointers.bash)
 
 add_shell_test(TestTextureUnsupportedMixedDim.bash)
 

--- a/tests/compiler/TestFix1454VectorOfPointers.bash
+++ b/tests/compiler/TestFix1454VectorOfPointers.bash
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Regression test for CHIP-SPV/chipStar#1454.
+#
+# Device IR that materialises a vector of pointers can only be translated to
+# SPIR-V when SPV_INTEL_masked_gather_scatter is permitted. chipStar pins the
+# allowed set in the HIPSPV driver with `--spirv-ext=-all,...`, so the
+# extension is not merely absent by default, it is switched off, and
+# llvm-spirv rejects such a module with
+#   RequiresExtension: ... SPV_INTEL_masked_gather_scatter
+# rocPRIM's test/rocprim/test_device_reduce_by_key.cpp is a real trigger:
+# without the extension the whole rocPRIM build fails and rocThrust,
+# rocSPARSE, hipSPARSE, hipMM and zeroRK fail after it.
+#
+# The driver does not expose its extension list through -### or -v, and no
+# small HIP source reliably produces a vector of pointers (adjacent pointer
+# copies, indexed gathers and scatters and an array-of-pointers dereference
+# were all tried and none vectorised), so the guard has two halves:
+#   1. the chipStar patch that sets the list must still list the extension
+#   2. the extension must still be what makes such a module translatable
+set -eu
+
+SRC_DIR="@CMAKE_CURRENT_SOURCE_DIR@"
+LLVM_SPIRV="@LLVM_SPIRV@"
+# llvm-as sits beside llvm-spirv in the same LLVM bin directory.
+LLVM_AS="$(dirname "@LLVM_SPIRV@")/llvm-as"
+SPIRV_VAL="@CMAKE_BINARY_DIR@/external/spirv-tools/bin/spirv-val"
+PATCH="@CMAKE_SOURCE_DIR@/llvm-patches/llvm-@LLVM_VERSION_MAJOR@/llvm/0001-hipspv-in-tree-spirv-backend.patch"
+OUT="@CMAKE_CURRENT_BINARY_DIR@/@TEST_NAME@.d"
+
+# Part 1: the driver patch must still permit the extension.
+if [ ! -f "${PATCH}" ]; then
+  echo "no HIPSPV driver patch for LLVM @LLVM_VERSION_MAJOR@; skipping"
+  exit 0
+fi
+if ! grep -q "SPV_INTEL_masked_gather_scatter" "${PATCH}"; then
+  echo "FAIL: ${PATCH} no longer permits SPV_INTEL_masked_gather_scatter."
+  echo "      Device code holding a vector of pointers will fail to translate."
+  exit 1
+fi
+echo "driver patch permits SPV_INTEL_masked_gather_scatter"
+
+# Part 2: show that this is still the extension that matters. Uses llvm-spirv
+# directly, so it is meaningful on the translator configuration only; with the
+# in-tree backend the same input aborts inside SPIRVEmitIntrinsics before any
+# extension is consulted, which is the unresolved half of #1454.
+if [ "${LLVM_SPIRV}" = "NOT_NEEDED" ] || [ ! -x "${LLVM_SPIRV}" ]; then
+  echo "external llvm-spirv not in use; skipping the translation half"
+  exit 0
+fi
+if [ ! -x "${SPIRV_VAL}" ] || [ ! -x "${LLVM_AS}" ]; then
+  echo "spirv-val or llvm-as not found; skipping the translation half"
+  exit 0
+fi
+
+rm -rf "${OUT}"; mkdir -p "${OUT}"; cd "${OUT}"
+BASE="-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups,+SPV_KHR_bit_instructions,+SPV_EXT_shader_atomic_float_add"
+"${LLVM_AS}" "${SRC_DIR}/TestFix1454VectorOfPointers.ll" -o vecptr.bc
+
+# Without the extension the module must still be rejected. If this ever
+# succeeds the extension is no longer needed and this test can go.
+if "${LLVM_SPIRV}" "--spirv-ext=${BASE}" vecptr.bc -o without.spv 2>/dev/null; then
+  echo "FAIL: translation unexpectedly succeeded without the extension"
+  exit 1
+fi
+
+# With it, translation must succeed and the result must validate.
+"${LLVM_SPIRV}" "--spirv-ext=${BASE},+SPV_INTEL_masked_gather_scatter" vecptr.bc -o with.spv
+"${SPIRV_VAL}" with.spv
+echo "PASSED"

--- a/tests/compiler/TestFix1454VectorOfPointers.ll
+++ b/tests/compiler/TestFix1454VectorOfPointers.ll
@@ -1,0 +1,15 @@
+; Reproducer for CHIP-SPV/chipStar#1454: device IR holding a vector of
+; pointers. Reduced with llvm-reduce from a failing Aurora application by the
+; issue reporter; rocPRIM's test/rocprim/test_device_reduce_by_key.cpp is a
+; real-world trigger. Translating this needs SPV_INTEL_masked_gather_scatter,
+; and chipStar's device flag list pins the allowed set with
+; `--spirv-ext=-all,...`, so without the extension llvm-spirv rejects it.
+
+target triple = "spirv64"
+
+define spir_kernel void @k(ptr addrspace(1) %src, ptr addrspace(1) %dst) {
+entry:
+  %v = load <4 x ptr addrspace(4)>, ptr addrspace(1) %src, align 8
+  store <4 x ptr addrspace(4)> %v, ptr addrspace(1) %dst, align 8
+  ret void
+}


### PR DESCRIPTION
Device code that materialises a vector of pointers cannot be emitted as SPIR-V without `SPV_INTEL_masked_gather_scatter`. The HIPSPV driver pins the allowed set with `--spirv-ext=-all,...`, so the extension was not merely absent but switched off, and llvm-spirv refused the module:

```
RequiresExtension: Feature requires the following SPIR-V extension:
 SPV_INTEL_masked_gather_scatter
NOTE: LLVM module contains vector of pointers, translation of which requires this extension
```

Found by building rocPRIM on Aurora against LLVM 23. `test/rocprim/test_device_reduce_by_key.cpp` triggers it, which fails the rocPRIM build and then cascades into rocThrust, rocSPARSE, hipSPARSE and hipMM, and into zeroRK because thrust headers are never installed. Six of fifteen components lost to one defect.

Isolated A/B/C against the reproducer, so the result does not depend on anything else in the toolchain:

```
upstream list                                   rc=18, RequiresExtension
upstream list + masked_gather_scatter           rc=0, spirv-val VALID
upstream list + an unrelated extension only     rc=18, RequiresExtension
```

IGC accepts the emitted SPIR-V on PVC (`ocloc compile -spirv_input -device pvc` reports `Build succeeded`).

End to end on Aurora PVC, LLVM `llvmorg-23.1.0-rc2`, `-DCHIP_LLVM_USE_INTERGRATED_SPIRV=OFF`, rebuilding the whole suite with the extension permitted:

```
components built      10/15 -> 14/15
rocPRIM               builds, 9/9 tests
rocThrust             builds, 76/76 tests
zeroRK                4/4 CPU vs GPU correctness checks
chipStar unit tests   1063/1063
```

This does NOT close https://github.com/CHIP-SPV/chipStar/issues/1454. The in-tree SPIR-V backend still aborts on the same input in `SPIRVEmitIntrinsics::deduceNestedTypeHelper` during type deduction, before any extension gating, so no flag reaches it. I confirmed the native configuration still fails identically with the extension permitted. The issue should stay open for the LLVM side.

The test has two halves because the driver does not expose its extension list through `-###` or `-v`, and no small HIP source reproduces the IR pattern. Adjacent pointer copies, indexed gathers and scatters and an array of pointers dereference were each compiled and none produced a vector of pointer type in the lowered device IR, so the `.ll` from the issue is used instead. Half one asserts the driver patch still permits the extension, which is what regresses. Half two runs llvm-spirv and spirv-val to show that this is still the extension that makes the difference, and fails if translation ever succeeds without it, so the test retires itself when the extension stops being needed.

One disclosure about the environment the end to end numbers came from. The shared LLVM source tree on Aurora used for those builds was edited by another party partway through, adding `+SPV_INTEL_cache_controls` to the same two lists. That edit is not in this PR and is not in chipStar main. The A/B/C isolation above was run separately through llvm-spirv precisely so the claim does not rest on that build.
