### PR TITLE
Give device side math the integral argument overloads C++ requires

### DIFF
--- a/include/hip/spirv_hip_devicelib.hh
+++ b/include/hip/spirv_hip_devicelib.hh
@@ -107,6 +107,30 @@ template<typename T> struct __hip_numeric_limits {
   static constexpr bool is_specialized = false;
 };
 
+template<> struct __hip_numeric_limits<bool> {
+  static constexpr bool is_integer = true;
+  static constexpr bool is_specialized = true;
+};
+template<> struct __hip_numeric_limits<char> {
+  static constexpr bool is_integer = true;
+  static constexpr bool is_specialized = true;
+};
+template<> struct __hip_numeric_limits<signed char> {
+  static constexpr bool is_integer = true;
+  static constexpr bool is_specialized = true;
+};
+template<> struct __hip_numeric_limits<unsigned char> {
+  static constexpr bool is_integer = true;
+  static constexpr bool is_specialized = true;
+};
+template<> struct __hip_numeric_limits<short> {
+  static constexpr bool is_integer = true;
+  static constexpr bool is_specialized = true;
+};
+template<> struct __hip_numeric_limits<unsigned short> {
+  static constexpr bool is_integer = true;
+  static constexpr bool is_specialized = true;
+};
 template<> struct __hip_numeric_limits<int> {
   static constexpr bool is_integer = true;
   static constexpr bool is_specialized = true;
@@ -188,18 +212,86 @@ __HIP_OVERLOAD2(double, max)
 __HIP_OVERLOAD2(double, min)
 __HIP_OVERLOAD2(double, pow)
 
+// Integer arguments must behave as if converted to double ([cmath.syn]).
+// devicelib declares float, double and __half flavours of these names, so
+// without an integral overload an integer argument converts equally well to
+// more than one of them and the call is ambiguous. The host standard library
+// supplies these overloads itself, but under libc++ they are not constexpr,
+// so they are host-only and gone from the device pass. See
+// CHIP-SPV/chipStar#1586.
+
+__HIP_OVERLOAD1(double, acosh)
+__HIP_OVERLOAD1(double, asinh)
+__HIP_OVERLOAD1(double, atanh)
+__HIP_OVERLOAD1(double, ceil)
+__HIP_OVERLOAD1(double, cos)
+__HIP_OVERLOAD1(double, erf)
+__HIP_OVERLOAD1(double, exp)
+__HIP_OVERLOAD1(double, exp2)
+__HIP_OVERLOAD1(double, floor)
+__HIP_OVERLOAD1(double, lgamma)
+__HIP_OVERLOAD1(double, log)
+__HIP_OVERLOAD1(double, log10)
+__HIP_OVERLOAD1(double, log1p)
+__HIP_OVERLOAD1(double, log2)
+__HIP_OVERLOAD1(double, logb)
+__HIP_OVERLOAD1(double, nearbyint)
+__HIP_OVERLOAD1(double, rint)
+__HIP_OVERLOAD1(double, sin)
+__HIP_OVERLOAD1(double, sqrt)
+__HIP_OVERLOAD1(double, tan)
+__HIP_OVERLOAD1(double, tgamma)
+__HIP_OVERLOAD1(double, trunc)
+__HIP_OVERLOAD1(double, cospi)
+__HIP_OVERLOAD1(double, exp10)
+__HIP_OVERLOAD1(double, rsqrt)
+__HIP_OVERLOAD1(double, sinpi)
+
+__HIP_OVERLOAD2(double, atan2)
+__HIP_OVERLOAD2(double, copysign)
+__HIP_OVERLOAD2(double, fdim)
+__HIP_OVERLOAD2(double, fmin)
+__HIP_OVERLOAD2(double, nextafter)
+__HIP_OVERLOAD2(double, remainder)
 namespace std {
 __HIP_OVERLOAD1(long, lrint);
-__HIP_OVERLOAD1(double, lgamma);
 __HIP_OVERLOAD1(double, erfc);
-__HIP_OVERLOAD1(double, erf);
 __HIP_OVERLOAD1(double, tanh);
 __HIP_OVERLOAD1(double, cosh);
 __HIP_OVERLOAD1(double, sinh);
 __HIP_OVERLOAD1(double, atan);
 __HIP_OVERLOAD1(double, acos);
 __HIP_OVERLOAD1(double, asin);
-__HIP_OVERLOAD1(double, tan);
+
+// CHIP-SPV/chipStar#1586: re-export the global integral overloads above.
+using ::acosh;
+using ::asinh;
+using ::atanh;
+using ::ceil;
+using ::cos;
+using ::erf;
+using ::exp;
+using ::exp2;
+using ::floor;
+using ::lgamma;
+using ::log;
+using ::log10;
+using ::log1p;
+using ::log2;
+using ::logb;
+using ::nearbyint;
+using ::rint;
+using ::sin;
+using ::sqrt;
+using ::tan;
+using ::tgamma;
+using ::trunc;
+using ::atan2;
+using ::copysign;
+using ::fdim;
+using ::fmin;
+using ::nextafter;
+using ::remainder;
 
 // libstdc++ pulls the C `modf` into std with a using-declaration, which covers
 // the double overload, but its float overload is a host-only inline. The device

--- a/tests/devicelib/CMakeLists.txt
+++ b/tests/devicelib/CMakeLists.txt
@@ -101,4 +101,9 @@ if(LIBCXX_PROBE_RESULT EQUAL 0)
     COMMAND ${CMAKE_BINARY_DIR}/bin/hipcc -stdlib=libc++ -c
       -o ${CMAKE_CURRENT_BINARY_DIR}/TestFix1583LongDoubleMath.o
       ${CMAKE_CURRENT_SOURCE_DIR}/TestFix1583LongDoubleMath.cpp)
+  # CHIP-SPV/chipStar#1586, same libc++-only visibility as the above.
+  add_test(NAME "TestFix1586IntegralArgMath"
+    COMMAND ${CMAKE_BINARY_DIR}/bin/hipcc -stdlib=libc++ -c
+      -o ${CMAKE_CURRENT_BINARY_DIR}/TestFix1586IntegralArgMath.o
+      ${CMAKE_CURRENT_SOURCE_DIR}/TestFix1586IntegralArgMath.cpp)
 endif()

--- a/tests/devicelib/TestFix1586IntegralArgMath.cpp
+++ b/tests/devicelib/TestFix1586IntegralArgMath.cpp
@@ -1,0 +1,63 @@
+// Reproduces CHIP-SPV/chipStar#1586: devicelib declares float, double and
+// __half overloads of the math functions but none taking an integer, so an
+// integer argument converts equally well to more than one of them and the
+// call is ambiguous. C++ requires <cmath> to provide "sufficient additional
+// overloads" so that integer arguments behave as if converted to double.
+// Compile-only test: it never has to run, it only has to compile.
+#include <hip/hip_runtime.h>
+#include <cmath>
+
+#define CHECK_UNARY(NAME)                                                      \
+  __device__ double check_##NAME(int A) { return NAME(A); }
+#define CHECK_BINARY(NAME)                                                     \
+  __device__ double checkII_##NAME(int A, int B) { return NAME(A, B); }        \
+  __device__ double checkDI_##NAME(double A, int B) { return NAME(A, B); }
+
+CHECK_UNARY(acosh)
+CHECK_UNARY(asinh)
+CHECK_UNARY(atanh)
+CHECK_UNARY(ceil)
+CHECK_UNARY(cos)
+CHECK_UNARY(cospi)
+CHECK_UNARY(erf)
+CHECK_UNARY(exp)
+CHECK_UNARY(exp10)
+CHECK_UNARY(exp2)
+CHECK_UNARY(floor)
+CHECK_UNARY(lgamma)
+CHECK_UNARY(log)
+CHECK_UNARY(log10)
+CHECK_UNARY(log1p)
+CHECK_UNARY(log2)
+CHECK_UNARY(logb)
+CHECK_UNARY(nearbyint)
+CHECK_UNARY(rint)
+CHECK_UNARY(rsqrt)
+CHECK_UNARY(sin)
+CHECK_UNARY(sinpi)
+CHECK_UNARY(sqrt)
+CHECK_UNARY(tan)
+CHECK_UNARY(tgamma)
+CHECK_UNARY(trunc)
+
+CHECK_BINARY(atan2)
+CHECK_BINARY(copysign)
+CHECK_BINARY(fdim)
+CHECK_BINARY(fmin)
+CHECK_BINARY(nextafter)
+CHECK_BINARY(remainder)
+
+// The same calls through namespace std, which is how portable code spells
+// them and how the boost and hip-tests failures showed up.
+__device__ double stdSqrtInt(int A) { return std::sqrt(A); }
+__device__ double stdPowIntInt(int A, int B) { return std::pow(A, B); }
+
+// Narrow integer types too: __hip_numeric_limits had no specialization for
+// them, so the integral overload never fired.
+__device__ double stdSqrtShort(short A) { return std::sqrt(A); }
+__device__ double stdSqrtChar(char A) { return std::sqrt(A); }
+__device__ double stdSqrtBool(bool A) { return std::sqrt(A); }
+
+__global__ void k(double *Out) { *Out = check_sqrt(4) + stdSqrtInt(4); }
+
+int main() { return 0; }


### PR DESCRIPTION
devicelib declares float, double and __half flavours of these math functions but none taking an integer, so an integer argument converts equally well to more than one of them and the call is ambiguous. libstdc++ hides this because its own integral overloads are constexpr, hence implicitly __host__ __device__; under libc++ they are host-only and gone from the device pass, so every macOS build sees it.

Reuses the existing __HIP_OVERLOAD1/__HIP_OVERLOAD2 machinery, declared at global scope and re-exported into std, and specializes __hip_numeric_limits for the narrow integer types it was missing. Stacked on #1584, so it targets that branch; retarget to main once #1584 merges.

Fixes #1586