### PR TITLE
ci: name the Mali staging trees after the pull request

### DIFF
--- a/.github/workflows/reap-ci-scratch.yml
+++ b/.github/workflows/reap-ci-scratch.yml
@@ -1,11 +1,12 @@
 name: Reap CI scratch
 
-# The self-hosted lanes leave one scratch tree per commit behind: salami's
-# ~/ci-stage/<sha>-<variant> (about 1 GB), the cross builder's
-# cross-chipstar-work/{src,native,cross}-<sha>-<variant> (about 2.5 GB per
-# variant), and the library presubmit's /tmp/chipstar-ci-staging-salami/<pr>.
-# A merged pull request will never be tested again, so its trees are dead the
-# moment it lands and this workflow deletes exactly those.
+# The self-hosted lanes leave one scratch tree per pull request behind: salami's
+# ~/ci-stage/pr-<N>-<variant> (about 1 GB), the cross builder's
+# cross-chipstar-work/{src,native,cross}-pr-<N>-<variant> (about 2.5 GB
+# per variant), and the library presubmit's
+# /tmp/chipstar-ci-staging-salami/<pr>. A closed pull request will never be
+# tested again, so its trees are dead the moment it closes and this workflow
+# deletes exactly those.
 #
 # It replaces the reap that used to sit at the end of the Mali test job and
 # matched only trees older than a week: those disks fill in days, so nothing
@@ -15,6 +16,8 @@ name: Reap CI scratch
 on:
   push:
     branches: [main]
+  pull_request:
+    types: [closed]
 
 permissions:
   contents: read
@@ -22,44 +25,38 @@ permissions:
 
 jobs:
   resolve:
-    name: resolve the merged pull request
+    name: resolve the closed pull request
     runs-on: ubuntu-latest
     outputs:
-      shas: ${{ steps.resolve.outputs.shas }}
       prs: ${{ steps.resolve.outputs.prs }}
     steps:
-      # The trees are named after the pull request's own commits, not after
-      # what lands on main: a squash or rebase merge rewrites the sha, so the
-      # pushed commit never matches a tree. Walk from the pushed commits back
-      # to the pull request and take every commit it carried.
+      # A push carries no pull request number of its own, so walk from the
+      # pushed commits back to the pull requests they closed. Both triggers
+      # are kept: an abandoned pull request never reaches main at all.
       - id: resolve
         uses: actions/github-script@v7
         with:
           script: |
             const {owner, repo} = context.repo;
