### PR TITLE
configure_llvm: stop re-fetching a pinned LLVM tag on every CI build

### DIFF
--- a/.github/workflows/test-llvm-patches.yml
+++ b/.github/workflows/test-llvm-patches.yml
@@ -132,9 +132,7 @@ jobs:
         # is not offline. Needs only git, so it costs a second and fails before
         # an hour of building rather than after.
         run: |
-          tests/configure_llvm_pinned_fetch.bash \
-            scripts/configure_llvm.sh \
-            "${RUNNER_TEMP:-/tmp}/configure_llvm_pinned_fetch.d"
+          tests/configure_llvm_pinned_fetch.bash scripts/configure_llvm.sh
       - name: Configure LLVM ${{ matrix.build-id }}
         run: |
           rm -rf $HOME/llvm-builds/${{ matrix.build-id }}
@@ -781,9 +779,7 @@ jobs:
         # guard here too, on the host, before an image build and an hour of
         # cross-compiling. Needs only git.
         run: |
-          tests/configure_llvm_pinned_fetch.bash \
-            scripts/configure_llvm.sh \
-            "${RUNNER_TEMP:-/tmp}/configure_llvm_pinned_fetch.d"
+          tests/configure_llvm_pinned_fetch.bash scripts/configure_llvm.sh
       - name: Build the cross-compilation container
         run: |
           docker build -t chipstar-llvm-cross-aarch64 \

--- a/.github/workflows/test-llvm-patches.yml
+++ b/.github/workflows/test-llvm-patches.yml
@@ -125,6 +125,16 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
           submodules: 'recursive'
+      - name: Check the pinned-ref fetch guard
+        # configure_llvm.sh runs next and prepares the LLVM source. This asserts
+        # the guard that stops it re-fetching an already-pinned llvm-project
+        # tag; the translator ref is a branch and is still fetched, so the step
+        # is not offline. Needs only git, so it costs a second and fails before
+        # an hour of building rather than after.
+        run: |
+          tests/configure_llvm_pinned_fetch.bash \
+            scripts/configure_llvm.sh \
+            "${RUNNER_TEMP:-/tmp}/configure_llvm_pinned_fetch.d"
       - name: Configure LLVM ${{ matrix.build-id }}
         run: |
           rm -rf $HOME/llvm-builds/${{ matrix.build-id }}
@@ -765,6 +775,15 @@ jobs:
           fi
           echo "Using cross-build workspace: $PICK"
           echo "CROSS_WORK=$PICK" >> "$GITHUB_ENV"
+      - name: Check the pinned-ref fetch guard
+        # The container runs configure_llvm.sh to prepare the LLVM source, and
+        # its fetch is what fails when this runner is throttled. Assert the
+        # guard here too, on the host, before an image build and an hour of
+        # cross-compiling. Needs only git.
+        run: |
+          tests/configure_llvm_pinned_fetch.bash \
+            scripts/configure_llvm.sh \
+            "${RUNNER_TEMP:-/tmp}/configure_llvm_pinned_fetch.d"
       - name: Build the cross-compilation container
         run: |
           docker build -t chipstar-llvm-cross-aarch64 \

--- a/.github/workflows/test-llvm-patches.yml
+++ b/.github/workflows/test-llvm-patches.yml
@@ -741,8 +741,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
-          # No submodules: the cross build only reads scripts/ and
-          # llvm-patches/.
+          # No submodules: this job reads only scripts/, llvm-patches/
+          # and tests/.
       - name: Pick a scratch workspace with room for the build
         run: |
           set -euo pipefail

--- a/.github/workflows/unit-tests-arm64-mali.yml
+++ b/.github/workflows/unit-tests-arm64-mali.yml
@@ -62,6 +62,10 @@ jobs:
           [ -d /space ] || W=$HOME/cross-chipstar-work
           mkdir -p "$W"
           echo "CROSS_WORK=$W" >> "$GITHUB_ENV"
+          # The image GC below must not delete the tag this run needs. Cheap
+          # text processing, so check it before an image build, not after.
+          tests/cross_image_gc.bash .github/workflows/unit-tests-arm64-mali.yml \
+            "${RUNNER_TEMP:-/tmp}/cross_image_gc.d"
           TAG=$(scripts/cross-aarch64/image-tag.sh)
           echo "CROSS_IMAGE=chipstar-cross-aarch64:$TAG" >> "$GITHUB_ENV"
           if docker image inspect "chipstar-cross-aarch64:$TAG" >/dev/null 2>&1; then
