### PR TITLE
Fix trimming HOST_ARCH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -708,7 +708,8 @@ endif()
 
 # For use by hipcc
 execute_process(COMMAND ${LLVM_CONFIG_BIN} --host-target
-  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE HOST_ARCH)
+  OUTPUT_VARIABLE HOST_ARCH)
+string(STRIP ${HOST_ARCH} HOST_ARCH)
 set(HOST_ARCH "--target=${HOST_ARCH}")
 
 # On macOS, pass the sysroot only to host compilation (-Xarch_host).


### PR DESCRIPTION
Using `execute_process(... OUTPUT_STRIP_TRAILING_WHITESPACE ...)` only strips trailing whitespace. But in some cases the `HOST_ARCH` variable contains leading whitespace and the result is that something like this is passed to clang++:
```
  "--target= x86_64-unknown-linux-gnu"
```
which leads to complaints from the compiler, starting with invalid target and, as a consequence, unsupported `-march=` and `-f16c` settings.

Use `string(STRIP)` to strip whitespace from both ends of the string.