### PR TITLE
spirv-extractor: report the wrapped test's exit status and argv correctly

### DIFF
--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -78,6 +78,7 @@ set(RUNTIME_TESTS_MANUAL
   TestFixFunctionLocalStaticDeviceVar.hip # multi-TU, second TU under inputs/
   TestFix1601ExtractorMultiTUDoubles.hip # multi-TU, compiled by its .bash, not a test
   TestFixLlvmUsedAddrspace.hip    # not registered as a test
+  TestFix1592ExtractorExitStatus.hip # compiled by TestFix1592ExtractorExitStatus.bash, not a test
   TestModuleCacheInvalidation.hip # run several times through a driver script
   TestStreamWaitEventOrdering.cpp # not registered as a test
   TestTemplateKernelModules.hip   # multi-TU, linked from hand-built objects
@@ -168,6 +169,10 @@ if(CHIP_SKIP_TESTS_WITH_DOUBLES)
     PASS_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST: Kernel uses doubles"
     SKIP_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST: Kernel uses doubles")
 endif()
+
+# spirv-extractor --check-for-doubles wraps every test when
+# CHIP_SKIP_TESTS_WITH_DOUBLES=ON; it must propagate the wrapped exit status.
+add_shell_test(TestFix1592ExtractorExitStatus.bash)
 
 add_shell_test(../run_testenvvars.sh)
 set_tests_properties(run_testenvvars PROPERTIES

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -79,6 +79,7 @@ set(RUNTIME_TESTS_MANUAL
   TestFix1601ExtractorMultiTUDoubles.hip # multi-TU, compiled by its .bash, not a test
   TestFixLlvmUsedAddrspace.hip    # not registered as a test
   TestFix1592ExtractorExitStatus.hip # compiled by TestFix1592ExtractorExitStatus.bash, not a test
+  TestFix1600ExtractorArgvBoundaries.hip # compiled by TestFix1600ExtractorArgvBoundaries.bash, not a test
   TestModuleCacheInvalidation.hip # run several times through a driver script
   TestStreamWaitEventOrdering.cpp # not registered as a test
   TestTemplateKernelModules.hip   # multi-TU, linked from hand-built objects
@@ -173,6 +174,10 @@ endif()
 # spirv-extractor --check-for-doubles wraps every test when
 # CHIP_SKIP_TESTS_WITH_DOUBLES=ON; it must propagate the wrapped exit status.
 add_shell_test(TestFix1592ExtractorExitStatus.bash)
+
+# The same wrapper must also hand the test its arguments byte for byte; a
+# Catch2 case name containing a space was being re-split by the shell.
+add_shell_test(TestFix1600ExtractorArgvBoundaries.bash)
 
 add_shell_test(../run_testenvvars.sh)
 set_tests_properties(run_testenvvars PROPERTIES

--- a/tests/runtime/TestFix1592ExtractorExitStatus.bash
+++ b/tests/runtime/TestFix1592ExtractorExitStatus.bash
@@ -1,0 +1,32 @@
+#!/bin/bash
+# spirv-extractor --check-for-doubles must propagate the wrapped test's exit
+# status. It returned system()'s raw wait status from main(), so a test that
+# exits 1 came back as 256 -> 0 and ctest reported it passed. Every build with
+# CHIP_SKIP_TESTS_WITH_DOUBLES=ON wraps its tests this way, so on those builds
+# any test without a PASS/FAIL regex could fail silently (chipStar issue #1592).
+set -u
+HIPCC="@CMAKE_BINARY_DIR@/bin/hipcc"
+EXTRACTOR="@CMAKE_BINARY_DIR@/bin/spirv-extractor"
+SRC="@CMAKE_CURRENT_SOURCE_DIR@/TestFix1592ExtractorExitStatus.hip"
+OUT="@CMAKE_CURRENT_BINARY_DIR@/@TEST_NAME@.d"
+
+if [ ! -x "${EXTRACTOR}" ]; then
+  echo "HIP_SKIP_THIS_TEST: spirv-extractor not built"
+  exit 0
+fi
+rm -rf "${OUT}"; mkdir -p "${OUT}"; cd "${OUT}" || exit 1
+"${HIPCC}" -O2 "${SRC}" -o fails > build.log 2>&1 || { echo "FAIL: could not build the reproducer"; tail -5 build.log; exit 1; }
+
+./fails > direct.log 2>&1; DIRECT=$?
+"${EXTRACTOR}" --check-for-doubles ./fails > wrapped.log 2>&1; WRAPPED=$?
+echo "direct exit=${DIRECT} wrapped exit=${WRAPPED}"
+
+if [ "${DIRECT}" -ne 1 ]; then
+  echo "FAIL: the reproducer itself should exit 1, got ${DIRECT}"; exit 1
+fi
+if [ "${WRAPPED}" -ne 1 ]; then
+  echo "FAIL: spirv-extractor --check-for-doubles turned exit ${DIRECT} into exit ${WRAPPED}"
+  echo "      a failing test wrapped this way is reported as passing (issue #1592)"
+  exit 1
+fi
+echo "PASSED"

--- a/tests/runtime/TestFix1592ExtractorExitStatus.bash
+++ b/tests/runtime/TestFix1592ExtractorExitStatus.bash
@@ -14,6 +14,12 @@ if [ ! -x "${EXTRACTOR}" ]; then
   echo "HIP_SKIP_THIS_TEST: spirv-extractor not built"
   exit 0
 fi
+# Never echo a captured log verbatim: it can hold the skip marker, and ctest
+# reads this script's own stdout, so printing it unredacted turns a failure into
+# a Skip (see add_shell_test's SKIP_REGULAR_EXPRESSION). Same reason as
+# TestFix1601ExtractorMultiTUDoubles.bash.
+show() { sed "s/HIP_SKIP_THIS_TEST/<skip-marker>/g" "$1"; }
+
 rm -rf "${OUT}"; mkdir -p "${OUT}"; cd "${OUT}" || exit 1
 "${HIPCC}" -O2 "${SRC}" -o fails > build.log 2>&1 || { echo "FAIL: could not build the reproducer"; tail -5 build.log; exit 1; }
 
@@ -22,12 +28,12 @@ rm -rf "${OUT}"; mkdir -p "${OUT}"; cd "${OUT}" || exit 1
 echo "direct exit=${DIRECT} wrapped exit=${WRAPPED}"
 
 if [ "${DIRECT}" -ne 1 ]; then
-  echo "FAIL: the reproducer itself should exit 1, got ${DIRECT}"; cat direct.log; exit 1
+  echo "FAIL: the reproducer itself should exit 1, got ${DIRECT}"; show direct.log; exit 1
 fi
 if [ "${WRAPPED}" -ne 1 ]; then
   echo "FAIL: spirv-extractor --check-for-doubles turned exit ${DIRECT} into exit ${WRAPPED}"
   echo "      a failing test wrapped this way is reported as passing (issue #1592)"
-  cat wrapped.log
+  show wrapped.log
   exit 1
 fi
 
@@ -38,7 +44,7 @@ echo "signal death wrapped exit=${SIGNALED}"
 if [ "${SIGNALED}" -ne 134 ]; then
   echo "FAIL: a wrapped test killed by SIGABRT must be reported as 134 (128+6),"
   echo "      got ${SIGNALED}"
-  cat signal.log
+  show signal.log
   exit 1
 fi
 
@@ -49,13 +55,13 @@ cp ./fails ./noexec && chmod -x ./noexec
 echo "unrunnable wrapped exit=${NOEXEC}"
 if [ "${NOEXEC}" -eq 0 ]; then
   echo "FAIL: a test the wrapper could not execute was reported as passing"
-  cat noexec.log
+  show noexec.log
   exit 1
 fi
 # and it must say why, or a CI log shows a bare status with no cause.
 if ! grep -q "spirv-extractor: could not run" noexec.log; then
   echo "FAIL: the wrapper failed to run ./noexec and printed no diagnostic"
-  cat noexec.log
+  show noexec.log
   exit 1
 fi
 echo "PASSED"

--- a/tests/runtime/TestFix1592ExtractorExitStatus.bash
+++ b/tests/runtime/TestFix1592ExtractorExitStatus.bash
@@ -1,9 +1,6 @@
 #!/bin/bash
-# spirv-extractor --check-for-doubles must propagate the wrapped test's exit
-# status. It returned system()'s raw wait status from main(), so a test that
-# exits 1 came back as 256 -> 0 and ctest reported it passed. Every build with
-# CHIP_SKIP_TESTS_WITH_DOUBLES=ON wraps its tests this way, so on those builds
-# any test without a PASS/FAIL regex could fail silently (chipStar issue #1592).
+# Gates chipStar issue #1592: the wrapper must report the child's exit status,
+# its signal death, and its own failure to run it.
 set -u
 HIPCC="@CMAKE_BINARY_DIR@/bin/hipcc"
 EXTRACTOR="@CMAKE_BINARY_DIR@/bin/spirv-extractor"
@@ -14,10 +11,8 @@ if [ ! -x "${EXTRACTOR}" ]; then
   echo "HIP_SKIP_THIS_TEST: spirv-extractor not built"
   exit 0
 fi
-# Never echo a captured log verbatim: it can hold the skip marker, and ctest
-# reads this script's own stdout, so printing it unredacted turns a failure into
-# a Skip (see add_shell_test's SKIP_REGULAR_EXPRESSION). Same reason as
-# TestFix1601ExtractorMultiTUDoubles.bash.
+# Redacted because ctest reads this script's stdout and add_shell_test treats a
+# raw marker as a skip.
 show() { sed "s/HIP_SKIP_THIS_TEST/<skip-marker>/g" "$1"; }
 
 rm -rf "${OUT}"; mkdir -p "${OUT}"; cd "${OUT}" || exit 1

--- a/tests/runtime/TestFix1592ExtractorExitStatus.bash
+++ b/tests/runtime/TestFix1592ExtractorExitStatus.bash
@@ -22,11 +22,40 @@ rm -rf "${OUT}"; mkdir -p "${OUT}"; cd "${OUT}" || exit 1
 echo "direct exit=${DIRECT} wrapped exit=${WRAPPED}"
 
 if [ "${DIRECT}" -ne 1 ]; then
-  echo "FAIL: the reproducer itself should exit 1, got ${DIRECT}"; exit 1
+  echo "FAIL: the reproducer itself should exit 1, got ${DIRECT}"; cat direct.log; exit 1
 fi
 if [ "${WRAPPED}" -ne 1 ]; then
   echo "FAIL: spirv-extractor --check-for-doubles turned exit ${DIRECT} into exit ${WRAPPED}"
   echo "      a failing test wrapped this way is reported as passing (issue #1592)"
+  cat wrapped.log
+  exit 1
+fi
+
+# A signal death must arrive as 128+signal, not as the shell's own status and
+# not as a success. Without this, mapping the signal arm to 0 goes undetected.
+"${EXTRACTOR}" --check-for-doubles ./fails abort > signal.log 2>&1; SIGNALED=$?
+echo "signal death wrapped exit=${SIGNALED}"
+if [ "${SIGNALED}" -ne 134 ]; then
+  echo "FAIL: a wrapped test killed by SIGABRT must be reported as 134 (128+6),"
+  echo "      got ${SIGNALED}"
+  cat signal.log
+  exit 1
+fi
+
+# A test the wrapper cannot execute must not be reported as a pass. Without
+# this, mapping the spawn-failure arm to 0 goes undetected.
+cp ./fails ./noexec && chmod -x ./noexec
+"${EXTRACTOR}" --check-for-doubles ./noexec > noexec.log 2>&1; NOEXEC=$?
+echo "unrunnable wrapped exit=${NOEXEC}"
+if [ "${NOEXEC}" -eq 0 ]; then
+  echo "FAIL: a test the wrapper could not execute was reported as passing"
+  cat noexec.log
+  exit 1
+fi
+# and it must say why, or a CI log shows a bare status with no cause.
+if ! grep -q "spirv-extractor: could not run" noexec.log; then
+  echo "FAIL: the wrapper failed to run ./noexec and printed no diagnostic"
+  cat noexec.log
   exit 1
 fi
 echo "PASSED"

--- a/tests/runtime/TestFix1592ExtractorExitStatus.hip
+++ b/tests/runtime/TestFix1592ExtractorExitStatus.hip
@@ -1,0 +1,20 @@
+// Reproducer for chipStar issue #1592: a deliberately failing HIP program.
+// TestFix1592ExtractorExitStatus.bash runs it directly and through
+// `spirv-extractor --check-for-doubles`, which is how every test is wrapped
+// when CHIP_SKIP_TESTS_WITH_DOUBLES=ON, and requires the wrapper to report the
+// same non-zero exit status. Before the fix the wrapper returned system()'s
+// raw wait status (256 for exit 1), which main() truncates to 0, so ctest saw
+// a passing test.
+//
+// It is compiled as a fatbinary so the wrapper has real SPIR-V to inspect; the
+// kernel is never launched. Not registered as a ctest itself (see
+// RUNTIME_TESTS_MANUAL); the .bash is the test.
+#include <hip/hip_runtime.h>
+#include <cstdio>
+
+__global__ void k(int *p) { *p = 1; }
+
+int main() {
+  printf("FAIL: deliberate, this program must exit 1\n");
+  return 1;
+}

--- a/tests/runtime/TestFix1592ExtractorExitStatus.hip
+++ b/tests/runtime/TestFix1592ExtractorExitStatus.hip
@@ -11,10 +11,19 @@
 // RUNTIME_TESTS_MANUAL); the .bash is the test.
 #include <hip/hip_runtime.h>
 #include <cstdio>
+#include <cstring>
+#include <cstdlib>
 
 __global__ void k(int *p) { *p = 1; }
 
-int main() {
+// Argument-free: exit 1. With "abort": die of SIGABRT, so the .bash can check
+// the 128+signal mapping too. Both are outcomes the wrapper claims to report.
+int main(int Argc, char **Argv) {
+  if (Argc > 1 && strcmp(Argv[1], "abort") == 0) {
+    printf("FAIL: deliberate, this program must die of SIGABRT\n");
+    fflush(stdout);
+    abort();
+  }
   printf("FAIL: deliberate, this program must exit 1\n");
   return 1;
 }

--- a/tests/runtime/TestFix1592ExtractorExitStatus.hip
+++ b/tests/runtime/TestFix1592ExtractorExitStatus.hip
@@ -1,14 +1,7 @@
-// Reproducer for chipStar issue #1592: a deliberately failing HIP program.
-// TestFix1592ExtractorExitStatus.bash runs it directly and through
-// `spirv-extractor --check-for-doubles`, which is how every test is wrapped
-// when CHIP_SKIP_TESTS_WITH_DOUBLES=ON, and requires the wrapper to report the
-// same non-zero exit status. Before the fix the wrapper returned system()'s
-// raw wait status (256 for exit 1), which main() truncates to 0, so ctest saw
-// a passing test.
-//
-// It is compiled as a fatbinary so the wrapper has real SPIR-V to inspect; the
-// kernel is never launched. Not registered as a ctest itself (see
-// RUNTIME_TESTS_MANUAL); the .bash is the test.
+// Deliberately failing child for TestFix1592ExtractorExitStatus.bash: exits 1,
+// or dies of SIGABRT given "abort". A fatbinary so the wrapper has real SPIR-V
+// to inspect; the kernel never launches. Listed in RUNTIME_TESTS_MANUAL, so the
+// .bash is the test, not this.
 #include <hip/hip_runtime.h>
 #include <cstdio>
 #include <cstring>

--- a/tests/runtime/TestFix1600ExtractorArgvBoundaries.bash
+++ b/tests/runtime/TestFix1600ExtractorArgvBoundaries.bash
@@ -1,0 +1,35 @@
+#!/bin/bash
+# spirv-extractor --check-for-doubles must hand the wrapped test its arguments
+# byte for byte. It joined them into one string for system(), so the shell
+# re-split any argument containing a space and Catch2 tests whose case name has
+# a space ran with a corrupted argv (chipStar issue #1600).
+#
+# Checking the exit status alone cannot catch this, so the child asserts its own
+# argument count and contents.
+set -u
+HIPCC="@CMAKE_BINARY_DIR@/bin/hipcc"
+EXTRACTOR="@CMAKE_BINARY_DIR@/bin/spirv-extractor"
+SRC="@CMAKE_CURRENT_SOURCE_DIR@/TestFix1600ExtractorArgvBoundaries.hip"
+OUT="@CMAKE_CURRENT_BINARY_DIR@/@TEST_NAME@.d"
+ARG="Unit_Device_sincos_Accuracy_Positive - float"
+
+if [ ! -x "${EXTRACTOR}" ]; then
+  echo "HIP_SKIP_THIS_TEST: spirv-extractor not built"
+  exit 0
+fi
+rm -rf "${OUT}"; mkdir -p "${OUT}"; cd "${OUT}" || exit 1
+"${HIPCC}" -O2 "${SRC}" -o argvcheck > build.log 2>&1 || { echo "FAIL: could not build the reproducer"; tail -5 build.log; exit 1; }
+
+./argvcheck "${ARG}" > direct.log 2>&1; DIRECT=$?
+"${EXTRACTOR}" --check-for-doubles ./argvcheck "${ARG}" > wrapped.log 2>&1; WRAPPED=$?
+echo "direct exit=${DIRECT} wrapped exit=${WRAPPED}"
+
+if [ "${DIRECT}" -ne 0 ]; then
+  echo "FAIL: the reproducer does not agree with itself when run directly"; cat direct.log; exit 1
+fi
+if [ "${WRAPPED}" -ne 0 ]; then
+  echo "FAIL: spirv-extractor altered the wrapped test's arguments (issue #1600)"
+  cat wrapped.log
+  exit 1
+fi
+echo "PASSED"

--- a/tests/runtime/TestFix1600ExtractorArgvBoundaries.bash
+++ b/tests/runtime/TestFix1600ExtractorArgvBoundaries.bash
@@ -1,11 +1,7 @@
 #!/bin/bash
-# spirv-extractor --check-for-doubles must hand the wrapped test its arguments
-# byte for byte. It joined them into one string for system(), so the shell
-# re-split any argument containing a space and Catch2 tests whose case name has
-# a space ran with a corrupted argv (chipStar issue #1600).
-#
-# Checking the exit status alone cannot catch this, so the child asserts its own
-# argument count and contents.
+# Gates chipStar issue #1600: the wrapper must hand the child its arguments byte
+# for byte. The child asserts its own argv, because the wrapper's exit status
+# cannot carry that.
 set -u
 HIPCC="@CMAKE_BINARY_DIR@/bin/hipcc"
 EXTRACTOR="@CMAKE_BINARY_DIR@/bin/spirv-extractor"
@@ -17,10 +13,8 @@ if [ ! -x "${EXTRACTOR}" ]; then
   echo "HIP_SKIP_THIS_TEST: spirv-extractor not built"
   exit 0
 fi
-# Never echo a captured log verbatim: it can hold the skip marker, and ctest
-# reads this script's own stdout, so printing it unredacted turns a failure into
-# a Skip (see add_shell_test's SKIP_REGULAR_EXPRESSION). Same reason as
-# TestFix1601ExtractorMultiTUDoubles.bash.
+# Redacted because ctest reads this script's stdout and add_shell_test treats a
+# raw marker as a skip.
 show() { sed "s/HIP_SKIP_THIS_TEST/<skip-marker>/g" "$1"; }
 
 rm -rf "${OUT}"; mkdir -p "${OUT}"; cd "${OUT}" || exit 1
@@ -33,10 +27,6 @@ echo "direct exit=${DIRECT} wrapped exit=${WRAPPED}"
 if [ "${DIRECT}" -ne 0 ]; then
   echo "FAIL: the reproducer does not agree with itself when run directly"; show direct.log; exit 1
 fi
-# Assert what the CHILD reported, not the wrapper's exit status. The status
-# cannot carry this: on a tree without the fix for chipStar#1592 the wrapper
-# returns system()'s raw wait status, which is zero for every child outcome, so
-# a status gate here passes even when the child saw a mangled argv.
 if grep -q "HIP_SKIP_THIS_TEST" wrapped.log; then
   echo "FAIL: the wrapper skipped ./argvcheck instead of running it, so nothing"
   echo "      exercised its argv; this test cannot gate issue #1600 that way"

--- a/tests/runtime/TestFix1600ExtractorArgvBoundaries.bash
+++ b/tests/runtime/TestFix1600ExtractorArgvBoundaries.bash
@@ -17,6 +17,12 @@ if [ ! -x "${EXTRACTOR}" ]; then
   echo "HIP_SKIP_THIS_TEST: spirv-extractor not built"
   exit 0
 fi
+# Never echo a captured log verbatim: it can hold the skip marker, and ctest
+# reads this script's own stdout, so printing it unredacted turns a failure into
+# a Skip (see add_shell_test's SKIP_REGULAR_EXPRESSION). Same reason as
+# TestFix1601ExtractorMultiTUDoubles.bash.
+show() { sed "s/HIP_SKIP_THIS_TEST/<skip-marker>/g" "$1"; }
+
 rm -rf "${OUT}"; mkdir -p "${OUT}"; cd "${OUT}" || exit 1
 "${HIPCC}" -O2 "${SRC}" -o argvcheck > build.log 2>&1 || { echo "FAIL: could not build the reproducer"; tail -5 build.log; exit 1; }
 
@@ -25,7 +31,7 @@ rm -rf "${OUT}"; mkdir -p "${OUT}"; cd "${OUT}" || exit 1
 echo "direct exit=${DIRECT} wrapped exit=${WRAPPED}"
 
 if [ "${DIRECT}" -ne 0 ]; then
-  echo "FAIL: the reproducer does not agree with itself when run directly"; cat direct.log; exit 1
+  echo "FAIL: the reproducer does not agree with itself when run directly"; show direct.log; exit 1
 fi
 # Assert what the CHILD reported, not the wrapper's exit status. The status
 # cannot carry this: on a tree without the fix for chipStar#1592 the wrapper
@@ -34,18 +40,18 @@ fi
 if grep -q "HIP_SKIP_THIS_TEST" wrapped.log; then
   echo "FAIL: the wrapper skipped ./argvcheck instead of running it, so nothing"
   echo "      exercised its argv; this test cannot gate issue #1600 that way"
-  cat wrapped.log
+  show wrapped.log
   exit 1
 fi
 if ! grep -qx "argc=2" wrapped.log ||
    ! grep -qxF "  argv[1]=<${ARG}>" wrapped.log; then
   echo "FAIL: spirv-extractor altered the wrapped test's arguments (issue #1600)"
-  cat wrapped.log
+  show wrapped.log
   exit 1
 fi
 if [ "${WRAPPED}" -ne 0 ]; then
   echo "FAIL: the child agreed on its argv but the wrapper still returned ${WRAPPED}"
-  cat wrapped.log
+  show wrapped.log
   exit 1
 fi
 echo "PASSED"

--- a/tests/runtime/TestFix1600ExtractorArgvBoundaries.bash
+++ b/tests/runtime/TestFix1600ExtractorArgvBoundaries.bash
@@ -27,8 +27,24 @@ echo "direct exit=${DIRECT} wrapped exit=${WRAPPED}"
 if [ "${DIRECT}" -ne 0 ]; then
   echo "FAIL: the reproducer does not agree with itself when run directly"; cat direct.log; exit 1
 fi
-if [ "${WRAPPED}" -ne 0 ]; then
+# Assert what the CHILD reported, not the wrapper's exit status. The status
+# cannot carry this: on a tree without the fix for chipStar#1592 the wrapper
+# returns system()'s raw wait status, which is zero for every child outcome, so
+# a status gate here passes even when the child saw a mangled argv.
+if grep -q "HIP_SKIP_THIS_TEST" wrapped.log; then
+  echo "FAIL: the wrapper skipped ./argvcheck instead of running it, so nothing"
+  echo "      exercised its argv; this test cannot gate issue #1600 that way"
+  cat wrapped.log
+  exit 1
+fi
+if ! grep -qx "argc=2" wrapped.log ||
+   ! grep -qxF "  argv[1]=<${ARG}>" wrapped.log; then
   echo "FAIL: spirv-extractor altered the wrapped test's arguments (issue #1600)"
+  cat wrapped.log
+  exit 1
+fi
+if [ "${WRAPPED}" -ne 0 ]; then
+  echo "FAIL: the child agreed on its argv but the wrapper still returned ${WRAPPED}"
   cat wrapped.log
   exit 1
 fi

--- a/tests/runtime/TestFix1600ExtractorArgvBoundaries.hip
+++ b/tests/runtime/TestFix1600ExtractorArgvBoundaries.hip
@@ -1,0 +1,41 @@
+// Reproducer for chipStar issue #1600: prints and checks its own argv.
+// TestFix1600ExtractorArgvBoundaries.bash runs it through
+// `spirv-extractor --check-for-doubles`, which is how every test is wrapped
+// when CHIP_SKIP_TESTS_WITH_DOUBLES=ON, passing one argument that contains
+// spaces. The wrapper built the child's command line by joining arguments
+// with spaces and handing the string to system(), so the shell re-split that
+// argument and the child saw three.
+//
+// Catch2 is the real victim: catch_discover_tests passes each test case name
+// as one argument and many contain spaces, e.g.
+// "Unit_Device_sincos_Accuracy_Positive - float".
+//
+// Compiled as a fatbinary so the wrapper has real SPIR-V to inspect; the
+// kernel is never launched. Not registered as a ctest itself (see
+// RUNTIME_TESTS_MANUAL); the .bash is the test.
+#include <hip/hip_runtime.h>
+#include <cstdio>
+#include <cstring>
+
+__global__ void k(int *p) { *p = 1; }
+
+// The argument the .bash passes. Spaces are the point.
+static const char *Expected = "Unit_Device_sincos_Accuracy_Positive - float";
+
+int main(int argc, char **argv) {
+  printf("argc=%d\n", argc);
+  for (int I = 1; I < argc; ++I)
+    printf("  argv[%d]=<%s>\n", I, argv[I]);
+
+  if (argc != 2) {
+    printf("FAILED: expected exactly 1 argument, got %d\n", argc - 1);
+    return 1;
+  }
+  if (strcmp(argv[1], Expected) != 0) {
+    printf("FAILED: argument altered\n  expected <%s>\n  got      <%s>\n",
+           Expected, argv[1]);
+    return 1;
+  }
+  printf("PASSED\n");
+  return 0;
+}

--- a/tools/spirv-extractor/spirv-extractor.cc
+++ b/tools/spirv-extractor/spirv-extractor.cc
@@ -1,21 +1,43 @@
 #include "spirv-extractor.hh"
+#include <cerrno>
+#include <spawn.h>
 #include <sys/wait.h>
 
+extern char **environ;
+
 // Run the wrapped test and return an exit status ctest can act on.
-// system() returns a wait status; returning it from main() truncates it to
-// the low 8 bits, so a test exiting 1 (status 256) came back as 0 and passed.
+//
+// The child is spawned from an argv vector rather than a command string, so an
+// argument keeps its exact bytes: Catch2 passes each test case name as one
+// argument and many contain spaces, which a shell would re-split.
+//
+// The wait status is decoded rather than returned: it carries the exit code in
+// its high bits, so returning it from main() truncates a child exit of 1 to 0.
 static int runWrapped(const std::string &fatbinaryPath,
                       const std::vector<std::string> &additionalArgs) {
-  std::string command = fatbinaryPath;
-  for (const auto &arg : additionalArgs)
-    command += " " + arg;
-  int status = system(command.c_str());
-  if (status == -1)
+  std::vector<char *> Argv;
+  Argv.reserve(additionalArgs.size() + 2);
+  Argv.push_back(const_cast<char *>(fatbinaryPath.c_str()));
+  for (const auto &Arg : additionalArgs)
+    Argv.push_back(const_cast<char *>(Arg.c_str()));
+  Argv.push_back(nullptr);
+
+  pid_t Pid;
+  // posix_spawn, not the p variant: fatbinaryPath is the path the extractor
+  // already opened and read, so searching PATH for it could run something else.
+  if (posix_spawn(&Pid, fatbinaryPath.c_str(), nullptr, nullptr, Argv.data(),
+                  environ) != 0)
     return 127;
-  if (WIFEXITED(status))
-    return WEXITSTATUS(status);
-  if (WIFSIGNALED(status))
-    return 128 + WTERMSIG(status);
+
+  int Status;
+  while (waitpid(Pid, &Status, 0) < 0)
+    if (errno != EINTR)
+      return 127;
+
+  if (WIFEXITED(Status))
+    return WEXITSTATUS(Status);
+  if (WIFSIGNALED(Status))
+    return 128 + WTERMSIG(Status);
   return 1;
 }
 

--- a/tools/spirv-extractor/spirv-extractor.cc
+++ b/tools/spirv-extractor/spirv-extractor.cc
@@ -29,8 +29,7 @@ static int runWrapped(const std::string &fatbinaryPath,
   // already opened and read, so searching PATH for it could run something else.
   if (int Err = posix_spawn(&Pid, fatbinaryPath.c_str(), nullptr, nullptr,
                             Argv.data(), environ)) {
-    // /bin/sh used to publish this; running the child directly makes it ours to
-    // report, and 127 alone is indistinguishable from a child that exits 127.
+    // 127 alone is indistinguishable from a child that exits 127.
     std::cerr << "spirv-extractor: could not run " << fatbinaryPath << ": "
               << std::strerror(Err) << "\n";
     return 127;

--- a/tools/spirv-extractor/spirv-extractor.cc
+++ b/tools/spirv-extractor/spirv-extractor.cc
@@ -1,6 +1,8 @@
 #include "spirv-extractor.hh"
 #include <cerrno>
 #include <spawn.h>
+#include <cstring>
+#include <iostream>
 #include <sys/wait.h>
 
 extern char **environ;
@@ -25,14 +27,22 @@ static int runWrapped(const std::string &fatbinaryPath,
   pid_t Pid;
   // posix_spawn, not the p variant: fatbinaryPath is the path the extractor
   // already opened and read, so searching PATH for it could run something else.
-  if (posix_spawn(&Pid, fatbinaryPath.c_str(), nullptr, nullptr, Argv.data(),
-                  environ) != 0)
+  if (int Err = posix_spawn(&Pid, fatbinaryPath.c_str(), nullptr, nullptr,
+                            Argv.data(), environ)) {
+    // /bin/sh used to publish this; running the child directly makes it ours to
+    // report, and 127 alone is indistinguishable from a child that exits 127.
+    std::cerr << "spirv-extractor: could not run " << fatbinaryPath << ": "
+              << std::strerror(Err) << "\n";
     return 127;
+  }
 
   int Status;
   while (waitpid(Pid, &Status, 0) < 0)
-    if (errno != EINTR)
+    if (errno != EINTR) {
+      std::cerr << "spirv-extractor: could not wait for " << fatbinaryPath
+                << ": " << std::strerror(errno) << "\n";
       return 127;
+    }
 
   if (WIFEXITED(Status))
     return WEXITSTATUS(Status);

--- a/tools/spirv-extractor/spirv-extractor.cc
+++ b/tools/spirv-extractor/spirv-extractor.cc
@@ -1,4 +1,23 @@
 #include "spirv-extractor.hh"
+#include <sys/wait.h>
+
+// Run the wrapped test and return an exit status ctest can act on.
+// system() returns a wait status; returning it from main() truncates it to
+// the low 8 bits, so a test exiting 1 (status 256) came back as 0 and passed.
+static int runWrapped(const std::string &fatbinaryPath,
+                      const std::vector<std::string> &additionalArgs) {
+  std::string command = fatbinaryPath;
+  for (const auto &arg : additionalArgs)
+    command += " " + arg;
+  int status = system(command.c_str());
+  if (status == -1)
+    return 127;
+  if (WIFEXITED(status))
+    return WEXITSTATUS(status);
+  if (WIFSIGNALED(status))
+    return 128 + WTERMSIG(status);
+  return 1;
+}
 
 int main(int argc, char *argv[]) {
   if (argc < 2) {
@@ -97,10 +116,7 @@ int main(int argc, char *argv[]) {
   if (spirvBinary.empty()) {
     if (checkForDoubles) {
       // Can't extract SPIR-V (e.g. hipRTC test) — run the binary anyway.
-      std::string command = fatbinaryPath;
-      for (const auto &arg : additionalArgs)
-        command += " " + arg;
-      return system(command.c_str());
+      return runWrapped(fatbinaryPath, additionalArgs);
     }
     std::cerr << "Failed to extract SPIR-V binary from the fatbinary: "
               << errorMsg << std::endl;
@@ -193,14 +209,8 @@ int main(int argc, char *argv[]) {
   if (checkForDoubles) {
     if (hasDoubles)
       std::cout << "HIP_SKIP_THIS_TEST: Kernel uses doubles" << std::endl;
-    else {
-      // Execute the binary with additional arguments
-      std::string command = fatbinaryPath;
-      for (const auto &arg : additionalArgs) {
-        command += " " + arg;
-      }
-      exitCode = system(command.c_str());
-    }
+    else
+      exitCode = runWrapped(fatbinaryPath, additionalArgs);
     return exitCode;
   }
 


### PR DESCRIPTION
Fixes #1592
Fixes #1600

`spirv-extractor --check-for-doubles` wraps every test when `CHIP_SKIP_TESTS_WITH_DOUBLES=ON`, and it got the wrapped test's exit status wrong in two ways. It returned `system()`'s raw wait status from `main()`, which keeps only the low 8 bits, so a test exiting 1 arrived as 256 and ctest reported it as passed. It also rebuilt the command as a single string, so an argument containing a space was re-split by the shell and the wrapped test saw a different argv than it was given. It now spawns the test with `posix_spawn` from an argv vector and decodes `waitpid`'s status, so exit codes, signal deaths and a failed spawn all reach ctest distinctly.

Split out of #1513, which needs these fixes but is otherwise about volatile access lowering.

Note for whoever merges this: it makes CI honest on lanes that set `CHIP_SKIP_TESTS_WITH_DOUBLES=ON`, so failures that were previously reported as passes become visible. On the salami Mali lane those are `Unit_hipMultiThreadStreams2_MultiThreadTest` and `TestProjectionBasisKernel`, both fixed in separate PRs that should land before this one.