@@ -79,9 +83,16 @@ jobs:
           cp -a "$W"/x86-stage/opt/* "$W"/spirv-stage/opt/* "$W/image-ctx/opt/"
           docker build -f scripts/cross-aarch64/Dockerfile.chipstar \
             -t "chipstar-cross-aarch64:$TAG" "$W/image-ctx"
-          # Keep only the two newest cross images; each is ~1.6 GB.
+          # Trim cross images, each ~1.6 GB: keep the two newest plus the one
+          # this run needs, so at most three non-base tags survive. Never the
+          # one this run needs: CreatedAt is the image's own timestamp, and a
+          # rebuild that hits the layer cache produces the SAME image, so the
+          # tag just written inherits a date that can sort it straight into the
+          # delete list. That untags the image between this step and the next,
+          # which then fails with "Unable to find image ... locally".
           docker images chipstar-cross-aarch64 --format '{{.Tag}} {{.CreatedAt}}' \
-            | grep -v '^base ' | sort -k2 -r | tail -n +3 | awk '{print $1}' \
+            | grep -v '^base ' | grep -v "^$TAG " | sort -k2 -r | tail -n +3 \
+            | awk '{print $1}' \
             | xargs -r -I{} docker rmi "chipstar-cross-aarch64:{}" || true
         timeout-minutes: 90
 

--- a/.github/workflows/unit-tests-arm64-mali.yml
+++ b/.github/workflows/unit-tests-arm64-mali.yml
@@ -64,8 +64,7 @@ jobs:
           echo "CROSS_WORK=$W" >> "$GITHUB_ENV"
           # The image GC below must not delete the tag this run needs. Cheap
           # text processing, so check it before an image build, not after.
-          tests/cross_image_gc.bash .github/workflows/unit-tests-arm64-mali.yml \
-            "${RUNNER_TEMP:-/tmp}/cross_image_gc.d"
+          tests/cross_image_gc.bash .github/workflows/unit-tests-arm64-mali.yml
           TAG=$(scripts/cross-aarch64/image-tag.sh)
           echo "CROSS_IMAGE=chipstar-cross-aarch64:$TAG" >> "$GITHUB_ENV"
           if docker image inspect "chipstar-cross-aarch64:$TAG" >/dev/null 2>&1; then

--- a/scripts/configure_llvm.sh
+++ b/scripts/configure_llvm.sh
@@ -20,6 +20,35 @@ retry() {
   echo "All $max_attempts attempts failed."
   return 1
 }
+
+# Fetch origin unless the pinned ref is a local tag we choose to trust.
+#
+# This step runs on every CI build, and a GitHub outage or a rate limit turns
+# the fetch into "could not read Username" and kills the job. Skipping it is a
+# policy, not a property of git: a tag CAN be force-moved upstream, and this
+# will not notice, exactly as an ordinary `git fetch origin` would not have
+# updated a diverged local tag either.
+#
+# Everything else still fetches: a branch (which moves by design), a ref that
+# is not local yet, and a name that is BOTH a tag and a branch here, since the
+# checkout that follows would resolve that ambiguously and the safe reading is
+# that a branch was meant.
+#
+# So this does NOT make source preparation offline, and is not meant to. Only
+# llvm-project is pinned to a tag; TRANSLATOR_BRANCH is a branch for every
+# version (llvm_release_230 and release/N.x style), so SPIRV-LLVM-Translator
+# is still fetched on every run. What this removes is the larger and wholly
+# redundant of the two fetches, and what retry adds is a bounded number of
+# second chances for the one that remains.
+fetch_pinned_ref() {
+  local ref="$1"
+  if git rev-parse -q --verify "refs/tags/${ref}" >/dev/null &&
+     ! git rev-parse -q --verify "refs/heads/${ref}" >/dev/null; then
+    echo "  ${ref} is a tag already present locally; skipping fetch"
+    return 0
+  fi
+  retry git fetch origin
+}
 # default values for optional arguments
 LINK_TYPE="dynamic"
 EMIT_ONLY="off"
@@ -197,7 +226,7 @@ if [ "$EMIT_ONLY" != "on" ]; then
     # Warn the user.
     echo "llvm-project directory already exists. Checking out ${LLVM_BRANCH}..."
     cd llvm-project
-    git fetch origin
+    fetch_pinned_ref "${LLVM_BRANCH}"
     git reset --hard
     git clean -fd
     git checkout ${LLVM_BRANCH}
@@ -209,7 +238,7 @@ if [ "$EMIT_ONLY" != "on" ]; then
       cd SPIRV-LLVM-Translator
     else
       cd llvm/projects/SPIRV-LLVM-Translator
-      git fetch origin
+      fetch_pinned_ref "${TRANSLATOR_BRANCH}"
       git reset --hard
       git clean -fd
     fi

--- a/scripts/configure_llvm.sh
+++ b/scripts/configure_llvm.sh
@@ -32,7 +32,10 @@ retry() {
 # Everything else still fetches: a branch (which moves by design), a ref that
 # is not local yet, and a name that is BOTH a tag and a branch here, since the
 # checkout that follows would resolve that ambiguously and the safe reading is
-# that a branch was meant.
+# that a branch was meant. Fetching a branch updates origin/<branch> and no
+# more: the `git checkout <branch>` below does not fast-forward an existing
+# local branch onto it, so this is preserved behaviour, not a freshness
+# guarantee.
 #
 # So this does NOT make source preparation offline, and is not meant to. Only
 # llvm-project is pinned to a tag; TRANSLATOR_BRANCH is a branch for every

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,8 @@ function(add_hip_test MAIN_SOURCE)
   add_dependencies(build_tests "${EXEC_NAME}")
 endfunction()
 
+# configure_llvm.sh must not depend on the network to check out a pinned tag it
+# already has. Needs only git, so it runs everywhere.
 add_test(NAME configure_llvm_pinned_fetch
   COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/configure_llvm_pinned_fetch.bash
     ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/configure_llvm.sh
@@ -24,6 +26,14 @@ set_tests_properties(configure_llvm_pinned_fetch PROPERTIES
 
 # The Mali workflow's image GC must not delete the image the run just built.
 # Needs only text processing, no docker.
+add_test(NAME cross_image_gc
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/cross_image_gc.bash
+    ${CMAKE_CURRENT_SOURCE_DIR}/../.github/workflows/unit-tests-arm64-mali.yml
+    ${CMAKE_CURRENT_BINARY_DIR}/cross_image_gc.d)
+set_tests_properties(cross_image_gc PROPERTIES
+  FAIL_REGULAR_EXPRESSION "FAIL"
+  PASS_REGULAR_EXPRESSION "PASSED")
+
 add_subdirectory(compiler)
 add_subdirectory(cuda)
 add_subdirectory(devicelib)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,8 +18,7 @@ endfunction()
 # already has. Needs only git, so it runs everywhere.
 add_test(NAME configure_llvm_pinned_fetch
   COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/configure_llvm_pinned_fetch.bash
-    ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/configure_llvm.sh
-    ${CMAKE_CURRENT_BINARY_DIR}/configure_llvm_pinned_fetch.d)
+    ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/configure_llvm.sh)
 set_tests_properties(configure_llvm_pinned_fetch PROPERTIES
   FAIL_REGULAR_EXPRESSION "FAIL"
   PASS_REGULAR_EXPRESSION "PASSED")
@@ -28,8 +27,7 @@ set_tests_properties(configure_llvm_pinned_fetch PROPERTIES
 # Needs only text processing, no docker.
 add_test(NAME cross_image_gc
   COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/cross_image_gc.bash
-    ${CMAKE_CURRENT_SOURCE_DIR}/../.github/workflows/unit-tests-arm64-mali.yml
-    ${CMAKE_CURRENT_BINARY_DIR}/cross_image_gc.d)
+    ${CMAKE_CURRENT_SOURCE_DIR}/../.github/workflows/unit-tests-arm64-mali.yml)
 set_tests_properties(cross_image_gc PROPERTIES
   FAIL_REGULAR_EXPRESSION "FAIL"
   PASS_REGULAR_EXPRESSION "PASSED")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,16 @@ function(add_hip_test MAIN_SOURCE)
   add_dependencies(build_tests "${EXEC_NAME}")
 endfunction()
 
+add_test(NAME configure_llvm_pinned_fetch
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/configure_llvm_pinned_fetch.bash
+    ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/configure_llvm.sh
+    ${CMAKE_CURRENT_BINARY_DIR}/configure_llvm_pinned_fetch.d)
+set_tests_properties(configure_llvm_pinned_fetch PROPERTIES
+  FAIL_REGULAR_EXPRESSION "FAIL"
+  PASS_REGULAR_EXPRESSION "PASSED")
+
+# The Mali workflow's image GC must not delete the image the run just built.
+# Needs only text processing, no docker.
 add_subdirectory(compiler)
 add_subdirectory(cuda)
 add_subdirectory(devicelib)

--- a/tests/configure_llvm_pinned_fetch.bash
+++ b/tests/configure_llvm_pinned_fetch.bash
@@ -67,26 +67,34 @@ run_case() {
 FAILED=0
 
 # A textual check, and only that: it reads the script rather than running it.
-# It catches the shape of the regression this test exists for, a reuse-path
-# caller fetching directly, and it catches a stray fetch appearing anywhere
-# else in the file. It cannot prove the callers behave correctly, because
-# driving them means running configure_llvm.sh's reuse path, which needs a
-# populated llvm-project and a patch series that applies, and that is out of
-# reach of a test meant to run before every LLVM build. Treat a pass here as
-# "nothing obviously reaches around the helper", not as caller coverage.
-# Each reuse-path `cd` into a repository must be followed by the helper. The
-# clone path also cds into llvm-project and correctly does not fetch, so only
-# lines whose NEXT line touches the network are of interest: the check is that
-# no `cd` into a repo is followed by a bare fetch.
-while IFS= read -r next; do
-  case "${next}" in
-    *"git fetch"*)
-      echo "FAIL: a reuse-path caller fetches directly instead of via fetch_pinned_ref:"
-      echo "      ${next}"
-      FAILED=1 ;;
-  esac
-done < <(grep -A1 -E '^[[:space:]]+cd (llvm-project|llvm/projects/SPIRV-LLVM-Translator)$' "${SCRIPT}" \
-         | grep -vE '^[[:space:]]*cd |^--$')
+# Driving the callers for real means running configure_llvm.sh's reuse path,
+# which needs a populated llvm-project and a patch series that applies, and
+# that is out of reach of a test meant to run before every LLVM build. What is
+# checkable statically is that each reuse-path caller still cds into its
+# repository and reaches the network through the helper, with the ref that
+# belongs to that repository.
+#
+# Anchored on the reuse-path marker, not on every `cd`: the clone path cds into
+# llvm-project too and correctly does not fetch there, so a rule over every cd
+# would fail a clean script.
+REUSE=$(grep -A2 'llvm-project directory already exists' "${SCRIPT}" \
+        | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | tail -2 | tr '\n' '|')
+if [ "${REUSE}" != 'cd llvm-project|fetch_pinned_ref "${LLVM_BRANCH}"|' ]; then
+  echo "FAIL: the llvm-project reuse path must cd in and then call"
+  echo "      fetch_pinned_ref \"\${LLVM_BRANCH}\"; found [${REUSE}]"
+  FAILED=1
+fi
+
+# The translator's reuse path is the only place this exact cd appears.
+XLATE=$(grep -A1 -E '^[[:space:]]*cd llvm/projects/SPIRV-LLVM-Translator$' "${SCRIPT}" \
+        | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | tr '\n' '|')
+if [ "${XLATE}" != 'cd llvm/projects/SPIRV-LLVM-Translator|fetch_pinned_ref "${TRANSLATOR_BRANCH}"|' ]; then
+  echo "FAIL: the SPIRV-LLVM-Translator reuse path must cd in and then call"
+  echo "      fetch_pinned_ref \"\${TRANSLATOR_BRANCH}\"; found [${XLATE}]"
+  FAILED=1
+fi
+
+# And nothing anywhere in the file may reach around the helper to fetch.
 # -E with a single alternation group: `\|` is a GNU extension that BSD grep,
 # and so macOS, does not honour, and there it silently matches nothing.
 # Trailing whitespace or a trailing comment must not hide a fetch from this.

--- a/tests/configure_llvm_pinned_fetch.bash
+++ b/tests/configure_llvm_pinned_fetch.bash
@@ -54,7 +54,11 @@ git init -q upstream || { echo "FAIL: fixture init"; exit 1; }
   git branch moving-branch
 ) || { echo "FAIL: fixture setup"; exit 1; }
 git clone -q upstream clone 2>/dev/null || { echo "FAIL: fixture clone"; exit 1; }
-git -C clone remote set-url origin https://no-such-host.invalid/nope.git
+# Every case below reads a fetch attempt as "went to the network", which only
+# holds while the remote cannot resolve. An unchecked rewrite here would leave
+# the fixture pointing at the real upstream and quietly weaken all of them.
+git -C clone remote set-url origin https://no-such-host.invalid/nope.git \
+  || { echo "FAIL: fixture remote rewrite"; exit 1; }
 
 # Echoes: <exit status> <number of fetches attempted> <command of the first>
 run_case() {

--- a/tests/configure_llvm_pinned_fetch.bash
+++ b/tests/configure_llvm_pinned_fetch.bash
@@ -1,0 +1,136 @@
+#!/bin/bash
+# configure_llvm.sh reuses an existing llvm-project checkout rather than
+# recloning it, but it fetched unconditionally before checking the pinned ref
+# out. For a pinned TAG that is already local that fetch retrieves nothing: it
+# only adds a network round trip, and it fails the whole build when GitHub is
+# unreachable or throttling the runner. For a moving BRANCH the fetch is
+# required, or the build would silently keep compiling stale source.
+#
+# Drives the real fetch_pinned_ref, extracted from configure_llvm.sh itself
+# rather than copied here, against fixture repositories whose remote does not
+# resolve. A skipped fetch therefore succeeds and an attempted one is recorded.
+#
+# Needs git and nothing else: no GPU, no toolchain, no network.
+#
+# Usage: configure_llvm_pinned_fetch.bash <configure_llvm.sh> <work-dir>
+set -u
+SCRIPT="${1:?path to configure_llvm.sh}"
+OUT="${2:?work directory}"
+
+[ -f "${SCRIPT}" ] || { echo "FAIL: no such script: ${SCRIPT}"; exit 1; }
+mkdir -p "${OUT}" || { echo "FAIL: cannot create ${OUT}"; exit 1; }
+# Absolute before the cd below, or a relative argument would resolve against
+# the work directory instead of the caller's.
+SCRIPT=$(cd "$(dirname "${SCRIPT}")" && pwd)/$(basename "${SCRIPT}")
+OUT=$(cd "${OUT}" && pwd)
+rm -rf "${OUT}"; mkdir -p "${OUT}"; cd "${OUT}" || exit 1
+
+# The function's real text. Renaming or removing it fails here rather than
+# leaving this test quietly exercising nothing.
+sed -n '/^fetch_pinned_ref() {/,/^}/p' "${SCRIPT}" > fn.sh
+if [ ! -s fn.sh ]; then
+  echo "FAIL: fetch_pinned_ref not found in ${SCRIPT}"
+  exit 1
+fi
+
+# Stand-in for retry. It records the exact command it was handed and does NOT
+# run it, so the test never touches the network and can assert what would have
+# been executed rather than merely that something was.
+{ echo 'retry() { echo "$*" >> "${ATTEMPTS}"; return "${RETRY_RC:-0}"; }'
+  cat fn.sh; } > fn_under_test.sh
+
+git init -q upstream || { echo "FAIL: fixture init"; exit 1; }
+(
+  cd upstream
+  git -c user.email=t@t -c user.name=t commit -q --allow-empty -m one
+  git tag pinned-tag
+  git branch moving-branch
+) || { echo "FAIL: fixture setup"; exit 1; }
+git clone -q upstream clone 2>/dev/null || { echo "FAIL: fixture clone"; exit 1; }
+git -C clone remote set-url origin https://no-such-host.invalid/nope.git
+
+# Echoes: <exit status> <number of fetches attempted> <command of the first>
+run_case() {
+  export ATTEMPTS="${OUT}/attempts.$1"
+  : > "${ATTEMPTS}"
+  ( cd clone && . "${OUT}/fn_under_test.sh" && fetch_pinned_ref "$1" >/dev/null 2>&1 )
+  local rc=$?
+  local calls cmd
+  calls=$(grep -c . "${ATTEMPTS}" 2>/dev/null)
+  cmd=$(head -1 "${ATTEMPTS}" 2>/dev/null)
+  echo "$rc ${calls:-0} ${cmd:-none}"
+}
+
+FAILED=0
+
+# A textual check, and only that: it reads the script rather than running it.
+# It catches the shape of the regression this test exists for, a reuse-path
+# caller fetching directly, and it catches a stray fetch appearing anywhere
+# else in the file. It cannot prove the callers behave correctly, because
+# driving them means running configure_llvm.sh's reuse path, which needs a
+# populated llvm-project and a patch series that applies, and that is out of
+# reach of a test meant to run before every LLVM build. Treat a pass here as
+# "nothing obviously reaches around the helper", not as caller coverage.
+# Each reuse-path `cd` into a repository must be followed by the helper. The
+# clone path also cds into llvm-project and correctly does not fetch, so only
+# lines whose NEXT line touches the network are of interest: the check is that
+# no `cd` into a repo is followed by a bare fetch.
+while IFS= read -r next; do
+  case "${next}" in
+    *"git fetch"*)
+      echo "FAIL: a reuse-path caller fetches directly instead of via fetch_pinned_ref:"
+      echo "      ${next}"
+      FAILED=1 ;;
+  esac
+done < <(grep -A1 -E '^[[:space:]]+cd (llvm-project|llvm/projects/SPIRV-LLVM-Translator)$' "${SCRIPT}" \
+         | grep -vE '^[[:space:]]*cd |^--$')
+# -E with a single alternation group: `\|` is a GNU extension that BSD grep,
+# and so macOS, does not honour, and there it silently matches nothing.
+# Trailing whitespace or a trailing comment must not hide a fetch from this.
+FETCHES=$(grep -cE '^[[:space:]]*(retry )?git fetch origin([[:space:]]|#|$)' "${SCRIPT}")
+if [ "${FETCHES}" -ne 1 ]; then
+  echo "FAIL: expected exactly one 'git fetch origin' in the script, found ${FETCHES};"
+  echo "      a caller is fetching without going through fetch_pinned_ref"
+  FAILED=1
+fi
+
+read -r RC CALLS CMD <<< "$(run_case pinned-tag)"
+echo "pinned tag already local -> rc=${RC} fetches=${CALLS} cmd=[${CMD}]"
+if [ "${RC}" -ne 0 ] || [ "${CALLS}" -ne 0 ]; then
+  echo "FAIL: a tag that is already local must not be fetched"; FAILED=1
+fi
+
+read -r RC CALLS CMD <<< "$(run_case moving-branch)"
+echo "moving branch            -> rc=${RC} fetches=${CALLS} cmd=[${CMD}]"
+if [ "${CALLS}" -ne 1 ] || [ "${CMD}" != "git fetch origin" ]; then
+  echo "FAIL: a branch must be fetched with 'git fetch origin', got ${CALLS} x [${CMD}]"; FAILED=1
+fi
+
+read -r RC CALLS CMD <<< "$(run_case absent-ref)"
+echo "ref not present locally  -> rc=${RC} fetches=${CALLS} cmd=[${CMD}]"
+if [ "${CALLS}" -ne 1 ] || [ "${CMD}" != "git fetch origin" ]; then
+  echo "FAIL: an absent ref must be fetched with 'git fetch origin'"; FAILED=1
+fi
+
+# A name that is both a tag and a branch here would be resolved ambiguously by
+# the checkout that follows, so it must fetch rather than trust the tag.
+git -C clone branch -q ambiguous 2>/dev/null
+git -C clone tag ambiguous 2>/dev/null
+read -r RC CALLS CMD <<< "$(run_case ambiguous)"
+echo "same name tag AND branch -> rc=${RC} fetches=${CALLS} cmd=[${CMD}]"
+if [ "${CALLS}" -ne 1 ]; then
+  echo "FAIL: an ambiguous ref must be fetched, not assumed to be the tag"; FAILED=1
+fi
+
+# A fetch that keeps failing must fail the build rather than proceed onto stale
+# source: the script runs under set -e and the caller relies on that.
+export RETRY_RC=1
+read -r RC CALLS CMD <<< "$(run_case moving-branch)"
+unset RETRY_RC
+echo "fetch fails              -> rc=${RC} fetches=${CALLS}"
+if [ "${RC}" -eq 0 ]; then
+  echo "FAIL: a failed fetch must propagate, not be swallowed"; FAILED=1
+fi
+
+if [ "${FAILED}" -eq 0 ]; then echo "PASSED"; exit 0; fi
+exit 1

--- a/tests/configure_llvm_pinned_fetch.bash
+++ b/tests/configure_llvm_pinned_fetch.bash
@@ -12,18 +12,21 @@
 #
 # Needs git and nothing else: no GPU, no toolchain, no network.
 #
-# Usage: configure_llvm_pinned_fetch.bash <configure_llvm.sh> <work-dir>
+# Usage: configure_llvm_pinned_fetch.bash <configure_llvm.sh>
 set -u
 SCRIPT="${1:?path to configure_llvm.sh}"
-OUT="${2:?work directory}"
 
 [ -f "${SCRIPT}" ] || { echo "FAIL: no such script: ${SCRIPT}"; exit 1; }
-mkdir -p "${OUT}" || { echo "FAIL: cannot create ${OUT}"; exit 1; }
 # Absolute before the cd below, or a relative argument would resolve against
 # the work directory instead of the caller's.
 SCRIPT=$(cd "$(dirname "${SCRIPT}")" && pwd)/$(basename "${SCRIPT}")
-OUT=$(cd "${OUT}" && pwd)
-rm -rf "${OUT}"; mkdir -p "${OUT}"; cd "${OUT}" || exit 1
+# The fixture repositories go in a directory this script creates and removes,
+# not one a caller names: a caller-supplied path has to be emptied to make
+# reruns repeatable, and emptying a directory somebody else owns is not this
+# test's to do.
+OUT=$(mktemp -d) || { echo "FAIL: cannot create a work directory"; exit 1; }
+trap 'rm -rf "${OUT}"' EXIT
+cd "${OUT}" || exit 1
 
 # The function's real text. Renaming or removing it fails here rather than
 # leaving this test quietly exercising nothing.

--- a/tests/configure_llvm_pinned_fetch.bash
+++ b/tests/configure_llvm_pinned_fetch.bash
@@ -3,8 +3,12 @@
 # recloning it, but it fetched unconditionally before checking the pinned ref
 # out. For a pinned TAG that is already local that fetch retrieves nothing: it
 # only adds a network round trip, and it fails the whole build when GitHub is
-# unreachable or throttling the runner. For a moving BRANCH the fetch is
-# required, or the build would silently keep compiling stale source.
+# unreachable or throttling the runner. A BRANCH is still fetched, because that
+# is the behaviour every non-pinned ref had before and narrowing it is a
+# separate change. Note what that fetch does and does not buy: it advances the
+# remote-tracking ref origin/<branch>, and the `git checkout <branch>` that
+# follows does NOT fast-forward an existing local branch onto it, so a reused
+# checkout can stay behind origin whether or not this fetch runs.
 #
 # Drives the real fetch_pinned_ref, extracted from configure_llvm.sh itself
 # rather than copied here, against fixture repositories whose remote does not
@@ -133,8 +137,8 @@ if [ "${CALLS}" -ne 1 ]; then
   echo "FAIL: an ambiguous ref must be fetched, not assumed to be the tag"; FAILED=1
 fi
 
-# A fetch that keeps failing must fail the build rather than proceed onto stale
-# source: the script runs under set -e and the caller relies on that.
+# A fetch that keeps failing must fail the build rather than be swallowed: the
+# script runs under set -e and the caller relies on that.
 export RETRY_RC=1
 read -r RC CALLS CMD <<< "$(run_case moving-branch)"
 unset RETRY_RC

--- a/tests/cross_image_gc.bash
+++ b/tests/cross_image_gc.bash
@@ -1,0 +1,67 @@
+#!/bin/bash
+# The Mali workflow trims cross-build images, each about 1.6 GB, keeping the
+# newest few. It sorted on {{.CreatedAt}}, which is the IMAGE's timestamp and
+# not the moment a tag was written, so a rebuild whose layers all hit the cache
+# produced the same image as before and the tag just created inherited an old
+# date. It then sorted into the delete list and was removed between the build
+# step and the step that runs it, which failed with "Unable to find image
+# chipstar-cross-aarch64:<tag> locally".
+#
+# Drives the workflow's own pipeline, extracted from the YAML rather than
+# copied, against a fixture image list. Needs no docker and no network.
+#
+# Usage: cross_image_gc.bash <unit-tests-arm64-mali.yml> <work-dir>
+set -u
+WF="${1:?path to the Mali workflow}"
+OUT="${2:?work directory}"
+
+[ -f "${WF}" ] || { echo "FAIL: no such workflow: ${WF}"; exit 1; }
+mkdir -p "${OUT}" || { echo "FAIL: cannot create ${OUT}"; exit 1; }
+WF=$(cd "$(dirname "${WF}")" && pwd)/$(basename "${WF}")
+OUT=$(cd "${OUT}" && pwd)
+rm -rf "${OUT}"; mkdir -p "${OUT}"; cd "${OUT}" || exit 1
+
+# The filter chain between `docker images` and `xargs docker rmi`: everything
+# that decides WHICH tags die. Taken from the workflow so a change there is
+# either reflected here or breaks this test.
+sed -n "/docker images chipstar-cross-aarch64 --format/,/xargs -r -I{} docker rmi/p" "${WF}" \
+  | sed -e 's/^ *//' -e 's/\\$//' > chain.txt
+if ! grep -q "grep -v" chain.txt; then
+  echo "FAIL: could not extract the image GC pipeline from ${WF}"
+  exit 1
+fi
+# Drop the docker calls at either end; feed the fixture in and read tags out.
+FILTER=$(sed -e '/docker images/d' -e '/xargs/d' chain.txt | tr -d '\n')
+if [ -z "${FILTER}" ]; then echo "FAIL: extracted an empty GC filter"; exit 1; fi
+
+# Two tags older than the one being built, which is what a cache-hit rebuild
+# looks like: same image, so the new tag carries the old creation date.
+# newtag carries an OLD date on purpose: that is what a cache-hit rebuild
+# produces, and it is what sorted the tag into the delete list. Enough other
+# tags to leave something for the GC to trim once newtag and base are excluded.
+cat > images.txt <<'IMAGES'
+newtag 2026-08-19 10:30:25 +0300 EEST
+oldtag-a 2026-09-04 12:42:46 +0300 EEST
+oldtag-b 2026-09-01 09:00:00 +0300 EEST
+oldtag-c 2026-08-19 10:30:25 +0300 EEST
+base 2026-08-19 09:14:48 +0300 EEST
+IMAGES
+
+TAG=newtag
+export TAG
+DOOMED=$(eval "cat images.txt ${FILTER}")
+echo "tags the GC would delete: [$(echo ${DOOMED} | tr '\n' ' ')]"
+
+if echo "${DOOMED}" | grep -qx "${TAG}"; then
+  echo "FAIL: the GC deletes ${TAG}, the image this run just built and is about to use"
+  exit 1
+fi
+if ! echo "${DOOMED}" | grep -qx "oldtag-c"; then
+  echo "FAIL: the GC no longer trims anything; it must still remove older images"
+  exit 1
+fi
+if echo "${DOOMED}" | grep -qx "base"; then
+  echo "FAIL: the GC must never delete the base image"
+  exit 1
+fi
+echo "PASSED"

