### PR TITLE
tests: mask the PoCL SVM memcpy crash on pastrami

### DIFF
--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -931,3 +931,15 @@ chipstar-rusticl: # AMD Radeon Pro W6400 via rusticl/radeonsi (self-hosted runne
   OPENCL_CPU:
   OPENCL_GPU:
   OPENCL_POCL:
+pastrami: # macOS on Apple silicon, PoCL 7.2
+  ALL:
+  LEVEL0_GPU:
+  OPENCL_CPU:
+  OPENCL_GPU:
+  OPENCL_POCL:
+    # Both variants segfault inside PoCL's pocl_svm_memcpy_common on a plain
+    # hipMemcpy, roughly one process in sixty, so a full suite run reddens the
+    # lane far more often than that. Tracked as CHIP-SPV/chipStar#1594; delete
+    # these two entries when the PoCL side is fixed.
+    'Unit_Device_Complex_hipCfma_Device_Sanity_Positive - hipFloatComplex_ComplexTest': 'SEGFAULT in PoCL pocl_svm_memcpy_common, null dereference reached from hipMemcpy (#1594)'
+    'Unit_Device_Complex_hipCfma_Device_Sanity_Positive - hipDoubleComplex_ComplexTest': 'SEGFAULT in PoCL pocl_svm_memcpy_common, null dereference reached from hipMemcpy (#1594)'


### PR DESCRIPTION
Both `hipCfma` device sanity variants segfault inside PoCL's `pocl_svm_memcpy_common` on a plain `hipMemcpy`, about one process in sixty, which has reddened the macOS lane on three consecutive runs and blocks every pull request. The fault is a null dereference inside PoCL on input the OpenCL spec allows, not a chipStar call error. Issue #1594 carries the backtrace, the reproduction and the spec quote.

The mask is scoped to the `pastrami` host so the Linux PoCL lane still reports the test. Delete both entries when the PoCL fix lands.
