### PR TITLE
tests: skip hipRTC fp64 kernels on devices without doubles

### DIFF
--- a/tests/hiprtc/CMakeLists.txt
+++ b/tests/hiprtc/CMakeLists.txt
@@ -29,6 +29,21 @@ add_hip_test(TestShellMetacharacters.cc)
 add_hip_test(TestConstantMemory.cc)
 add_hip_test(TestProjectionBasisKernel.cc)
 add_hip_test(TestFixHiprtcFp64Skip.cc)
+
+# The two tests above compile an fp64 kernel through hipRTC and skip themselves
+# when the device reports no doubles. Assert their OUTPUT rather than their exit
+# status, because the status carries no verdict on the devices these gates are
+# for: there the run goes through ${SKIP_DOUBLE_TESTS}, whose main() returns
+# system()'s raw wait status, and ctest keeps only the low 8 bits of it, so a
+# child that exits 1 arrives as 0. A gate on the status therefore cannot go red
+# on an fp64-less device however broken the skip is, while a missing marker
+# still can.
+set_tests_properties(TestFixHiprtcFp64Skip PROPERTIES
+  PASS_REGULAR_EXPRESSION "PASSED|HIP_SKIP_THIS_TEST")
+set_tests_properties(TestProjectionBasisKernel PROPERTIES
+  PASS_REGULAR_EXPRESSION
+    "All projection basis HIPRTC tests PASSED|HIP_SKIP_THIS_TEST")
+
 add_hip_test(TestHiprtcCacheNameExpressions.cc)
 # This test exercises the HIPRTC SPIR-V cache, so it needs CHIP_MODULE_CACHE_DIR
 # set in the environment at libCHIP static-init time. Use a private directory

--- a/tests/hiprtc/CMakeLists.txt
+++ b/tests/hiprtc/CMakeLists.txt
@@ -28,6 +28,7 @@ add_hip_test(TestHiprtcOptions.cc)
 add_hip_test(TestShellMetacharacters.cc)
 add_hip_test(TestConstantMemory.cc)
 add_hip_test(TestProjectionBasisKernel.cc)
+add_hip_test(TestFixHiprtcFp64Skip.cc)
 add_hip_test(TestHiprtcCacheNameExpressions.cc)
 # This test exercises the HIPRTC SPIR-V cache, so it needs CHIP_MODULE_CACHE_DIR
 # set in the environment at libCHIP static-init time. Use a private directory

--- a/tests/hiprtc/TestCommon.hh
+++ b/tests/hiprtc/TestCommon.hh
@@ -60,6 +60,25 @@
     }                                                                          \
   } while (0)
 