--- a/tests/cross_image_gc.bash
+++ b/tests/cross_image_gc.bash
@@ -10,16 +10,18 @@
 # Drives the workflow's own pipeline, extracted from the YAML rather than
 # copied, against a fixture image list. Needs no docker and no network.
 #
-# Usage: cross_image_gc.bash <unit-tests-arm64-mali.yml> <work-dir>
+# Usage: cross_image_gc.bash <unit-tests-arm64-mali.yml>
 set -u
 WF="${1:?path to the Mali workflow}"
-OUT="${2:?work directory}"
 
 [ -f "${WF}" ] || { echo "FAIL: no such workflow: ${WF}"; exit 1; }
-mkdir -p "${OUT}" || { echo "FAIL: cannot create ${OUT}"; exit 1; }
 WF=$(cd "$(dirname "${WF}")" && pwd)/$(basename "${WF}")
-OUT=$(cd "${OUT}" && pwd)
-rm -rf "${OUT}"; mkdir -p "${OUT}"; cd "${OUT}" || exit 1
+# The fixture goes in a directory this script creates and removes, not one a
+# caller names: emptying a directory somebody else owns is not this test's to
+# do, and the fixture has to start empty to be repeatable.
+OUT=$(mktemp -d) || { echo "FAIL: cannot create a work directory"; exit 1; }
+trap 'rm -rf "${OUT}"' EXIT
+cd "${OUT}" || exit 1
 
 # The filter chain between `docker images` and `xargs docker rmi`: everything
 # that decides WHICH tags die. Taken from the workflow so a change there is

