### PR TITLE
llvm_passes: lower vector-of-pointer loads and stores for SPIR-V

### DIFF
--- a/llvm_passes/CMakeLists.txt
+++ b/llvm_passes/CMakeLists.txt
@@ -119,6 +119,7 @@ add_library(LLVMHipPasses MODULE
     HipLowerFPAtomicMinMax.cpp
     HipLowerMemset.cpp
     HipLowerOverflowIntrinsics.cpp
+    HipLowerPointerVectors.cpp
     HipLowerRoundIntrinsics.cpp
     HipLowerSubwordAtomics.cpp
     HipLowerSwitch.cpp

--- a/llvm_passes/HipLowerPointerVectors.cpp
+++ b/llvm_passes/HipLowerPointerVectors.cpp
@@ -1,0 +1,205 @@
+//===- HipLowerPointerVectors.cpp -----------------------------------------===//
+//
+// Part of the chipStar Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// WORKAROUND(CHIP-SPV/chipStar#1577, llvm/llvm-project#217948): LLVM 23 forms
+// <N x ptr> values that no SPIR-V path accepts. SROA folds a struct of
+// pointers into a single vector-typed access, for example rocPRIM's
+// scan_state in test/rocprim/test_device_reduce_by_key.cpp:
+//
+//   %v = load <3 x ptr addrspace(4)>, ptr %scan_state, align 8
+//   store <3 x ptr addrspace(4)> %v, ptr %dst, align 32
+//
+// The in-tree SPIR-V backend aborts on an assertion in SPIRVEmitIntrinsics
+// (FixedVectorType::get rejects a pointer element type), and llvm-spirv
+// refuses the module unless SPV_INTEL_masked_gather_scatter is permitted.
+// That extension is not a portable answer: IGC 2.11.29 accepts it but IGC
+// 2.38.2 rejects it on bmg, dg2 and adl-s.
+//
+// Two independent facts, and only the second is new in LLVM 23: the backend
+// has never accepted <N x ptr>, reproducing on stock upstream 21, 22 and main
+// under `llc -mtriple=spirv64` (hence upstream's regression:21 label), and
+// LLVM 23 started forming the type for source that did not produce it before.
+//
+// A vector of integers, by contrast, is ordinary SPIR-V. This pass therefore
+// carries such values as an integer vector of the same element width, so the
+// pointer vector never exists by the time SPIR-V is emitted. Uses that need a
+// real pointer get it back with inttoptr, which the backend handles.
+//
+// The rewrite covers loads and stores, which is the whole of the copy pattern
+// SROA produces. A pointer vector reaching anything else is diagnosed rather
+// than passed through, so the gap is visible at the pass instead of surfacing
+// as an assertion inside SPIR-V emission.
+//
+// Remove this pass once the SPIR-V backend legalises <N x ptr> itself, or
+// once LLVM stops forming the type for SPIR-V targets. Removal conditions are
+// tracked in https://github.com/CHIP-SPV/chipStar/issues/1577; the original
+// report is https://github.com/CHIP-SPV/chipStar/issues/1454 and the upstream
+// bug is https://github.com/llvm/llvm-project/issues/217948.
+//
+// Copyright (c) 2026 chipStar developers
+//===----------------------------------------------------------------------===//
+
+#include "HipLowerPointerVectors.h"
+
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "llvm/ADT/SmallVector.h"
+
+#include <vector>
+
+#define DEBUG_TYPE "hip-lower-pointer-vectors"
+
+using namespace llvm;
+
+namespace {
+
+/// Returns the matching integer vector type for a vector of pointers, or
+/// nullptr if \p Ty is not one. <3 x ptr addrspace(4)> becomes <3 x i64> on a
+/// 64 bit target, so the value keeps its size and element count.
+static FixedVectorType *getIntVecTypeFor(Type *Ty, const DataLayout &DL) {
+  auto *VecTy = dyn_cast<FixedVectorType>(Ty);
+  if (!VecTy || !VecTy->getElementType()->isPointerTy())
+    return nullptr;
+  unsigned AS = VecTy->getElementType()->getPointerAddressSpace();
+  IntegerType *IntTy =
+      IntegerType::get(Ty->getContext(), DL.getPointerSizeInBits(AS));
+  return FixedVectorType::get(IntTy, VecTy->getNumElements());
+}
+
+/// Rewrites one load of a pointer vector into a load of an integer vector.
+/// Users that consume the value as a vector of pointers are served with a
+/// single inttoptr, so the pointer vector is confined to those users rather
+/// than reaching the load itself.
+static bool lowerLoad(LoadInst *LI, const DataLayout &DL) {
+  FixedVectorType *IntVecTy = getIntVecTypeFor(LI->getType(), DL);
+  if (!IntVecTy)
+    return false;
+
+  IRBuilder<> B(LI);
+  auto *NewLI = B.CreateAlignedLoad(IntVecTy, LI->getPointerOperand(),
+                                    LI->getAlign(), LI->isVolatile());
+  NewLI->copyMetadata(*LI);
+
+  // Only materialise a pointer vector again where something actually wants
+  // one. In the copy pattern this pass targets, the sole user is a store,
+  // which the store rewrite below turns into an integer store, leaving no
+  // pointer vector at all.
+  Value *AsPtrVec = B.CreateIntToPtr(NewLI, LI->getType());
+  LI->replaceAllUsesWith(AsPtrVec);
+  LI->eraseFromParent();
+  return true;
+}
+
+/// Rewrites one store of a pointer vector into a store of an integer vector.
+static bool lowerStore(StoreInst *SI, const DataLayout &DL) {
+  Value *Val = SI->getValueOperand();
+  FixedVectorType *IntVecTy = getIntVecTypeFor(Val->getType(), DL);
+  if (!IntVecTy)
+    return false;
+
+  IRBuilder<> B(SI);
+  // If the value came straight from a load this pass already rewrote, it is
+  // an inttoptr of the integer vector we want. Use that operand directly
+  // rather than adding a ptrtoint back: emitting the round trip would leave
+  // <N x ptr> as the type of the intermediate values, which is exactly what
+  // must not reach SPIR-V emission.
+  Value *AsInts = nullptr;
+  if (auto *ITP = dyn_cast<IntToPtrInst>(Val))
+    if (ITP->getOperand(0)->getType() == IntVecTy)
+      AsInts = ITP->getOperand(0);
+  if (!AsInts)
+    AsInts = B.CreatePtrToInt(Val, IntVecTy);
+  auto *NewSI = B.CreateAlignedStore(AsInts, SI->getPointerOperand(),
+                                     SI->getAlign(), SI->isVolatile());
+  NewSI->copyMetadata(*SI);
+  SI->eraseFromParent();
+  return true;
+}
+
+} // namespace
+
+PreservedAnalyses HipLowerPointerVectorsPass::run(Module &M,
+                                                  ModuleAnalysisManager &AM) {
+  const DataLayout &DL = M.getDataLayout();
+  bool Changed = false;
+
+  // Collect first: the rewrites erase instructions as they go.
+  std::vector<LoadInst *> Loads;
+  std::vector<StoreInst *> Stores;
+  for (Function &F : M)
+    for (BasicBlock &BB : F)
+      for (Instruction &I : BB) {
+        if (auto *LI = dyn_cast<LoadInst>(&I))
+          Loads.push_back(LI);
+        else if (auto *SI = dyn_cast<StoreInst>(&I))
+          Stores.push_back(SI);
+      }
+
+  // Loads first, so that by the time a store is rewritten its value operand
+  // is already the inttoptr this pass inserted and can be folded away.
+  for (LoadInst *LI : Loads)
+    Changed |= lowerLoad(LI, DL);
+  for (StoreInst *SI : Stores)
+    Changed |= lowerStore(SI, DL);
+
+  // Drop inttoptr values left with no users once the stores folded them out.
+  // Without this the pointer vector survives as the type of a dead value and
+  // still reaches the backend.
+  for (Function &F : M) {
+    SmallVector<Instruction *, 8> Dead;
+    for (BasicBlock &BB : F)
+      for (Instruction &I : BB)
+        if (isa<IntToPtrInst>(&I) && I.use_empty() &&
+            I.getType()->isVectorTy())
+          Dead.push_back(&I);
+    for (Instruction *I : Dead) {
+      I->eraseFromParent();
+      Changed = true;
+    }
+  }
+
+  // Only loads and stores are rewritten, which covers the copy pattern SROA
+  // produces. A pointer vector reaching any other instruction (extractelement,
+  // phi, select, a call argument) still cannot be emitted, so say so here
+  // instead of letting SPIR-V emission abort on an assertion that names
+  // neither this pass nor the issue it belongs to.
+  auto reportSurvivor = [&](const Function &F, const Instruction &I) {
+    std::string Msg;
+    raw_string_ostream OS(Msg);
+    OS << "HipLowerPointerVectors: a vector of pointers survives in '"
+       << F.getName() << "', which SPIR-V cannot represent:\n  " << I
+       << "\nOnly loads and stores of such vectors are lowered today. See "
+          "https://github.com/CHIP-SPV/chipStar/issues/1577";
+    report_fatal_error(StringRef(OS.str()), /*GenCrashDiag=*/false);
+  };
+
+  for (Function &F : M) {
+    // An argument of this type has no defining instruction to point at, so it
+    // is checked separately from the instruction walk below.
+    for (Argument &A : F.args())
+      if (getIntVecTypeFor(A.getType(), DL) && !F.empty())
+        reportSurvivor(F, *F.getEntryBlock().begin());
+    for (BasicBlock &BB : F)
+      for (Instruction &I : BB) {
+        if (getIntVecTypeFor(I.getType(), DL))
+          reportSurvivor(F, I);
+        for (const Use &U : I.operands())
+          if (getIntVecTypeFor(U->getType(), DL))
+            reportSurvivor(F, I);
+      }
+  }
+
+  LLVM_DEBUG(dbgs() << "HipLowerPointerVectors: changed=" << Changed << "\n");
+  return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
+}

--- a/llvm_passes/HipLowerPointerVectors.h
+++ b/llvm_passes/HipLowerPointerVectors.h
@@ -1,0 +1,38 @@
+//===- HipLowerPointerVectors.h -------------------------------------------===//
+//
+// Part of the chipStar Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// WORKAROUND(CHIP-SPV/chipStar#1577, llvm/llvm-project#217948): rewrites loads
+// and stores of <N x ptr> so no vector-of-pointer type reaches SPIR-V
+// emission.
+//
+// Remove this pass, its registration and its test once the SPIR-V backend
+// legalises <N x ptr> itself, or once LLVM stops forming that type for SPIR-V
+// targets. See https://github.com/CHIP-SPV/chipStar/issues/1577.
+//
+// Copyright (c) 2026 chipStar developers
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_PASSES_HIP_LOWER_POINTER_VECTORS_H
+#define LLVM_PASSES_HIP_LOWER_POINTER_VECTORS_H
+
+#include "llvm/IR/PassManager.h"
+
+using namespace llvm;
+
+#if LLVM_VERSION_MAJOR < 14
+#error LLVM 14+ required.
+#endif
+
+class HipLowerPointerVectorsPass
+    : public PassInfoMixin<HipLowerPointerVectorsPass> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  static bool isRequired() { return true; }
+};
+
+#endif