+/// Reports HIP_SKIP_THIS_TEST and exits when the device has no fp64.
+///
+/// A kernel compiled at runtime through hipRTC is in none of the SPIR-V modules
+/// embedded in the test executable, which is all that
+/// `spirv-extractor --check-for-doubles` (the CHIP_SKIP_TESTS_WITH_DOUBLES
+/// wrapper around every ctest) can inspect. That wrapper therefore cannot skip
+/// a hipRTC test whose kernel uses double, and on a device without fp64 the
+/// program build fails with hipErrorSharedObjectInitFailed. Such a test asks
+/// for the skip itself by calling this before it compiles the kernel.
+void SkipIfDeviceHasNoDoubles() {
+  hipDeviceProp_t Props;
+  HIP_CHECK(hipGetDeviceProperties(&Props, 0));
+  if (Props.arch.hasDoubles)
+    return;
+  std::cout << "HIP_SKIP_THIS_TEST: device has no fp64 and the kernel this "
+               "test compiles at runtime uses double\n";
+  exit(0);
+}
+
 hiprtcProgram HiprtcAssertCreateProgram(const std::string &Src) {
   hiprtcProgram Program;
   HIPRTC_CHECK(

--- a/tests/hiprtc/TestCommon.hh
+++ b/tests/hiprtc/TestCommon.hh
@@ -64,11 +64,14 @@
 ///
 /// A kernel compiled at runtime through hipRTC is in none of the SPIR-V modules
 /// embedded in the test executable, which is all that
-/// `spirv-extractor --check-for-doubles` (the CHIP_SKIP_TESTS_WITH_DOUBLES
-/// wrapper around every ctest) can inspect. That wrapper therefore cannot skip
-/// a hipRTC test whose kernel uses double, and on a device without fp64 the
-/// program build fails with hipErrorSharedObjectInitFailed. Such a test asks
-/// for the skip itself by calling this before it compiles the kernel.
+/// `spirv-extractor --check-for-doubles` can inspect. That is the wrapper every
+/// add_hip_test registration goes through when CHIP_SKIP_TESTS_WITH_DOUBLES is
+/// on, so it cannot skip a hipRTC test whose kernel uses double, and the device
+/// compiler is left to reject the kernel: the module build fails with
+/// hipErrorSharedObjectInitFailed on OpenCL and hipErrorInvalidImage on Level
+/// Zero, unless IGC is emulating fp64 (IGC_EnableDPEmulation), which
+/// arch.hasDoubles does not report. Such a test asks for the skip itself by
+/// calling this before it compiles the kernel.
 void SkipIfDeviceHasNoDoubles() {
   hipDeviceProp_t Props;
   HIP_CHECK(hipGetDeviceProperties(&Props, 0));

--- a/tests/hiprtc/TestFixHiprtcFp64Skip.cc
+++ b/tests/hiprtc/TestFixHiprtcFp64Skip.cc
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 chipStar developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+// The smallest hipRTC kernel that needs fp64, kept as the canary for the gap
+// the build-time doubles guard cannot cover.
+//
+// CHIP_SKIP_TESTS_WITH_DOUBLES wraps every ctest in
+// `spirv-extractor --check-for-doubles`, which reads the SPIR-V embedded in the
+// test executable and skips the test when it finds a double. A kernel handed to
+// hipRTC as a string is compiled after the process starts and lives in no
+// embedded module, so that wrapper structurally cannot see it: on a device
+// without fp64 the program build fails instead
+// (hipErrorSharedObjectInitFailed). Nothing the build system can inspect covers
+// that, so a hipRTC test whose kernel uses double has to ask for the skip
+// itself.
+
+#include "TestCommon.hh"
+
+static constexpr auto DoubleKernelSource = R"---(
+extern "C" __global__ void scale(double *Out) { Out[0] = Out[0] * 2.0; }
+)---";
+
+int main() {
+  double *Out = nullptr;
+  HIP_CHECK(hipMalloc(&Out, sizeof(double)));
+  double Input = 21.0;
+  HIP_CHECK(hipMemcpy(Out, &Input, sizeof(double), hipMemcpyHostToDevice));
+
+  auto Program = HiprtcAssertCreateProgram(DoubleKernelSource);
+  auto Code = HiprtcAssertCompileProgram(Program);
+
+  hipModule_t Module;
+  hipFunction_t Kernel;
+  HIP_CHECK(hipModuleLoadData(&Module, Code.data()));
+  HIP_CHECK(hipModuleGetFunction(&Kernel, Module, "scale"));
+
+  void *Args[] = {&Out};
+  HIP_CHECK(hipModuleLaunchKernel(Kernel, 1, 1, 1, 1, 1, 1, 0, nullptr, Args,
+                                  nullptr));
+  HIP_CHECK(hipDeviceSynchronize());
+
+  double Result = 0.0;
+  HIP_CHECK(hipMemcpy(&Result, Out, sizeof(double), hipMemcpyDeviceToHost));
+  TEST_ASSERT(Result == 42.0);
+
+  HIPRTC_CHECK(hiprtcDestroyProgram(&Program));
+  HIP_CHECK(hipModuleUnload(Module));
+  HIP_CHECK(hipFree(Out));
+
+  std::cout << "PASSED\n";
+  return 0;
+}

--- a/tests/hiprtc/TestFixHiprtcFp64Skip.cc
+++ b/tests/hiprtc/TestFixHiprtcFp64Skip.cc
@@ -20,18 +20,19 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-// The smallest hipRTC kernel that needs fp64, kept as the canary for the gap
-// the build-time doubles guard cannot cover.
+// The smallest hipRTC kernel that needs fp64, kept as the regression guard for
+// the gap the doubles wrapper cannot cover.
 //
-// CHIP_SKIP_TESTS_WITH_DOUBLES wraps every ctest in
-// `spirv-extractor --check-for-doubles`, which reads the SPIR-V embedded in the
-// test executable and skips the test when it finds a double. A kernel handed to
-// hipRTC as a string is compiled after the process starts and lives in no
-// embedded module, so that wrapper structurally cannot see it: on a device
-// without fp64 the program build fails instead
-// (hipErrorSharedObjectInitFailed). Nothing the build system can inspect covers
-// that, so a hipRTC test whose kernel uses double has to ask for the skip
-// itself.
+// When CHIP_SKIP_TESTS_WITH_DOUBLES is on, every add_hip_test registration runs
+// under `spirv-extractor --check-for-doubles`, which reads the SPIR-V embedded
+// in the test executable and skips the test when it finds a double. A kernel
+// handed to hipRTC as a string is compiled after the process starts and lives
+// in no embedded module, so that wrapper structurally cannot see it and the
+// device compiler is left to reject the kernel: the module build fails with
+// hipErrorSharedObjectInitFailed on OpenCL and hipErrorInvalidImage on Level
+// Zero, unless IGC is emulating fp64 (IGC_EnableDPEmulation), which
+// arch.hasDoubles does not report. Nothing the wrapper can inspect covers that,
+// so a hipRTC test whose kernel uses double has to ask for the skip itself.
 
 #include "TestCommon.hh"
 

--- a/tests/hiprtc/TestFixHiprtcFp64Skip.cc
+++ b/tests/hiprtc/TestFixHiprtcFp64Skip.cc
@@ -40,6 +40,8 @@ extern "C" __global__ void scale(double *Out) { Out[0] = Out[0] * 2.0; }
 )---";
 
 int main() {
+  SkipIfDeviceHasNoDoubles();
+
   double *Out = nullptr;
   HIP_CHECK(hipMalloc(&Out, sizeof(double)));
   double Input = 21.0;

--- a/tests/hiprtc/TestProjectionBasisKernel.cc
+++ b/tests/hiprtc/TestProjectionBasisKernel.cc
@@ -204,7 +204,8 @@ static void testProjectionKernel(int dim, int P_1d, int Q_1d) {
 
 int main() {
   // The kernel above is entirely fp64 and reaches the device compiler only at
-  // runtime, so the build-time doubles guard cannot see it (see TestCommon.hh).
+  // runtime, so the doubles wrapper every add_hip_test registration goes
+  // through cannot see it (see TestCommon.hh).
   SkipIfDeviceHasNoDoubles();
 
   // Test the projection basis kernel for each dimension as libCEED t319 does.

--- a/tests/hiprtc/TestProjectionBasisKernel.cc
+++ b/tests/hiprtc/TestProjectionBasisKernel.cc
@@ -203,6 +203,10 @@ static void testProjectionKernel(int dim, int P_1d, int Q_1d) {
 }
 
 int main() {
+  // The kernel above is entirely fp64 and reaches the device compiler only at
+  // runtime, so the build-time doubles guard cannot see it (see TestCommon.hh).
+  SkipIfDeviceHasNoDoubles();
+
   // Test the projection basis kernel for each dimension as libCEED t319 does.
   // dim=1: P_from=5, P_to=6 => P_1d=5, Q_1d=6
   // dim=2: same P/Q, larger arrays


### PR DESCRIPTION
`TestProjectionBasisKernel` compiles an entirely fp64 kernel through hipRTC, so on a device without fp64 the OpenCL program build fails with `hipErrorSharedObjectInitFailed`. The doubles wrapper that every `add_hip_test` registration runs under cannot cover this: `spirv-extractor --check-for-doubles` reads the SPIR-V embedded in the test executable, and a hipRTC kernel is compiled after the process starts and lives in no such module.

Both hipRTC tests whose kernels use double now consult `hipDeviceProp_t::arch.hasDoubles` and print `HIP_SKIP_THIS_TEST`, which `add_hip_test` already registers as a ctest skip. `arch.hasDoubles` comes from `cl_khr_fp64` in the OpenCL backend and from `ZE_DEVICE_MODULE_FLAG_FP64` in the Level Zero backend, and is what `scripts/check.py` already reads to decide whether a device can run fp64 tests. The first commit adds a minimal hipRTC fp64 test, since the gap is a property of runtime compiled kernels in general rather than of this one test.

Both tests also gain a `PASS_REGULAR_EXPRESSION`, because on an fp64-less device their exit status carries no verdict: the run goes through `${SKIP_DOUBLE_TESTS}`, whose `main()` returns `system()`'s raw wait status, and ctest keeps only its low 8 bits, so a child exiting 1 arrives as 0. Without the property a broken skip reports `Passed`. This matches `TestFix1601MultiTUDoublesSkipped` in `tests/runtime/CMakeLists.txt`.

The skip path is only reachable on a device reporting `arch.hasDoubles` 0, and no CI lane on a test-only PR has one, since the salami job that exercises fp64-less hardware lives in `test-llvm-patches.yml` and is path filtered to `llvm-patches/**`, `scripts/configure_llvm.sh`, `scripts/cross-aarch64/*` and its own workflow file. It was validated locally on an Intel UHD 770 with fp64 disabled, under both the OpenCL and Level Zero backends.