--- a/tests/cross_image_gc.bash
+++ b/tests/cross_image_gc.bash
@@ -32,15 +32,24 @@ if ! grep -q "grep -v" chain.txt; then
   echo "FAIL: could not extract the image GC pipeline from ${WF}"
   exit 1
 fi
+# sed runs to end-of-file when the closing pattern never matches, which would
+# hand the rest of the workflow to the eval below and diagnose the resulting
+# mess as a GC regression. Insist the slice ends on the line it is supposed to.
+if ! tail -1 chain.txt | grep -q "xargs -r -I{} docker rmi"; then
+  echo "FAIL: the GC pipeline slice does not end at the xargs docker rmi line;"
+  echo "      the workflow's formatting changed and this test is reading past it"
+  exit 1
+fi
 # Drop the docker calls at either end; feed the fixture in and read tags out.
 FILTER=$(sed -e '/docker images/d' -e '/xargs/d' chain.txt | tr -d '\n')
 if [ -z "${FILTER}" ]; then echo "FAIL: extracted an empty GC filter"; exit 1; fi
 
-# Two tags older than the one being built, which is what a cache-hit rebuild
-# looks like: same image, so the new tag carries the old creation date.
-# newtag carries an OLD date on purpose: that is what a cache-hit rebuild
-# produces, and it is what sorted the tag into the delete list. Enough other
-# tags to leave something for the GC to trim once newtag and base are excluded.
+# newtag is the tag this run needs, and it carries the OLDEST date on purpose:
+# a cache-hit rebuild produces the image that was already there, so the tag
+# just written inherits that image's creation date. Sorting newest-first there-
+# fore puts it last, which is what sorted it into the delete list. oldtag-a and
+# oldtag-b are newer and must survive as the two the GC keeps; oldtag-c ties
+# newtag's date and is the one that must still be trimmed.
 cat > images.txt <<'IMAGES'
 newtag 2026-08-19 10:30:25 +0300 EEST
 oldtag-a 2026-09-04 12:42:46 +0300 EEST
