### PR TITLE
Fix the four pre-existing failures on the ARM64 Mali lane

### DIFF
--- a/scripts/cross-aarch64/README.md
+++ b/scripts/cross-aarch64/README.md
@@ -122,6 +122,19 @@ command shape in `CTestTestfile.cmake`, not by name, so a new test is
 classified by what it does. On the last measurement 164 of 260 tests
 survive the cut and 110 of those run (the rest skip for fp64); all pass.
 
+A test can also reach the compiler without its ctest command showing it, by
+calling hipRTC from inside the process, and those look exactly like a plain
+prebuilt binary. They are classified the same way, by behaviour rather than
+by name: a binary whose dynamic symbols import `hiprtc*` compiles at run
+time, so it is dropped too. What the target loses by that is narrow and
+deliberate, the device execution of a kernel hipRTC produced; the
+compilation itself is host side and is covered on the x86 gate. Before this
+rule the hipRTC tests shipped and failed on salami with `hipcc: not found`,
+which is issue
+[#1602](https://github.com/CHIP-SPV/chipStar/issues/1602): the tree's
+`bin/hipcc` is a wrapper whose exec target is the builder container's path,
+and `bin/hipcc.bin` behind it is x86, so no `PATH` change could have helped.
+
 Two things in chipStar are worked around here rather than fixed, and
 should be fixed there:
 

--- a/scripts/cross-aarch64/ship-to-salami.sh
+++ b/scripts/cross-aarch64/ship-to-salami.sh
@@ -14,9 +14,23 @@
 #      with a working hipcc. Keep only tests that execute a prebuilt binary,
 #      identified by their command shape rather than by name so a new test
 #      is classified by what it does.
+#      A test can also reach the compiler without its ctest command showing
+#      it, by calling hipRTC in process, and those look exactly like a plain
+#      prebuilt binary. They are classified the same way, by behaviour: a
+#      binary that imports a hiprtc* symbol compiles at run time, so it is
+#      dropped too. What that costs the target is the device execution of a
+#      kernel hipRTC produced; the compilation itself is host side and is
+#      covered on the x86 gate.
 #   3. .o files and CMakeFiles are build intermediates; leave them behind.
 set -e
 BUILD="${1:?build dir}"; SHA="${2:?sha}"; HOST="${3:-salami}"
+# The ELF reader used to classify test binaries. Named here rather than looked
+# up inside the filter so the tool this depends on is visible at the top, and
+# overridable when binutils lives somewhere else.
+case "${READELF:=/usr/bin/readelf}" in
+  /*) ;;
+  *) echo "ship-to-salami: READELF must be an absolute path, got '$READELF'" >&2; exit 1 ;;
+esac
 PREFIX="/home/pvelesko/ci-stage/$SHA"
 # The paths baked into the tree are the CONTAINER's view of the build dir
 # (/work/cross-<sha>), not this host's mount of it, so read them from the
@@ -37,12 +51,55 @@ grep -rl "$SRC_PREFIX" "$STAGE" --include=CTestTestfile.cmake \
 # 2. keep only tests that run a prebuilt binary through the doubles wrapper
 #    (or a bare binary under tests/ or samples/). Everything else is a
 #    toolchain invocation and is dropped from the target's test set.
-python3 - "$STAGE" "$PREFIX" <<'PY'
-import re, sys, pathlib
-stage, prefix = sys.argv[1], sys.argv[2]
+python3 - "$STAGE" "$PREFIX" "$READELF" <<'PY'
+import re, subprocess, sys, pathlib
+stage, prefix, readelf = sys.argv[1], sys.argv[2], sys.argv[3]
 keep_re = re.compile(
     r'^add_test\(\[=\[([^\]]+)\]=\] "(?:%s/bin/spirv-extractor" "--check-for-doubles" ")?%s/(?:tests|samples)/[^"]+"' % (re.escape(prefix), re.escape(prefix)))
-kept = dropped = 0
+# The FIRST argument under the target prefix is the test executable. The
+# doubles wrapper that may precede it lives under <prefix>/bin, which this does
+# not match, and anything after the executable is its own argument, which may
+# well be an input file under tests/.
+bin_re = re.compile(r'"(%s/(?:tests|samples)/[^"]+)"' % re.escape(prefix))
+
+def imports_hiprtc(binary):
+    """True when the binary imports a hipRTC entry point, so it compiles when
+    it runs.
+
+    readelf rather than nm: it reads the ELF's own tables, so it works on the
+    aarch64 binaries from the x86 builder whatever targets the local binutils
+    was configured for. Undefined symbols only: a binary that merely defines
+    something with hiprtc in the name does not call the runtime compiler."""
+    out = subprocess.run([readelf, "-sW", "--dyn-syms", str(binary)],
+                         capture_output=True, text=True, timeout=120)
+    if out.returncode != 0:
+        raise RuntimeError("readelf failed on %s: %s"
+                           % (binary, out.stderr.strip()[:200]))
+    for ln in out.stdout.splitlines():
+        f = ln.split()
+        # Num: Value Size Type Bind Vis Ndx Name
+        # The name may carry a version suffix, as in hiprtcVersion@@HIP_1.0.
+        if len(f) >= 8 and f[6] == "UND" and \
+           f[7].split("@")[0].startswith("hiprtc"):
+            return True
+    return False
+
+def compiles_at_runtime(line):
+    """True when this add_test line runs a binary that compiles at run time.
+
+    Raises rather than returning False when the question cannot be answered:
+    silently keeping a test would ship exactly what this filter exists to keep
+    off the target."""
+    m = bin_re.findall(line)
+    if not m:
+        return False
+    staged = pathlib.Path(stage) / pathlib.Path(m[0]).relative_to(prefix)
+    # No existence probe: readelf raises if the binary is not there, and that
+    # propagates, because shipping a test set this filter could not classify is
+    # the failure it exists to prevent.
+    return imports_hiprtc(staged)
+
+kept = dropped = dropped_rtc = 0
 for f in pathlib.Path(stage).rglob('CTestTestfile.cmake'):
     out = []
     lines = f.read_text().splitlines()
@@ -51,7 +108,11 @@ for f in pathlib.Path(stage).rglob('CTestTestfile.cmake'):
         l = lines[i]
         if l.startswith('add_test('):
             name = re.match(r'add_test\(\[=\[([^\]]+)\]=\]', l).group(1)
-            if keep_re.match(l):
+            if keep_re.match(l) and compiles_at_runtime(l):
+                dropped += 1; dropped_rtc += 1
+                while i + 1 < len(lines) and lines[i+1].startswith('set_tests_properties('):
+                    i += 1
+            elif keep_re.match(l):
                 out.append(l); kept += 1
                 # keep its set_tests_properties line(s)
                 while i + 1 < len(lines) and lines[i+1].startswith('set_tests_properties('):
@@ -64,7 +125,7 @@ for f in pathlib.Path(stage).rglob('CTestTestfile.cmake'):
             out.append(l)
         i += 1
     f.write_text('\n'.join(out) + '\n')
-print(f"tests kept={kept} dropped(toolchain-invoking)={dropped}")
+print(f"tests kept={kept} dropped(toolchain-invoking)={dropped} of which runtime-compiling={dropped_rtc}")
 PY
 
 # 3. ship, plus the source tree the surviving tests reference (test inputs)

--- a/tests/benchmarks/CMakeLists.txt
+++ b/tests/benchmarks/CMakeLists.txt
@@ -51,3 +51,8 @@ set_tests_properties(
   hostRegisterOverhead
   hostRegisterMemcpyOverhead
   PROPERTIES RUN_SERIAL ON)
+
+# manyMallocMemcopies opts out where its measurement cannot speak about
+# chipStar; without this the opt-out reads as a silent pass.
+set_tests_properties(manyMallocMemcopies PROPERTIES
+  SKIP_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST")

--- a/tests/benchmarks/manyMallocMemcopies.hip
+++ b/tests/benchmarks/manyMallocMemcopies.hip
@@ -1,8 +1,48 @@
 #include <hip/hip_runtime.h>
+#include <hip/hip_interop.h>
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
 #include <vector>
+
+// This benchmark guards a chipStar property: that chipStar does not scan its
+// own allocation list on the copy path. It measures total hipMemcpy time,
+// which is only a proxy for that, and the proxy breaks where the vendor driver
+// itself scans a list of live allocations per copy. chipStar hands one
+// clSVMAlloc to the driver per hipMalloc when coarse-grain SVM is the strategy
+// in use, and on Mali-G52 that makes a 192 byte copy cost 1.3 ms once 15000
+// allocations are live, all of it inside libmali. See
+// https://github.com/CHIP-SPV/chipStar/issues/1322.
+//
+// So skip where the measurement cannot speak about chipStar. Ask the runtime
+// which strategy it settled on rather than reconstructing that from device
+// capabilities: the selection also depends on how chipStar was built and on
+// CHIP_OCL_USE_ALLOC_STRATEGY, and a reconstruction has to track every one of
+// those rules to stay true.
+// HAVE_OPENCL, not __has_include: the header is on the include path of every
+// build, since this target inherits CHIP's own include directories, but the
+// backend it declares is compiled only when CMake enabled it. Guarding on the
+// header would put a dynamic_cast to CHIPContextOpenCL into a Level Zero only
+// build, whose RTTI is not there to link against. src/backend/backends.hh
+// gates on the same flag.
+#include <chipStarConfig.hh>
+#ifdef HAVE_OPENCL
+#include "backend/OpenCL/CHIPBackendOpenCL.hh"
+#endif
+
+// True when every hipMalloc becomes one allocation the driver tracks itself.
+static bool allocationsAreCoarseGrainSVM() {
+#ifdef HAVE_OPENCL
+  // Only meaningful once the runtime has initialised and chosen a strategy.
+  if (hipFree(nullptr) != hipSuccess)
+    return false;
+  auto *Ctx = dynamic_cast<CHIPContextOpenCL *>(
+      Backend->getActiveDevice()->getContext());
+  return Ctx && Ctx->getAllocStrategy() == AllocationStrategy::CoarseGrainSVM;
+#else
+  return false; // no OpenCL backend compiled in, so no coarse-grain SVM path
+#endif
+}
 
 #define CHECK(cmd)                                                        \
     do {                                                                  \
@@ -15,6 +55,14 @@
     } while (0)
 
 int main() {
+    if (allocationsAreCoarseGrainSVM()) {
+        printf("HIP_SKIP_THIS_TEST: this build allocates through coarse-grained "
+               "SVM, so every allocation is one the vendor driver tracks itself "
+               "and the copy time measured here is not chipStar's to hold flat "
+               "(chipStar issue #1322)\n");
+        return 0;
+    }
+
     const int    ITERS     = 15000;
     const size_t BUF_SIZE  = 192;
     double samples[ITERS];

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -76,6 +76,7 @@ set(RUNTIME_TESTS_MANUAL
   TestFix1393ExitDuringModuleBuild.hip # run under an interposer by a driver script
   TestFix1543SwitchModeEventLeak.hip # run under an interposer by a driver script
   TestFixFunctionLocalStaticDeviceVar.hip # multi-TU, second TU under inputs/
+  TestFix1601ExtractorMultiTUDoubles.hip # multi-TU, compiled by its .bash, not a test
   TestFixLlvmUsedAddrspace.hip    # not registered as a test
   TestModuleCacheInvalidation.hip # run several times through a driver script
   TestStreamWaitEventOrdering.cpp # not registered as a test
@@ -132,6 +133,41 @@ endif()
 # as a C string). Runs TestKernelArgs and inspects its stderr; only meaningful
 # for the build log path on the Level Zero backend.
 add_shell_test(TestFixZeBuildLogNul.bash)
+
+# spirv-extractor --check-for-doubles must see every device module in a binary,
+# not just the first, or a multi-TU test runs on a device without fp64.
+add_shell_test(TestFix1601ExtractorMultiTUDoubles.bash)
+
+# The same defect, asserted where the wrapper actually runs. The shell test
+# above cannot ship to the cross-staged aarch64 target, which takes no shell
+# tests at all, so build the two translation units into a fixture and register
+# THAT under the doubles wrapper: the fixture exits non-zero if it is ever
+# executed, so ctest goes red exactly when the wrapper fails to look past the
+# first device module, and reports a skip when it does. Only meaningful where
+# the wrapper is in use.
+if(CHIP_SKIP_TESTS_WITH_DOUBLES)
+  set_source_files_properties(
+    TestFix1601ExtractorMultiTUDoubles.hip
+    inputs/ExtractorMultiTUDoublesTU2.hip PROPERTIES LANGUAGE CXX)
+  add_executable(TestFix1601MultiTUDoublesFixture
+    TestFix1601ExtractorMultiTUDoubles.hip
+    inputs/ExtractorMultiTUDoublesTU2.hip)
+  set_target_properties(TestFix1601MultiTUDoublesFixture PROPERTIES
+    CXX_STANDARD_REQUIRED ON)
+  target_link_libraries(TestFix1601MultiTUDoublesFixture CHIP deviceInternal)
+  add_test(NAME TestFix1601MultiTUDoublesSkipped
+    COMMAND ${SKIP_DOUBLE_TESTS}
+            ${CMAKE_CURRENT_BINARY_DIR}/TestFix1601MultiTUDoublesFixture)
+  # Assert the wrapper's OUTPUT, not its exit status. On a tree without the fix
+  # for CHIP-SPV/chipStar#1592 the wrapper returns system()'s raw wait status
+  # from main(), which keeps only the low 8 bits, and every child outcome maps
+  # to 0 there: an exit code E arrives as E<<8, and a signal death arrives as
+  # the shell's own 128+signal, likewise shifted. So an exit-status gate cannot
+  # fail on such a tree, while a missing marker still can.
+  set_tests_properties(TestFix1601MultiTUDoublesSkipped PROPERTIES
+    PASS_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST: Kernel uses doubles"
+    SKIP_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST: Kernel uses doubles")
+endif()
 
 add_shell_test(../run_testenvvars.sh)
 set_tests_properties(run_testenvvars PROPERTIES

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -57,6 +57,10 @@ function(add_shell_test SCRIPT)
   configure_file(${SCRIPT} ${SCRIPT} @ONLY)
   add_test(NAME ${TEST_NAME}
     COMMAND /bin/bash ${CMAKE_CURRENT_BINARY_DIR}/${SCRIPT})
+  # Without this a script that prints the skip marker is reported as a pass,
+  # so an unsupported configuration is indistinguishable from a tested one.
+  set_tests_properties(${TEST_NAME} PROPERTIES
+    SKIP_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST")
 endfunction()
 
 # Tests are registered by globbing Test*.hip and Test*.cpp, so adding one is a

--- a/tests/runtime/TestFix1601ExtractorMultiTUDoubles.bash
+++ b/tests/runtime/TestFix1601ExtractorMultiTUDoubles.bash
@@ -1,0 +1,51 @@
+#!/bin/bash
+# spirv-extractor --check-for-doubles must find fp64 in ANY device module of a
+# binary, not just the first. It walked to the first __CLANG_OFFLOAD_BUNDLE__ in
+# .hip_fatbin and stopped, so a multi-TU binary whose doubles live in a later
+# translation unit was reported as double-free and ran anyway. On a device
+# without fp64 that surfaces as a build failure rather than a skip, which is how
+# cuda-reduction failed on Mali-G52 (chipStar issue #1601).
+#
+# The link order is the whole point: the fp64 TU goes second.
+set -u
+HIPCC="@CMAKE_BINARY_DIR@/bin/hipcc"
+EXTRACTOR="@CMAKE_BINARY_DIR@/bin/spirv-extractor"
+SRC1="@CMAKE_CURRENT_SOURCE_DIR@/TestFix1601ExtractorMultiTUDoubles.hip"
+SRC2="@CMAKE_CURRENT_SOURCE_DIR@/inputs/ExtractorMultiTUDoublesTU2.hip"
+OUT="@CMAKE_CURRENT_BINARY_DIR@/@TEST_NAME@.d"
+
+if [ ! -x "${EXTRACTOR}" ]; then
+  # tools/spirv-extractor is built unconditionally, so its absence means a
+  # broken build rather than an unsupported configuration.
+  echo "FAIL: spirv-extractor was not built at ${EXTRACTOR}"
+  exit 1
+fi
+rm -rf "${OUT}"; mkdir -p "${OUT}"; cd "${OUT}" || exit 1
+"${HIPCC}" -O1 -c "${SRC1}" -o tu1.o > build.log 2>&1 || { echo "FAIL: could not build TU1"; tail -5 build.log; exit 1; }
+"${HIPCC}" -O1 -c "${SRC2}" -o tu2.o >> build.log 2>&1 || { echo "FAIL: could not build TU2"; tail -5 build.log; exit 1; }
+"${HIPCC}" tu1.o tu2.o -o twotu >> build.log 2>&1 || { echo "FAIL: could not link"; tail -5 build.log; exit 1; }
+
+# -o then count lines: grep -c counts matching LINES, and two bundle markers
+# can share one line of a binary, which would undercount to 1 and let the test
+# conclude the multi-module case was unbuildable when it was not.
+BUNDLES=$(grep -a -o "__CLANG_OFFLOAD_BUNDLE__" twotu 2>/dev/null | wc -l)
+echo "offload bundles in the binary: ${BUNDLES}"
+if [ "${BUNDLES}" -lt 2 ]; then
+  echo "HIP_SKIP_THIS_TEST: this toolchain emitted ${BUNDLES} bundle(s), so the multi-module case cannot be built here"
+  exit 0
+fi
+
+OUTPUT=$("${EXTRACTOR}" --check-for-doubles ./twotu 2>&1)
+# Never echo the extractor's output verbatim: it contains the skip marker this
+# test is looking FOR, and ctest would read it off this script's own stdout and
+# call the test skipped.
+if echo "${OUTPUT}" | grep -q "HIP_SKIP_THIS_TEST: Kernel uses doubles"; then
+  echo "extractor skipped the binary, as it must"
+  echo "PASSED"
+  exit 0
+fi
+echo "FAIL: --check-for-doubles missed the fp64 kernel in the second translation unit"
+echo "      and ran the program instead of skipping it (issue #1601)"
+echo "--- extractor output, marker redacted so ctest does not read it as a skip:"
+echo "${OUTPUT}" | grep -v "driver name\|pci id" | sed "s/HIP_SKIP_THIS_TEST/<skip-marker>/"
+exit 1

--- a/tests/runtime/TestFix1601ExtractorMultiTUDoubles.hip
+++ b/tests/runtime/TestFix1601ExtractorMultiTUDoubles.hip
@@ -1,0 +1,24 @@
+// First translation unit of the reproducer for chipStar issue #1601.
+// Holds only a single-precision kernel, so the device module built from this
+// TU carries no OpTypeFloat 64. The double kernel lives in the second TU,
+// inputs/ExtractorMultiTUDoublesTU2.hip, and the .bash links this one first so
+// the doubles land in the SECOND __CLANG_OFFLOAD_BUNDLE__ of the fatbinary.
+//
+// spirv-extractor --check-for-doubles stopped at the first bundle, so it
+// reported no doubles and let the test run on a device without fp64. Compiled
+// by TestFix1601ExtractorMultiTUDoubles.bash; not a ctest itself (see
+// RUNTIME_TESTS_MANUAL).
+#include <hip/hip_runtime.h>
+#include <cstdio>
+
+__global__ void kFloat(float *P) { *P = 1.0f; }
+
+int main() {
+  // Never launched, and never meant to run at all: --check-for-doubles is
+  // supposed to skip this binary before it starts. The ctest entry asserts the
+  // wrapper's OUTPUT rather than its exit status, so reaching here fails that
+  // entry by the absence of the skip marker, whatever this returns.
+  printf("FAILED: this binary ran, so the fp64 kernel in the second "
+         "translation unit was not detected\n");
+  return 1;
+}

--- a/tests/runtime/inputs/ExtractorMultiTUDoublesTU2.hip
+++ b/tests/runtime/inputs/ExtractorMultiTUDoublesTU2.hip
@@ -1,0 +1,6 @@
+// Second translation unit for TestFix1601ExtractorMultiTUDoubles: the double
+// kernel, and the only fp64 in the binary. Its device module becomes the
+// second bundle of the fatbinary.
+#include <hip/hip_runtime.h>
+
+__global__ void kDouble(double *P) { *P = 2.0; }

--- a/tools/spirv-extractor/spirv-extractor.cc
+++ b/tools/spirv-extractor/spirv-extractor.cc
@@ -110,6 +110,35 @@ int main(int argc, char *argv[]) {
   auto spirvText = disassembleSPIRV(spirvBinary);
   bool hasDoubles = usesDoubles(spirvText);
 
+  // A linked executable holds one offload bundle per translation unit, and any
+  // one of them can be the one carrying fp64. spirvBinary above is only the
+  // first, which is all the other modes need, so widen the doubles answer to
+  // every module before it decides whether a test can run.
+  if (checkForDoubles && !hasDoubles) {
+    const char *BufEnd = buffer.data() + buffer.size();
+    for (const void *Bundle :
+         collectOffloadBundles(buffer.data(), buffer.size())) {
+      std::string BundleErr;
+      // Bound the descriptor walk by what is left after this bundle starts:
+      // the walk is driven by counts and sizes read out of the buffer, so a
+      // truncated trailing bundle would otherwise run off the end.
+      size_t Remaining = BufEnd - static_cast<const char *>(Bundle);
+      auto Module = extractSPIRVModule(Bundle, BundleErr, Remaining);
+      if (Module.empty()) {
+        // Not "no fp64": the module could not be read. Say so, because the
+        // caller is about to decide whether a test may run.
+        std::cerr << "spirv-extractor: could not read a device module while "
+                     "checking for doubles: "
+                  << BundleErr << std::endl;
+        continue;
+      }
+      if (usesDoubles(disassembleSPIRV(Module))) {
+        hasDoubles = true;
+        break;
+      }
+    }
+  }
+
   int exitCode = 0;
   
   // Perform SPIR-V validation if requested (lighter weight than full verify)

--- a/tools/spirv-extractor/spirv-extractor.hh
+++ b/tools/spirv-extractor/spirv-extractor.hh
@@ -167,6 +167,67 @@ MagicResult seekToMagic(const void *Bundle) {
   return {nullptr, BinaryType::UNKNOWN};
 }
 
+/// Every offload bundle in the \p BinarySize bytes at \p Binary, in order.
+///
+/// seekToMagic returns the FIRST bundle, which is all a per-translation-unit
+/// fatbin wrapper holds. A linked executable holds one bundle per translation
+/// unit concatenated in .hip_fatbin, so anything that has to reason about the
+/// whole program, rather than about one module, has to see all of them.
+///
+/// \p BinarySize is required rather than optional: every read here is bounded
+/// by it, including the ELF header and section table, so a truncated or
+/// non-ELF input cannot walk off the end.
+std::vector<const void *> collectOffloadBundles(const void *Binary,
+                                                size_t BinarySize) {
+  std::vector<const void *> Bundles;
+  constexpr size_t MagicLen = sizeof(CLANG_OFFLOAD_BUNDLER_MAGIC) - 1;
+  const char *Base = static_cast<const char *>(Binary);
+
+  // True when [Off, Off+N) lies inside the buffer.
+  auto InBounds = [&](size_t Off, size_t N) {
+    return Off <= BinarySize && N <= BinarySize - Off;
+  };
+  auto Scan = [&](size_t Off, size_t Size) {
+    if (!InBounds(Off, Size) || Size < MagicLen)
+      return;
+    for (size_t J = 0; J <= Size - MagicLen; ++J)
+      if (std::memcmp(Base + Off + J, CLANG_OFFLOAD_BUNDLER_MAGIC, MagicLen) ==
+          0)
+        Bundles.push_back(Base + Off + J);
+  };
+
+  if (InBounds(0, sizeof(Elf64_Ehdr)) &&
+      memcmp(Base, ELFMAG, SELFMAG) == 0) {
+    const Elf64_Ehdr *Ehdr = reinterpret_cast<const Elf64_Ehdr *>(Base);
+    size_t ShdrBytes = static_cast<size_t>(Ehdr->e_shnum) * sizeof(Elf64_Shdr);
+    if (!InBounds(Ehdr->e_shoff, ShdrBytes) ||
+        Ehdr->e_shstrndx >= Ehdr->e_shnum)
+      return Bundles;
+    const Elf64_Shdr *Shdr =
+        reinterpret_cast<const Elf64_Shdr *>(Base + Ehdr->e_shoff);
+    size_t StrOff = Shdr[Ehdr->e_shstrndx].sh_offset;
+    size_t StrSize = Shdr[Ehdr->e_shstrndx].sh_size;
+    if (!InBounds(StrOff, StrSize))
+      return Bundles;
+    for (size_t I = 0; I < Ehdr->e_shnum; I++) {
+      size_t NameOff = Shdr[I].sh_name;
+      if (NameOff >= StrSize)
+        continue;
+      // The string table is bounded, so this comparison cannot run past it.
+      if (strncmp(Base + StrOff + NameOff, ".hip_fatbin", StrSize - NameOff) ==
+          0) {
+        Scan(Shdr[I].sh_offset, Shdr[I].sh_size);
+        return Bundles;
+      }
+    }
+    return Bundles;
+  }
+
+  // Not an ELF: scan what there is, never more.
+  Scan(0, std::min<size_t>(BinarySize, 1024 * 1024));
+  return Bundles;
+}
+
 /// Extract the SPIR-V module from \p Bundle.
 ///
 /// \p BundleSize is the number of bytes readable at \p Bundle. It bounds the
@@ -266,11 +327,23 @@ std::string_view extractSPIRVModule(const void *Bundle, std::string &ErrorMsg,
         // Legacy entry ID used during early development.
         EntryID == "hip-spir64-unknown-unknown") {
       // std::cout << "Found SPIR-V bundle" << std::endl;
-      const char *spirvData = Header + Offset;
-      if (!InBounds(spirvData, std::max<uint64_t>(Size, sizeof(uint32_t)))) {
-        ErrorMsg = "Clang offload bundle entry payload runs past end of buffer";
-        return std::string_view();
+      // Check the offset and the length numerically, BEFORE forming
+      // Header + Offset: Offset comes out of the buffer, so a garbage value
+      // makes that pointer itself undefined, and a pointer already past the
+      // end turns the InBounds subtraction below into a huge unsigned size
+      // that compares as in bounds.
+      uint64_t Need = std::max<uint64_t>(Size, sizeof(uint32_t));
+      size_t HeaderOff = static_cast<size_t>(Header - BufBegin);
+      if (BufEnd) {
+        size_t Avail = static_cast<size_t>(BufEnd - BufBegin);
+        if (HeaderOff > Avail || Offset > Avail - HeaderOff ||
+            Need > Avail - HeaderOff - Offset) {
+          ErrorMsg =
+              "Clang offload bundle entry payload runs past end of buffer";
+          return std::string_view();
+        }
       }
+      const char *spirvData = Header + Offset;
       uint32_t magic;
       std::memcpy(&magic, spirvData, sizeof(uint32_t));
       // std::cout << "Magic at offset: 0x" << std::hex << magic << std::dec


### PR DESCRIPTION
The ARM64 Mali lane had four tests failing. They had been failing for months and were reported green, because `spirv-extractor --check-for-doubles`, which wraps every test on that lane, returned `system()`'s raw wait status and so truncated every non-zero exit to 0. PR #1513 fixes that truncation and makes them visible. All four were reproduced on a tree that does not contain #1513, so none of them is caused by it.

Three separate causes.

`TestProjectionBasisKernel` and `TestHiprtcCacheNameExpressions` fail with `hipcc: not found`. `ship-to-salami.sh` already drops tests that invoke a compiler at test time, because the toolchain in the staged tree is x86, but it classified by the ctest command shape and so missed the ones that reach the compiler in process through hipRTC. It now classifies those the same way it classifies the rest, by behaviour: a binary whose undefined dynamic symbols name a hipRTC entry point. Fixes #1602.

`cuda-reduction` fails `clBuildProgram` on Mali with `Unsupported SPIR-V capability: Float64`, because the sample instantiates `reduce<double>` in the same module as `reduce<int>` and Mali-G52 has no fp64. The doubles wrapper should have skipped it and did not: it inspected only the first offload bundle, and a linked executable has one per translation unit. It now inspects every bundle, with every read bounded by the buffer size and payload offsets checked numerically before pointers are formed. Fixes #1601.

`manyMallocMemcopies` fails its own assertion at 65x. The cost is a linked-list walk over live SVM allocations inside ARM's closed `libmali`, on every `clEnqueueSVMMemcpy`, so it is not chipStar's to hold flat. The benchmark now asks the runtime which allocation strategy it selected and opts out when that is coarse-grain SVM, with `SKIP_REGULAR_EXPRESSION` so the opt-out is a visible skip rather than a silent pass. The gate stays live wherever the measurement can speak about chipStar. Refs #1322.

Nothing is added to `tests/known_failures.yaml`.