-            const pushed = new Set((context.payload.commits || []).map(c => c.id));
-            if (context.sha) pushed.add(context.sha);
-            const shas = new Set(), prs = new Set();
-            for (const commit_sha of pushed) {
-              const {data} = await github.rest.repos.listPullRequestsAssociatedWithCommit(
-                {owner, repo, commit_sha});
-              for (const pr of data) {
-                if (!pr.merged_at || prs.has(String(pr.number))) continue;
-                prs.add(String(pr.number));
-                const commits = await github.paginate(github.rest.pulls.listCommits,
-                  {owner, repo, pull_number: pr.number, per_page: 100});
-                for (const c of commits) shas.add(c.sha.substring(0, 12));
+            const prs = new Set();
+            if (context.payload.pull_request) {
+              prs.add(String(context.payload.pull_request.number));
+            } else {
+              const pushed = new Set((context.payload.commits || []).map(c => c.id));
+              if (context.sha) pushed.add(context.sha);
+              for (const commit_sha of pushed) {
+                const {data} = await github.rest.repos.listPullRequestsAssociatedWithCommit(
+                  {owner, repo, commit_sha});
+                for (const pr of data) if (pr.merged_at) prs.add(String(pr.number));
               }
             }
-            core.info(`merged PRs: ${[...prs].join(' ') || 'none'}`);
-            core.info(`commits: ${[...shas].join(' ') || 'none'}`);
-            core.setOutput('shas', [...shas].join(' '));
+            core.info(`closed PRs: ${[...prs].join(' ') || 'none'}`);
             core.setOutput('prs', [...prs].join(' '));
 
   cross-builder:
     name: reap cross build trees
     needs: resolve
-    if: needs.resolve.outputs.shas != ''
+    if: needs.resolve.outputs.prs != ''
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 15
     steps:
@@ -68,18 +65,18 @@ jobs:
           fetch-depth: 1
       - name: Reap
         env:
-          SHAS: ${{ needs.resolve.outputs.shas }}
+          PRS: ${{ needs.resolve.outputs.prs }}
         run: |
           set -euo pipefail
           W=/space/pvelesko/cross-chipstar-work
           [ -d /space ] || W=$HOME/cross-chipstar-work
           scripts/ci/reap-merged-dirs.sh -d "$W" \
-            -p 'src-%s-*' -p 'native-%s-*' -p 'cross-%s-*' $SHAS
+            -p 'src-pr-%s-*' -p 'native-pr-%s-*' -p 'cross-pr-%s-*' $PRS
 
   salami:
     name: reap stage trees
     needs: resolve
-    if: needs.resolve.outputs.shas != ''
+    if: needs.resolve.outputs.prs != ''
     runs-on: [self-hosted, Linux, ARM64]
     timeout-minutes: 15
     steps:
@@ -88,10 +85,9 @@ jobs:
           fetch-depth: 1
       - name: Reap
         env:
-          SHAS: ${{ needs.resolve.outputs.shas }}
           PRS: ${{ needs.resolve.outputs.prs }}
         run: |
           set -euo pipefail
-          scripts/ci/reap-merged-dirs.sh -d "$HOME/ci-stage" -p '%s-*' $SHAS
+          scripts/ci/reap-merged-dirs.sh -d "$HOME/ci-stage" -p 'pr-%s-*' $PRS
           # The library presubmit stages under the pull request number instead.
           scripts/ci/reap-merged-dirs.sh -d /tmp/chipstar-ci-staging-salami -p '%s' $PRS

--- a/.github/workflows/unit-tests-arm64-mali.yml
+++ b/.github/workflows/unit-tests-arm64-mali.yml
@@ -7,10 +7,9 @@ name: Unit tests (ARM64 Mali)
 # Both SPIR-V producers are covered; each is a separate cross build.
 #
 # The two jobs share nothing on disk. The handoff is an rsync to
-# salami:~/ci-stage/<sha>/, keyed by commit rather than PR number so two
-# pushes to one PR in quick succession cannot overwrite each other's tree.
-# Those trees, and the builder's, are deleted when the pull request merges,
-# by .github/workflows/reap-ci-scratch.yml.
+# salami:~/ci-stage/pr-<N>-<variant>/, one tree per pull request that each push
+# rewrites in place, and .github/workflows/reap-ci-scratch.yml deletes when the
+# pull request closes.
 # See scripts/cross-aarch64/README.md for how the cross build works and
 # which tests it deliberately leaves to the x86 gate.
 
@@ -36,7 +35,7 @@ jobs:
           - variant: translator
             integrated_spirv: "OFF"
     outputs:
-      sha: ${{ steps.sha.outputs.sha }}
+      tree: ${{ steps.tree.outputs.tree }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -44,8 +43,14 @@ jobs:
           fetch-depth: 0
           submodules: 'recursive'
 
-      - id: sha
-        run: echo "sha=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+      # Named after the pull request, which survives a force push; a dispatch
+      # has no pull request and is named after its head instead.
+      - id: tree
+        env:
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          if [ -n "$PR" ]; then TREE="pr-$PR"; else TREE="manual-$(git rev-parse --short=12 HEAD)"; fi
+          echo "tree=$TREE" >> "$GITHUB_OUTPUT"
 
       # The image bakes in an LLVM 23 built from llvm-patches/llvm-23, so a
       # change to any patch changes the compiler that builds the Mali test
@@ -101,19 +106,19 @@ jobs:
           JOBS=$(nproc); JOBS=$(( JOBS > 1 ? JOBS - 1 : 1 ))
           docker run --rm --user "$(id -u):$(id -g)" -e HOME=/work \
             -e INTEGRATED_SPIRV=${{ matrix.integrated_spirv }} \
-            -e STAGE_PREFIX=/home/pvelesko/ci-stage/${{ steps.sha.outputs.sha }}-${{ matrix.variant }} \
+            -e STAGE_PREFIX=/home/pvelesko/ci-stage/${{ steps.tree.outputs.tree }}-${{ matrix.variant }} \
             -v "$PWD":/chipstar:ro -v "$CROSS_WORK":/work \
             "$CROSS_IMAGE" \
             /chipstar/scripts/cross-aarch64/cross-chipstar.sh \
-              ${{ steps.sha.outputs.sha }}-${{ matrix.variant }} "$JOBS"
+              ${{ steps.tree.outputs.tree }}-${{ matrix.variant }} "$JOBS"
         timeout-minutes: 30
 
       - name: Ship to salami
         run: |
           set -euo pipefail
           scripts/cross-aarch64/ship-to-salami.sh \
-            "$CROSS_WORK/cross-${{ steps.sha.outputs.sha }}-${{ matrix.variant }}" \
-            ${{ steps.sha.outputs.sha }}-${{ matrix.variant }}
+            "$CROSS_WORK/cross-${{ steps.tree.outputs.tree }}-${{ matrix.variant }}" \
+            ${{ steps.tree.outputs.tree }}-${{ matrix.variant }}
         timeout-minutes: 15
 
   test-mali:
@@ -132,7 +137,7 @@ jobs:
       - name: Test igpu opencl (${{ matrix.variant }})
         run: |
           set -euo pipefail
-          T=$HOME/ci-stage/${{ needs.cross-compile.outputs.sha }}-${{ matrix.variant }}
+          T=$HOME/ci-stage/${{ needs.cross-compile.outputs.tree }}-${{ matrix.variant }}
           [ -x "$T/hipInfo" ] || { echo "::error::no cross-built tree at $T"; exit 1; }
           cd "$T"
           rm -rf ~/.cache/chipStar
@@ -145,6 +150,6 @@ jobs:
         with:
           name: test-logs-salami-${{ matrix.variant }}
           path: |
-            ~/ci-stage/${{ needs.cross-compile.outputs.sha }}-${{ matrix.variant }}/checkpy_*.txt
-            ~/ci-stage/${{ needs.cross-compile.outputs.sha }}-${{ matrix.variant }}/Testing/**/LastTest.log
+            ~/ci-stage/${{ needs.cross-compile.outputs.tree }}-${{ matrix.variant }}/checkpy_*.txt
+            ~/ci-stage/${{ needs.cross-compile.outputs.tree }}-${{ matrix.variant }}/Testing/**/LastTest.log
           if-no-files-found: ignore

--- a/scripts/ci/reap-merged-dirs.sh
+++ b/scripts/ci/reap-merged-dirs.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Delete the CI scratch directories that belong to a merged pull request.
+# Delete the CI scratch directories that belong to a closed pull request.
 #
-# Every self-hosted lane names its scratch after the commit it was built from,
-# or after the pull request number: salami's ~/ci-stage/<sha>-<variant>, the
-# cross builder's cross-chipstar-work/{src,native,cross}-<sha>-<variant>, the
-# library presubmit's /tmp/chipstar-ci-staging-salami/<pr>. Once the pull
-# request is merged nothing will ever read those again, so the merge is the
-# moment to delete them.
+# Every self-hosted lane names its scratch after the pull request it belongs
+# to: salami's ~/ci-stage/pr-<N>-<variant>, the cross builder's
+# cross-chipstar-work/{src,native,cross}-pr-<N>-<variant>, the library
+# presubmit's /tmp/chipstar-ci-staging-salami/<pr>. Once the pull request is
+# closed nothing will ever read those again, so that is the moment to delete
+# them.
 #
 # Usage: reap-merged-dirs.sh [-n] -d DIR -p TEMPLATE [-p TEMPLATE ...] TOKEN...
 #   -d DIR       directory holding the scratch trees
@@ -19,9 +19,9 @@
 # workflow variable can never turn a template into a wildcard that matches
 # every tree in DIR. A missing DIR and an empty token list are both no-ops.
 #
-# Example (the cross builder's trees for one merged commit):
+# Example (the cross builder's trees for one closed pull request):
 #   reap-merged-dirs.sh -d /space/pvelesko/cross-chipstar-work \
-#       -p 'src-%s-*' -p 'native-%s-*' -p 'cross-%s-*' 9ad35e7c5b2d
+#       -p 'src-pr-%s-*' -p 'native-pr-%s-*' -p 'cross-pr-%s-*' 1614
 set -eu
 
 DIR=""


### PR DESCRIPTION
The Mali lane named each staging tree after the head that built it, and `reap-ci-scratch.yml` named trees from the pull request's commit list. A force push during review takes the superseded head out of that list for good, so its trees could never be named again by anything, and salami filled up.

Both halves now key on the pull request alone: one tree per pull request, `pr-<N>-<variant>`, that every push rewrites in place (`manual-<sha12>` for a `workflow_dispatch`, which has no pull request). The reaper reaps `pr-<N>-*`, no longer walks the commit list, and runs on closure as well as on merge so an abandoned pull request does not leak its pair.

Trees already on disk under the old `<sha12>-<variant>` names match neither rule and are being removed by hand.

Fixes #1614