### PR TITLE
Run TestFixZeBuildLogNul against a doubles-free binary

### DIFF
--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -130,8 +130,8 @@ endif()
 # The runtime's stderr must stay NUL-free at CHIP_LOGLEVEL=info (the Level
 # Zero build log dump wrote the driver's terminating NUL and printed the
 # "ZE Build Log:" line for empty logs; gtest death tests read captured stderr
-# as a C string). Runs TestKernelArgs and inspects its stderr; only meaningful
-# for the build log path on the Level Zero backend.
+# as a C string). Runs TestFixByvalStructArgSize and inspects its stderr; only
+# meaningful for the build log path on the Level Zero backend.
 add_shell_test(TestFixZeBuildLogNul.bash)
 
 # spirv-extractor --check-for-doubles must see every device module in a binary,

--- a/tests/runtime/TestFixZeBuildLogNul.bash
+++ b/tests/runtime/TestFixZeBuildLogNul.bash
@@ -20,7 +20,22 @@
 set -u
 
 BIN="@CMAKE_CURRENT_BINARY_DIR@/TestKernelArgs"
+EXTRACTOR="@CMAKE_BINARY_DIR@/bin/spirv-extractor"
 OUT="@CMAKE_CURRENT_BINARY_DIR@/@TEST_NAME@.d"
+
+# BIN is run raw below, outside the ${SKIP_DOUBLE_TESTS} wrapper that every
+# ctest registration of a runtime test goes through, so it has to be one the
+# wrapper never skips: where CHIP_SKIP_TESTS_WITH_DOUBLES is on, ctest skips a
+# test whose device module carries fp64 because the device may have none, and
+# this script would run it regardless. The wrapper decides which binaries those
+# are, so ask it, and read its stdout: its exit status is system()'s raw wait
+# status (CHIP-SPV/chipStar#1592) and says nothing.
+if "${EXTRACTOR}" --check-for-doubles "${BIN}" 2>/dev/null |
+    grep -q "HIP_SKIP_THIS_TEST: Kernel uses doubles"; then
+  echo "FAIL: ${BIN} has an fp64 device module, so ctest skips it wherever"
+  echo "      CHIP_SKIP_TESTS_WITH_DOUBLES is on while this script runs it."
+  exit 1
+fi
 
 rm -rf "${OUT}"
 mkdir -p "${OUT}"

--- a/tests/runtime/TestFixZeBuildLogNul.bash
+++ b/tests/runtime/TestFixZeBuildLogNul.bash
@@ -11,15 +11,16 @@
 # before the expected abort message and every Kokkos_CoreUnitTest_HIP death
 # test failed with "died but not with expected error".
 #
-# Runs TestKernelArgs (any small test that builds a module will do) at info
-# level, captures stderr and fails if it holds a NUL byte, or if a
-# "ZE Build Log:" line is followed by an empty log. Both checks are backend
-# agnostic. Only the Level Zero backend prints "ZE Build Log:", so on an
-# OpenCL run (the CPU gate) a pass proves only that the OpenCL path is clean;
-# run with CHIP_BE=level0 to exercise the path this guards.
+# Runs TestFixByvalStructArgSize (any small test that builds a module and
+# carries no fp64 will do, see the doubles check below) at info level, captures
+# stderr and fails if it holds a NUL byte, or if a "ZE Build Log:" line is
+# followed by an empty log. Both checks are backend agnostic. Only the Level
+# Zero backend prints "ZE Build Log:", so on an OpenCL run (the CPU gate) a
+# pass proves only that the OpenCL path is clean; run with CHIP_BE=level0 to
+# exercise the path this guards.
 set -u
 
-BIN="@CMAKE_CURRENT_BINARY_DIR@/TestKernelArgs"
+BIN="@CMAKE_CURRENT_BINARY_DIR@/TestFixByvalStructArgSize"
 EXTRACTOR="@CMAKE_BINARY_DIR@/bin/spirv-extractor"
 OUT="@CMAKE_CURRENT_BINARY_DIR@/@TEST_NAME@.d"
 


### PR DESCRIPTION
Fixes #1606

`tests/runtime/TestFixZeBuildLogNul.bash` ran `TestKernelArgs` directly, outside the `${SKIP_DOUBLE_TESTS}` wrapper that every ctest registration of a runtime test goes through, so wherever `CHIP_SKIP_TESTS_WITH_DOUBLES` is on, ctest skipped `TestKernelArgs` for its fp64 device module while this script ran it anyway on a device that may have no fp64. It now runs `TestFixByvalStructArgSize`, which builds a device module the same way and carries no fp64, and it asks the wrapper up front whether its binary is one the wrapper would skip, so the same bypass cannot come back through a later change of binary.

`TestBoolKernelParam`, the other doubles-free candidate, is registered as a known failure on the PoCL lanes in `tests/known_failures.yaml`, so it would have moved the failure rather than removed it. `TestFixByvalStructArgSize` is unmasked on every platform.