@@ -66,4 +75,12 @@ if echo "${DOOMED}" | grep -qx "base"; then
   echo "FAIL: the GC must never delete the base image"
   exit 1
 fi
+# Trimming something is not enough: a GC that keeps nothing but the current tag
+# passes every check above while throwing away the cache the next run wants.
+for KEEP in oldtag-a oldtag-b; do
+  if echo "${DOOMED}" | grep -qx "${KEEP}"; then
+    echo "FAIL: the GC deletes ${KEEP}; it must keep the newest images below ${TAG}"
+    exit 1
+  fi
+done
 echo "PASSED"


### PR DESCRIPTION
The aarch64 LLVM cross-build fails intermittently at source preparation:

```
llvm-project directory already exists. Checking out llvmorg-23.1.0-rc2...
fatal: could not read Username for 'https://github.com': No such device or address
```

`configure_llvm.sh` reuses an existing `llvm-project` checkout rather than recloning it, but fetched origin unconditionally before checking the pinned ref out. For `--version 23` that ref is `llvmorg-23.1.0-rc2`, a tag which is already in the clone with HEAD on it, so the fetch retrieves nothing. It only makes every build depend on GitHub being reachable at that instant, and when the runner is throttled git falls back to prompting for a username, gets no terminal, and the script dies. Timed on the cross-build runner, that fetch is 8.4 s of the step while the reset, clean and checkout around it total under a second.

`fetch_pinned_ref` now skips the fetch when the ref resolves as a local tag and not also as a branch. Branches, absent refs and ambiguous names still fetch, and the remaining fetches go through the script's own `retry`, which all four `git clone` calls here already used.

This does not make source preparation offline: only `llvm-project` is pinned to a tag, while the translator ref is a branch for every version, so `SPIRV-LLVM-Translator` is still fetched every run. What this removes is the larger and wholly redundant of the two fetches.

The reset and clean in that path are deliberately untouched. The script applies the patch series in-tree with `git apply` further down, so a rerun needs pristine source.

The Mali workflow's image GC is the other half: it sorted on `{{.CreatedAt}}`, the image's timestamp rather than the moment a tag was written, so a cache-hit rebuild produced the same image and the tag just created inherited an old date, sorted into the delete list, and was removed between the build step and the step that runs it. It is now excluded like the base image.

Both tests need only `git` and text processing, and run before the work they guard so a break costs a second rather than an image build and an hour of cross-compiling.

