### PR TITLE
hip_fp16: stop specializing std::is_floating_point for _Float16

### DIFF
--- a/include/hip/spirv_hip_fp16.h
+++ b/include/hip/spirv_hip_fp16.h
@@ -75,8 +75,15 @@ THE SOFTWARE.
         #include "spirv_math_fwd.h"
         #include "spirv_hip_vector_types.h"
       #endif
-        namespace std
+        // std::is_floating_point is not a customization point: [namespace.std]
+        // only allows specializing a standard template for a program-defined
+        // type, and libc++ >= 20 marks the trait
+        // [[clang::no_specializations]], which turns the specialization into a
+        // hard error. Use a chipStar-local trait instead (issue #1582).
+        namespace hip_impl
         {
+            template<typename T>
+            struct is_floating_point : std::is_floating_point<T> {};
             template<> struct is_floating_point<_Float16> : std::true_type {};
         }
 
@@ -103,7 +110,7 @@ THE SOFTWARE.
                 __half(decltype(data) x) : data{x} {}
                 template<
                     typename T,
-                    Enable_if_t<std::is_floating_point<T>{}>* = nullptr>
+                    Enable_if_t<hip_impl::is_floating_point<T>{}>* = nullptr>
                 __HOST_DEVICE__
                 __half(T x) : data{static_cast<_Float16>(x)} {}
             #endif
@@ -162,7 +169,7 @@ THE SOFTWARE.
             #if !defined(__HIP_NO_HALF_CONVERSIONS__)
                 template<
                     typename T,
-                    Enable_if_t<std::is_floating_point<T>{}>* = nullptr>
+                    Enable_if_t<hip_impl::is_floating_point<T>{}>* = nullptr>
                 __HOST_DEVICE__
                 __half& operator=(T x)
                 {
@@ -232,7 +239,7 @@ THE SOFTWARE.
             #if !defined(__HIP_NO_HALF_CONVERSIONS__)
                 template<
                     typename T,
-                    Enable_if_t<std::is_floating_point<T>{}>* = nullptr>
+                    Enable_if_t<hip_impl::is_floating_point<T>{}>* = nullptr>
                 __HOST_DEVICE__
                 operator T() const { return data; }
             #endif

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -130,6 +130,8 @@ add_hipcc_test(TestFix1248HalfHostOps.hip HIPCC_OPTIONS -fsyntax-only)
 
 add_hipcc_test(TestHalfDeviceMathFuncs.hip HIPCC_OPTIONS -fsyntax-only)
 
+add_hipcc_test(TestFix1582StdTraitSpecialization.hip HIPCC_OPTIONS -fsyntax-only)
+
 add_hipcc_test(TestRocmVersionHeader.hip HIPCC_OPTIONS -fsyntax-only)
 
 add_hipcc_test(TestZeroLenArrayTypes.hip TEST_NAME TestZeroLenArrayTypes-O0

--- a/tests/compiler/TestFix1582StdTraitSpecialization.hip
+++ b/tests/compiler/TestFix1582StdTraitSpecialization.hip
@@ -1,0 +1,31 @@
+// Reproduces issue #1582: hip_fp16.h must not specialize std::is_floating_point
+// for _Float16. That is UB ([namespace.std] allows specializing a standard
+// template only for program-defined types) and libc++ >= 20 marks the trait
+// [[clang::no_specializations]], turning it into a hard error.
+#include <hip/hip_fp16.h>
+#include <type_traits>
+
+// The standard trait must be left exactly as the standard library defines it.
+static_assert(!std::is_floating_point<_Float16>::value,
+              "chipStar must not specialize std::is_floating_point<_Float16>");
+
+// The __half conversions that the specialization used to enable must keep
+// working through a chipStar-local trait.
+__host__ __device__ void half_conversions() {
+    _Float16 f16 = 1.5;
+    __half h{f16};
+    h = f16;
+    _Float16 back = h;
+
+    __half hf{1.5f};
+    hf = 2.5f;
+    float f = hf;
+
+    __half hd{1.5};
+    hd = 2.5;
+    double d = hd;
+
+    (void)back; (void)f; (void)d;
+}
+
+int main() { return 0; }


### PR DESCRIPTION
`spirv_hip_fp16.h` opened `namespace std` and specialized `std::is_floating_point<_Float16>`. That is UB: `[namespace.std]` allows specializing a standard template only for a program-defined type, and `_Float16` is not one. libc++ >= 20 marks the trait `[[clang::no_specializations]]`, which turns it from UB into a hard error, so any build against libc++ >= 20 fails on any platform. It shows up on macOS first only because libc++ is the default there.

The specialization is replaced with a chipStar-local trait in `hip_impl`, and the three `__half` members that consumed it (the converting constructor, `operator=`, and `operator T()`) now use that trait. The standard trait is left exactly as the standard library defines it.

Reproducer `TestFix1582StdTraitSpecialization.hip` asserts that `std::is_floating_point<_Float16>` is unspecialized and that the `__half` conversions the specialization used to enable still compile. It fails on the tests-only commit and passes on the fix commit. Asserting on the trait rather than on the libc++ diagnostic makes it fire on every platform, including the libstdc++ CI lanes, which the diagnostic itself never reaches.

Verified on Intel Arc B570, LLVM 22.1.0, level0 backend. Full `check.py igpu level0` run on the baseline header and on the fixed header gives byte-identical failure sets (445 vs 444 of 1671); the single difference is the new test, which fails on baseline and passes with the fix. The six tests named in the issue all pass here: `hipcc-TestFix797ShflHalf`, `TestHipccHalfConversions`, `TestHipccHalfOperators`, `hipcc-TestFix1248HalfHostOps`, `hipcc-TestHalfDeviceMathFuncs`, `TestHipccFp16Include`.

No libc++ is installed on the development machine, so the `-Winvalid-specialization` error itself was not reproduced locally, only the root cause it stems from. Confirmation on the macOS lane with an SDK carrying `_LIBCPP_VERSION >= 200000` is still wanted.

One behavior consequence worth naming: `is_valid_type` in `spirv_hip_cooperative_groups_helper.h` uses `std::is_floating_point<T>`, so a cooperative-groups reduction over a raw `_Float16` was accepted when `hip_fp16.h` happened to be included first, and is now rejected. That acceptance was already include-order dependent and `__half` was never accepted there, so it is left alone rather than widened in this PR.

Fixes #1582