### PR TITLE
Add device side long double math and floating-point abs overloads

### DIFF
--- a/include/hip/devicelib/double_precision/dp_math.hh
+++ b/include/hip/devicelib/double_precision/dp_math.hh
@@ -524,6 +524,76 @@ extern "C++" inline __device__ double yn(int n, double x) {
   return ::__chip_yn_f64(n, x);
 }
 
+// On the device target 'long double' is a 64-bit double (same size, same
+// 53-bit mantissa), and SPIR-V has no wider floating-point type, so device
+// side long double math is exactly double math. Without these overloads a
+// device side call such as sqrt(1.0L) has no exact match - the candidates
+// are the double and __half ones - and is ambiguous. See
+// CHIP-SPV/chipStar#1583.
+//
+// These are templates constrained to an exact 'long double' argument rather
+// than plain overloads on purpose: a plain 'long double' overload would tie
+// with the 'double' one for integer arguments (int -> double and
+// int -> long double are the same conversion rank), making calls such as
+// std::pow(2, 3) ambiguous.
+namespace chipDevicelibImpl {
+template <class T, class U> struct isSameType {
+  static const bool Value = false;
+};
+template <class T> struct isSameType<T, T> { static const bool Value = true; };
+template <bool B, class T> struct enableIfType {};
+template <class T> struct enableIfType<true, T> { typedef T Type; };
+template <class T> struct isLongDouble : isSameType<T, long double> {};
+} // namespace chipDevicelibImpl
+
+#define CHIP_DEF_LONG_DOUBLE_FN1(NAME)                                         \
+  template <class T>                                                           \
+  static inline __device__ typename chipDevicelibImpl::enableIfType<           \
+      chipDevicelibImpl::isLongDouble<T>::Value, long double>::Type            \
+  NAME(T x) {                                                                  \
+    return ::NAME(static_cast<double>(x));                                     \
+  }
+#define CHIP_DEF_LONG_DOUBLE_FN2(NAME)                                         \
+  template <class T, class U>                                                  \
+  static inline __device__ typename chipDevicelibImpl::enableIfType<           \
+      chipDevicelibImpl::isLongDouble<T>::Value &&                             \
+          chipDevicelibImpl::isLongDouble<U>::Value,                           \
+      long double>::Type                                                       \
+  NAME(T x, U y) {                                                             \
+    return ::NAME(static_cast<double>(x), static_cast<double>(y));             \
+  }
+
+CHIP_DEF_LONG_DOUBLE_FN1(acos)
+CHIP_DEF_LONG_DOUBLE_FN1(asin)
+CHIP_DEF_LONG_DOUBLE_FN1(atan)
+CHIP_DEF_LONG_DOUBLE_FN1(ceil)
+CHIP_DEF_LONG_DOUBLE_FN1(cos)
+CHIP_DEF_LONG_DOUBLE_FN1(cosh)
+CHIP_DEF_LONG_DOUBLE_FN1(erf)
+CHIP_DEF_LONG_DOUBLE_FN1(erfc)
+CHIP_DEF_LONG_DOUBLE_FN1(exp)
+CHIP_DEF_LONG_DOUBLE_FN1(expm1)
+CHIP_DEF_LONG_DOUBLE_FN1(fabs)
+CHIP_DEF_LONG_DOUBLE_FN1(floor)
+CHIP_DEF_LONG_DOUBLE_FN1(lgamma)
+CHIP_DEF_LONG_DOUBLE_FN1(log)
+CHIP_DEF_LONG_DOUBLE_FN1(log10)
+CHIP_DEF_LONG_DOUBLE_FN1(log1p)
+CHIP_DEF_LONG_DOUBLE_FN1(log2)
+CHIP_DEF_LONG_DOUBLE_FN1(nearbyint)
+CHIP_DEF_LONG_DOUBLE_FN1(sin)
+CHIP_DEF_LONG_DOUBLE_FN1(sinh)
+CHIP_DEF_LONG_DOUBLE_FN1(sqrt)
+CHIP_DEF_LONG_DOUBLE_FN1(tan)
+CHIP_DEF_LONG_DOUBLE_FN1(tanh)
+CHIP_DEF_LONG_DOUBLE_FN1(trunc)
+CHIP_DEF_LONG_DOUBLE_FN2(copysign)
+CHIP_DEF_LONG_DOUBLE_FN2(nextafter)
+CHIP_DEF_LONG_DOUBLE_FN2(pow)
+
+#undef CHIP_DEF_LONG_DOUBLE_FN1
+#undef CHIP_DEF_LONG_DOUBLE_FN2
+
 namespace std {
 // Clang does provide device side std:: functions via HIP include
 // wrappers but, alas, the wrappers won't compile on chipStar due to

--- a/include/hip/devicelib/integer/int_math.hh
+++ b/include/hip/devicelib/integer/int_math.hh
@@ -114,6 +114,14 @@ static inline __host__ __device__ long long int llmin(const long long int a, con
   return (a < b) ? a : b;
 }
 
+// Floating-point abs(). Without these the only device side candidates are
+// the integer overloads, so an unqualified abs() on a float, double or long
+// double is ambiguous - which is how boost::math::ccmath::abs<double> fails
+// to compile. See CHIP-SPV/chipStar#1583.
+static inline __device__ float abs(float a) { return ::fabsf(a); }
+static inline __device__ double abs(double a) { return ::fabs(a); }
+static inline __device__ long double abs(long double a) { return ::fabs(a); }
+
 namespace std {
 // Clang does provide device side std::abs via HIP include wrappers
 // but, alas, the wrappers won't compile on chipStar due to AMD

--- a/tests/devicelib/CMakeLists.txt
+++ b/tests/devicelib/CMakeLists.txt
@@ -83,3 +83,22 @@ set_tests_properties(TestStdLlroundFloat PROPERTIES
 add_hip_test(TestStdLdexp.cpp)
 set_tests_properties(TestStdLdexp PROPERTIES
   PASS_REGULAR_EXPRESSION "PASSED")
+
+# The long double / floating-point abs ambiguity of CHIP-SPV/chipStar#1583 only
+# shows up with a C++ standard library whose host math overloads are not
+# constexpr - libc++, i.e. every macOS build. libstdc++ marks them constexpr,
+# which makes them implicitly __host__ __device__ and hides the gap. Register
+# the compile check only where libc++ is actually usable.
+set(LIBCXX_PROBE_SRC ${CMAKE_CURRENT_BINARY_DIR}/libcxx_probe.cpp)
+file(WRITE ${LIBCXX_PROBE_SRC}
+  "#include <cmath>\nint main() { return static_cast<int>(std::sqrt(4.0)); }\n")
+execute_process(
+  COMMAND ${CLANG_ROOT_PATH_BIN}/clang++ -stdlib=libc++ -fsyntax-only ${LIBCXX_PROBE_SRC}
+  RESULT_VARIABLE LIBCXX_PROBE_RESULT
+  OUTPUT_QUIET ERROR_QUIET)
+if(LIBCXX_PROBE_RESULT EQUAL 0)
+  add_test(NAME "TestFix1583LongDoubleMath"
+    COMMAND ${CMAKE_BINARY_DIR}/bin/hipcc -stdlib=libc++ -c
+      -o ${CMAKE_CURRENT_BINARY_DIR}/TestFix1583LongDoubleMath.o
+      ${CMAKE_CURRENT_SOURCE_DIR}/TestFix1583LongDoubleMath.cpp)
+endif()

--- a/tests/devicelib/TestFix1583LongDoubleMath.cpp
+++ b/tests/devicelib/TestFix1583LongDoubleMath.cpp
@@ -1,0 +1,32 @@
+// Reproduces CHIP-SPV/chipStar#1583: chipStar's devicelib declares only
+// double and __half overloads of the math functions it hoists into
+// namespace std, so device-side code that calls them with 'long double' -
+// or calls unqualified abs() on a floating-point value - is ambiguous.
+// Compile-only test: it never has to run, it only has to compile.
+#include <hip/hip_runtime.h>
+#include <cmath>
+
+__device__ long double rsqrtRef(long double Arg) { return 1.0L / std::sqrt(Arg); }
+
+__device__ long double powRef(long double A, long double B) {
+  return std::pow(A, B);
+}
+
+// boost::math::ccmath::abs<double> calls unqualified abs() like this.
+__device__ double absDouble(double Arg) { return abs(Arg); }
+__device__ float absFloat(float Arg) { return abs(Arg); }
+__device__ long double absLongDouble(long double Arg) { return abs(Arg); }
+
+// Integer arguments must keep picking the plain double overloads: a plain
+// long double overload would tie with the double one here, since int ->
+// double and int -> long double are the same conversion rank.
+__device__ double powIntShort(int A, short B) { return std::pow(A, B); }
+
+__global__ void k(double *Out) {
+  *Out = static_cast<double>(rsqrtRef(4.0L)) +
+         static_cast<double>(powRef(2.0L, 3.0L)) + absDouble(-3.0) +
+         absFloat(-3.0f) + static_cast<double>(absLongDouble(-3.0L)) +
+         powIntShort(2, 3);
+}
+
+int main() { return 0; }


### PR DESCRIPTION
devicelib declared only double and __half overloads of the math functions it hoists into namespace std, and only integer overloads of abs(), so device code calling sqrt(1.0L) or an unqualified abs() on a floating-point value was ambiguous. On the device target long double is a 64-bit double, so the new overloads forward to the double entry points without losing precision.

The gap is hidden by libstdc++, whose constexpr host math overloads are implicitly __host__ __device__, so the added compile test is registered only where libc++ is available.

Fixes #1583