--- a/llvm_passes/HipPasses.cpp
+++ b/llvm_passes/HipPasses.cpp
@@ -37,6 +37,7 @@
 #include "HipFunctionPointerAS.h"
 #include "HipPromoteInts.h"
 #include "HipLowerOverflowIntrinsics.h"
+#include "HipLowerPointerVectors.h"
 #include "HipSpirvFunctionReorderPass.h"
 #include "HipVerify.h"
 #include "HipCanonicalizeGEP.h"
@@ -245,6 +246,15 @@ static void addFullLinkTimePasses(ModulePassManager &MPM) {
   addPassWithVerification(MPM, HipLowerOverflowIntrinsicsPass(),
                           "HipLowerOverflowIntrinsicsPass");
 
+  // WORKAROUND(CHIP-SPV/chipStar#1577, llvm/llvm-project#217948): LLVM 23's
+  // SROA folds a struct of pointers into <N x ptr>, which the in-tree backend
+  // asserts on and llvm-spirv will not translate without
+  // SPV_INTEL_masked_gather_scatter, an extension current IGC rejects. Carry
+  // such values as integer vectors instead. Remove once the SPIR-V path
+  // handles <N x ptr> itself.
+  addPassWithVerification(MPM, HipLowerPointerVectorsPass(),
+                          "HipLowerPointerVectorsPass");
+
   // Must be last: removes __chip_*/__hip_* globals and stubs their users.
   // Runs after HipIGBADetectorPass which creates __chip_module_has_no_IGBAs.
   addPassWithVerification(MPM, HipCleanupPass(), "HipCleanupPass");
@@ -294,6 +304,12 @@ llvmGetPassPluginInfo() {
                   // which makes it directly testable with opt.
                   if (Name == "hip-lower-overflow-intrinsics") {
                     MPM.addPass(HipLowerOverflowIntrinsicsPass());
+                    return true;
+                  }
+                  // Same for the pointer-vector lowering, so the workaround
+                  // in #1577 can be tested with opt directly.
+                  if (Name == "hip-lower-pointer-vectors") {
+                    MPM.addPass(HipLowerPointerVectorsPass());
                     return true;
                   }
                   // Register the 8 and 16 bit atomic lowering as standalone,

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -172,6 +172,10 @@ add_shell_test(TestPrintfStaticString.bash)
 # fails. This skips when the in-tree SPIR-V backend is used
 # (LLVM_SPIRV=NOT_NEEDED), since the patch targets the external translator.
 add_shell_test(TestSpirvDuplicatePhiHip.bash)
+add_shell_test(TestFix1577PointerVectors.bash)
+# Fails the day upstream stops rejecting <N x ptr>, which is the signal to
+# delete the hip-lower-pointer-vectors pass. Read its header before acting.
+add_shell_test(CanaryPointerVectorsRejected.bash)
 
 add_shell_test(TestTextureUnsupportedMixedDim.bash)
 

--- a/tests/compiler/CanaryPointerVectorsRejected.bash
+++ b/tests/compiler/CanaryPointerVectorsRejected.bash
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Canary for CHIP-SPV/chipStar#1577. THIS TEST IS MEANT TO FAIL EVENTUALLY.
+#
+# It asserts that the SPIR-V path still rejects a vector of pointers, which is
+# the only reason the hip-lower-pointer-vectors pass exists. When this test
+# goes red, upstream has fixed the gap: delete
+# llvm_passes/HipLowerPointerVectors.*, its registration in
+# llvm_passes/HipPasses.cpp and llvm_passes/CMakeLists.txt,
+# tests/compiler/TestFix1577PointerVectors.*, and this file, then close
+# https://github.com/CHIP-SPV/chipStar/issues/1577 naming the upstream fix.
+#
+# It probes the compiler directly rather than through chipStar, so a failure
+# points at the toolchain and nothing else. The upstream bug is
+# https://github.com/llvm/llvm-project/issues/217948. It deliberately does NOT go red
+# when the chipStar pass is reverted; that is the regression test's job.
+#
+# Two things make the assertion real rather than incidental:
+#   - an availability control runs first, so "the tool could not start" can
+#     never be read as "the tool rejected our module";
+#   - the rejection must carry the known signature, so an unrelated failure
+#     fails the test instead of quietly satisfying it.
+#
+# Known gap: #1577 lists a second removal condition, LLVM ceasing to form
+# <N x ptr> for this pattern. This fixture writes the type by hand, so it
+# cannot observe that; only the emitter-side condition is covered here.
+set -eu
+
+SRC_DIR="@CMAKE_CURRENT_SOURCE_DIR@"
+CLANG="@LLVM_TOOLS_BINARY_DIR@/clang"
+LLVM_AS="@LLVM_TOOLS_BINARY_DIR@/llvm-as"
+LLVM_SPIRV="@LLVM_SPIRV@"
+OUT="@CMAKE_CURRENT_BINARY_DIR@/@TEST_NAME@.d"
+
+[ -x "${CLANG}" ] || { echo "clang not found at ${CLANG}; skipping"; exit 0; }
+
+rm -rf "${OUT}"; mkdir -p "${OUT}"; cd "${OUT}"
+
+CHECKED=0
+
+# --- in-tree SPIR-V backend -------------------------------------------------
+# Control: can this toolchain emit SPIR-V at all? A module valid for any target,
+# so a failure here means the target is missing, not that the module was bad.
+printf 'define void @probe() {\nentry:\n  ret void\n}\n' > probe.ll
+if "${CLANG}" -cc1 -triple spirv64v1.3-unknown-chipstar -emit-obj \
+        probe.ll -o probe.img > probe.log 2>&1; then
+  # The shell prints "Aborted" for the expected crash below. That line is the
+  # evidence the canary really ran, so it is announced rather than hidden: a
+  # silenced canary is indistinguishable from one that did nothing.
+  echo "canary: emitting the unlowered module, an abort here is expected today"
+  if "${CLANG}" -cc1 -triple spirv64v1.3-unknown-chipstar -emit-obj \
+          "${SRC_DIR}/TestFix1577PointerVectors.ll" -o canary.img > canary.log 2>&1; then
+    echo "CANARY FIRED: the SPIR-V backend now emits <N x ptr> without help."
+    echo "  The hip-lower-pointer-vectors workaround is obsolete."
+    echo "  Delete the pass, its registration, TestFix1577PointerVectors and this"
+    echo "  test, and close https://github.com/CHIP-SPV/chipStar/issues/1577"
+    exit 1
+  fi
+  if ! grep -qiE "isValidElementType|[Vv]ector of pointers|masked_gather_scatter" canary.log; then
+    echo "FAIL: the backend rejected the module, but not for the reason this canary tracks."
+    echo "      Expected isValidElementType / vector of pointers / masked_gather_scatter."
+    head -5 canary.log
+    exit 1
+  fi
+  echo "canary: backend still rejects <N x ptr>, so the workaround is still needed"
+  grep -iE "isValidElementType|[Vv]ector of pointers|masked_gather_scatter" canary.log | head -1
+  CHECKED=$((CHECKED + 1))
+else
+  echo "note: no in-tree SPIR-V backend in this toolchain, skipping that half"
+fi
+
+# --- external translator ----------------------------------------------------
+if [ "${LLVM_SPIRV}" != "NOT_NEEDED" ] && [ -x "${LLVM_SPIRV}" ] \
+        && [ -x "${LLVM_AS}" ]; then
+  # llvm-spirv reads bitcode, not textual IR, so assemble the fixture first.
+  "${LLVM_AS}" "${SRC_DIR}/TestFix1577PointerVectors.ll" -o canary-in.bc
+  EXTS="-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups"
+  EXTS="${EXTS},+SPV_KHR_bit_instructions,+SPV_EXT_shader_atomic_float_add"
+  if "${LLVM_SPIRV}" "--spirv-ext=${EXTS}" canary-in.bc -o canary.spv \
+          > canary-tr.log 2>&1; then
+    echo "CANARY FIRED: llvm-spirv now translates <N x ptr> without the extension."
+    echo "  The hip-lower-pointer-vectors workaround is obsolete."
+    echo "  Delete the pass, its registration, TestFix1577PointerVectors and this"
+    echo "  test, and close https://github.com/CHIP-SPV/chipStar/issues/1577"
+    exit 1
+  fi
+  if ! grep -qiE "masked_gather_scatter|RequiresExtension" canary-tr.log; then
+    echo "FAIL: llvm-spirv failed, but not for the reason this canary tracks."
+    echo "      Expected masked_gather_scatter / RequiresExtension."
+    head -5 canary-tr.log
+    exit 1
+  fi
+  echo "canary: llvm-spirv still demands SPV_INTEL_masked_gather_scatter"
+  grep -iE "masked_gather_scatter|RequiresExtension" canary-tr.log | head -1
+  CHECKED=$((CHECKED + 1))
+fi
+
+if [ "${CHECKED}" -eq 0 ]; then
+  echo "FAIL: no SPIR-V emitter was available, so this canary checked nothing."
+  echo "      A canary that cannot observe the bug must not report success."
+  exit 1
+fi
+
+echo "PASSED"

--- a/tests/compiler/TestFix1577PointerVectors.bash
+++ b/tests/compiler/TestFix1577PointerVectors.bash
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Regression test for CHIP-SPV/chipStar#1577.
+#
+# WORKAROUND(CHIP-SPV/chipStar#1577, llvm/llvm-project#217948): guards the
+# hip-lower-pointer-vectors
+# pass, which exists only because neither SPIR-V path can consume a vector of
+# pointers. Delete this test together with the pass once the SPIR-V backend
+# legalises <N x ptr> itself, or once LLVM stops forming that type for SPIR-V
+# targets. See https://github.com/CHIP-SPV/chipStar/issues/1577.
+#
+# The test runs the real chipStar pipeline and then real SPIR-V emission, so
+# without the pass it fails the way the issue reports: the in-tree backend
+# aborts inside SPIRVEmitIntrinsics, and llvm-spirv refuses the module for
+# want of SPV_INTEL_masked_gather_scatter.
+#
+# chipStar supports translator-only toolchains (scripts/configure_llvm.sh
+# builds LLVM_TARGETS="host" for those), so the backend half is checked only
+# where the SPIR-V target exists. At least one emitter must be exercised: a
+# run that checks neither is a pass that proves nothing, and fails instead.
+set -eu
+
+SRC_DIR="@CMAKE_CURRENT_SOURCE_DIR@"
+OPT="@LLVM_TOOLS_BINARY_DIR@/opt"
+CLANG="@LLVM_TOOLS_BINARY_DIR@/clang"
+LLVM_SPIRV="@LLVM_SPIRV@"
+PLUGIN="@CMAKE_BINARY_DIR@/lib/libLLVMHipSpvPasses.so"
+OUT="@CMAKE_CURRENT_BINARY_DIR@/@TEST_NAME@.d"
+
+[ -x "${OPT}" ] || { echo "opt not found at ${OPT}; skipping"; exit 0; }
+[ -f "${PLUGIN}" ] || { echo "pass plugin not built; skipping"; exit 0; }
+
+rm -rf "${OUT}"; mkdir -p "${OUT}"; cd "${OUT}"
+
+# Does this toolchain have the in-tree SPIR-V backend at all? Probe it with a
+# module that is valid for any target, so a failure can only mean the target
+# is missing, never that the module was rejected.
+printf 'define void @probe() {\nentry:\n  ret void\n}\n' > probe.ll
+if "${CLANG}" -cc1 -triple spirv64v1.3-unknown-chipstar -emit-obj \
+        probe.ll -o probe.img > probe.log 2>&1; then
+  HAVE_BACKEND=1
+else
+  HAVE_BACKEND=0
+  echo "note: no in-tree SPIR-V backend in this toolchain, skipping that half"
+  grep -iE "unable to create target" probe.log | head -1 || true
+fi
+
+HAVE_TRANSLATOR=0
+if [ "${LLVM_SPIRV}" != "NOT_NEEDED" ] && [ -x "${LLVM_SPIRV}" ]; then
+  HAVE_TRANSLATOR=1
+fi
+
+if [ "${HAVE_BACKEND}" -eq 0 ] && [ "${HAVE_TRANSLATOR}" -eq 0 ]; then
+  echo "FAIL: neither the in-tree SPIR-V backend nor llvm-spirv is available,"
+  echo "      so this test would prove nothing. Check the toolchain configuration."
+  exit 1
+fi
+
+# Run the pipeline chipStar actually uses before SPIR-V emission. This is
+# deliberately the whole pipeline and not the individual pass, so the test
+# reproduces the reported failure rather than merely asserting that some
+# named pass exists.
+"${OPT}" -load-pass-plugin "${PLUGIN}" -passes=hip-post-link-passes \
+    "${SRC_DIR}/TestFix1577PointerVectors.ll" -o lowered.bc
+
+# 1. The in-tree SPIR-V backend. Without the lowering this aborts with
+#    "Assertion `isValidElementType(ElementType)' failed" in the
+#    'SPIRV emit intrinsics' pass.
+if [ "${HAVE_BACKEND}" -eq 1 ]; then
+  if ! "${CLANG}" -cc1 -triple spirv64v1.3-unknown-chipstar -emit-obj \
+          lowered.bc -o backend.img > backend.log 2>&1; then
+    echo "FAIL: the in-tree SPIR-V backend could not emit a module holding a vector of pointers"
+    grep -iE "Assertion|error:|Running pass" backend.log | head -4
+    exit 1
+  fi
+  echo "checked: in-tree SPIR-V backend emitted the lowered module"
+fi
+
+# 2. The external translator, using the extension set chipStar permits.
+#    Without the lowering this stops at
+#    "RequiresExtension: ... SPV_INTEL_masked_gather_scatter".
+if [ "${HAVE_TRANSLATOR}" -eq 1 ]; then
+  EXTS="-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups"
+  EXTS="${EXTS},+SPV_KHR_bit_instructions,+SPV_EXT_shader_atomic_float_add"
+  if ! "${LLVM_SPIRV}" "--spirv-ext=${EXTS}" lowered.bc -o translated.spv \
+          > translate.log 2>&1; then
+    echo "FAIL: llvm-spirv could not translate a module holding a vector of pointers"
+    head -3 translate.log
+    exit 1
+  fi
+  echo "checked: llvm-spirv translated the lowered module"
+fi
+
+# 3. A pointer vector the rewrite cannot remove must be reported by this pass,
+#    naming the issue, instead of reaching SPIR-V emission and aborting there.
+if "${OPT}" -load-pass-plugin "${PLUGIN}" -passes=hip-post-link-passes \
+        "${SRC_DIR}/TestFix1577PointerVectorsUnsupported.ll" -o unsupported.bc \
+        > unsupported.log 2>&1; then
+  echo "FAIL: a pointer vector that cannot be lowered passed through silently."
+  echo "      It would abort later inside SPIR-V emission instead."
+  exit 1
+fi
+if ! grep -q "HipLowerPointerVectors: a vector of pointers survives" unsupported.log; then
+  echo "FAIL: the unsupported case failed, but without the diagnostic that names it."
+  head -5 unsupported.log
+  exit 1
+fi
+echo "checked: an unlowerable pointer vector is diagnosed by name"
+grep -m1 "chipStar/issues/1577" unsupported.log || true
+
+echo "PASSED"

--- a/tests/compiler/TestFix1577PointerVectors.ll
+++ b/tests/compiler/TestFix1577PointerVectors.ll
@@ -1,0 +1,20 @@
+; Reproducer for CHIP-SPV/chipStar#1577.
+;
+; LLVM 23's SROA folds a struct of pointers into a vector of pointers. This is
+; the shape it produces for rocPRIM's scan_state in
+; test/rocprim/test_device_reduce_by_key.cpp, reduced to the load/store pair:
+; the value is only copied, never dereferenced as a vector.
+;
+; Neither SPIR-V path accepts <N x ptr>. The in-tree backend asserts in
+; SPIRVEmitIntrinsics, and llvm-spirv demands SPV_INTEL_masked_gather_scatter,
+; which IGC 2.38.2 then refuses. hip-lower-pointer-vectors must rewrite these
+; so no vector-of-pointer type survives.
+
+target triple = "spirv64"
+
+define spir_kernel void @copy_ptr_vec(ptr %src, ptr %dst) {
+entry:
+  %v = load <3 x ptr addrspace(4)>, ptr %src, align 8
+  store <3 x ptr addrspace(4)> %v, ptr %dst, align 32
+  ret void
+}

--- a/tests/compiler/TestFix1577PointerVectorsUnsupported.ll
+++ b/tests/compiler/TestFix1577PointerVectorsUnsupported.ll
@@ -1,0 +1,17 @@
+; Companion to TestFix1577PointerVectors.ll for CHIP-SPV/chipStar#1577.
+;
+; Here the pointer vector is not merely copied, it is taken apart with
+; extractelement, so the load/store rewrite cannot remove it. SPIR-V still
+; cannot represent the value, and hip-lower-pointer-vectors is expected to say
+; so by name rather than let SPIR-V emission abort on an assertion.
+
+target triple = "spirv64"
+
+define spir_kernel void @use_ptr_vec(ptr %src, ptr %out) {
+entry:
+  %v = load <3 x ptr addrspace(4)>, ptr %src, align 8
+  %p = extractelement <3 x ptr addrspace(4)> %v, i32 0
+  %x = load i32, ptr addrspace(4) %p, align 4
+  store i32 %x, ptr %out, align 4
+  ret void
+}


### PR DESCRIPTION
LLVM 23's SROA folds structs of pointers into `<N x ptr>` values, which neither SPIR-V emitter accepts: the in-tree backend asserts in `SPIRVEmitIntrinsics`, and `llvm-spirv` needs `SPV_INTEL_masked_gather_scatter`, which IGC 2.38.2 rejects on bmg, dg2 and adl-s. This adds a chipStar pass that rewrites those loads and stores to carry the values as integer vectors, which is ordinary SPIR-V and needs no extension. A pointer vector reaching anything other than a load or store is diagnosed by name rather than passed through to fail later inside SPIR-V emission.

Temporary workaround. It comes out when the SPIR-V backend legalises these itself, or LLVM stops forming vector-of-pointer types for this pattern on SPIR-V targets; removal conditions are tracked in https://github.com/CHIP-SPV/chipStar/issues/1577, which the `WORKAROUND` markers reference. The extension route was tried and abandoned in https://github.com/CHIP-SPV/chipStar/pull/1570.

`CanaryPointerVectorsRejected` asserts both emitters still reject `<N x ptr>`, so it goes red the day upstream fixes this and the pass can be deleted. It covers only the emitter-side removal condition; it cannot observe LLVM ceasing to form the type, since the fixture writes it by hand.

Fixes #1454