### PR TITLE
Fix the volatile-lowering gate, the reconfigure escape hatch and the driver test

### DIFF
--- a/.github/workflows/test-llvm-patches.yml
+++ b/.github/workflows/test-llvm-patches.yml
@@ -267,10 +267,10 @@ jobs:
           cmake .. -DLLVM_CONFIG_BIN=${LLVM_BIN}/llvm-config -GNinja \
             -DCMAKE_BUILD_TYPE=Debug \
             -DCHIP_BUILD_SAMPLES=OFF -DCHIP_BUILD_TESTS=ON
-          if grep -q "CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND:BOOL=ON" CMakeCache.txt; then
+          if ! grep -q "CHIP_CACHE_CONTROLS_SUPPORTED:INTERNAL=ON" CMakeCache.txt; then
             echo "ERROR: the configure probe did not find SPV_INTEL_cache_controls in this"
-            echo "       toolchain, so it forced the atomic lowering and the cache-control"
-            echo "       lowering is still ungated. Check llvm-patches/llvm-23."
+            echo "       toolchain, so the build fell back to the atomic lowering and the"
+            echo "       cache-control lowering is still ungated. Check llvm-patches/llvm-23."
             exit 1
           fi
           ninja LLVMHipPasses -j$(nproc)

--- a/.github/workflows/test-llvm-patches.yml
+++ b/.github/workflows/test-llvm-patches.yml
@@ -134,8 +134,13 @@ jobs:
         run: |
           tests/configure_llvm_pinned_fetch.bash scripts/configure_llvm.sh
       - name: Configure LLVM ${{ matrix.build-id }}
+        # The source tree is kept between runs. configure_llvm.sh resets and
+        # cleans an existing checkout before it re-applies the patch series, so
+        # deleting it buys nothing and costs two full clones per run, one of
+        # them llvm-project. It also makes the pinned-ref fetch skip the step
+        # above tests for unreachable, since that path only runs when the
+        # checkout already exists.
         run: |
-          rm -rf $HOME/llvm-builds/${{ matrix.build-id }}
           mkdir -p $HOME/llvm-builds/${{ matrix.build-id }}
           cd $HOME/llvm-builds/${{ matrix.build-id }}
           rm -rf scripts llvm-patches
@@ -536,7 +541,6 @@ jobs:
         run: |
           export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
           BUILD_DIR="$HOME/llvm-builds/23"
-          rm -rf "$BUILD_DIR"
           mkdir -p "$BUILD_DIR"
           cd "$BUILD_DIR"
           rm -rf scripts llvm-patches

--- a/.github/workflows/test-llvm-patches.yml
+++ b/.github/workflows/test-llvm-patches.yml
@@ -284,11 +284,14 @@ jobs:
             echo "       cache-control lowering is still ungated. Check llvm-patches/llvm-23."
             exit 1
           fi
-          command -v ocloc >/dev/null || {
-            echo "ERROR: ocloc is not on PATH. The ISA gate would report itself"
-            echo "       skipped and this lane would go green without inspecting"
-            echo "       a single generated instruction."
-            exit 1; }
+          for T in ocloc spirv-dis; do
+            command -v $T >/dev/null || {
+              echo "ERROR: $T is not on PATH. Without ocloc the ISA gate reports"
+              echo "       itself skipped, and without spirv-dis the decoration"
+              echo "       count never runs, so this lane would go green without"
+              echo "       establishing that any cache control was emitted."
+              exit 1; }
+          done
           ninja LLVMHipPasses hipcc.bin devicelib_bc -j$(nproc)
           ctest -R 'hipVolatileAccesses|TestFixVolatileLoadLowering' --output-on-failure
         timeout-minutes: 20

--- a/.github/workflows/test-llvm-patches.yml
+++ b/.github/workflows/test-llvm-patches.yml
@@ -259,7 +259,13 @@ jobs:
         # is never exercised. Only the LLVM 23 series carries the patch that
         # puts the extension in clang's HIPSPV allow list, so only here does the
         # configure probe leave the workaround off and select that lowering.
-        # The pass plugin is the whole dependency: no runtime, no GPU.
+        #
+        # This is the only lane that runs the volatile gates against it, so it
+        # runs all three: the compiler fixture on the emitted IR, and the two
+        # shell gates that follow the accesses into the SPIR-V module and then
+        # into the ISA ocloc generates for five Intel parts. hipcc and the
+        # device bitcode are what those need beyond the plugin; ocloc is an
+        # offline compiler, so still no runtime and no GPU.
         if: matrix.llvm-version == 23 && steps.build_chipstar.outcome == 'success'
         run: |
           LLVM_PREFIX="$HOME/install/llvm/${{ matrix.llvm-version }}.0${{ matrix.install-suffix }}"
@@ -278,8 +284,13 @@ jobs:
             echo "       cache-control lowering is still ungated. Check llvm-patches/llvm-23."
             exit 1
           fi
-          ninja LLVMHipPasses -j$(nproc)
-          ctest -R hipVolatileAccesses --output-on-failure
+          command -v ocloc >/dev/null || {
+            echo "ERROR: ocloc is not on PATH. The ISA gate would report itself"
+            echo "       skipped and this lane would go green without inspecting"
+            echo "       a single generated instruction."
+            exit 1; }
+          ninja LLVMHipPasses hipcc.bin devicelib_bc -j$(nproc)
+          ctest -R 'hipVolatileAccesses|TestFixVolatileLoadLowering' --output-on-failure
         timeout-minutes: 20
       - name: Test chipStar with LLVM ${{ matrix.build-id }} (iGPU OpenCL)
         if: always() && steps.build_chipstar.outcome == 'success'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,14 +551,6 @@ endif()
 set(CHIP_CACHE_CONTROLS_SUPPORTED ${_cc_supported} CACHE INTERNAL
     "the configured toolchain's HIPSPV extension list carries SPV_INTEL_cache_controls")
 
-# An earlier chipStar let the probe overwrite the option, so a build directory
-# configured by one holds a value nobody asked for. Drop it.
-if(DEFINED CHIP_CACHE_BYPASS_CHOSEN_BY_PROBE)
-  get_property(_cc_doc CACHE CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND PROPERTY HELPSTRING)
-  set(CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND OFF CACHE BOOL "${_cc_doc}" FORCE)
-  unset(CHIP_CACHE_BYPASS_CHOSEN_BY_PROBE CACHE)
-endif()
-
 # The single variable every consumer of the choice reads.
 if(CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND OR NOT CHIP_CACHE_CONTROLS_SUPPORTED)
   set(CHIP_VOLATILE_LOWERING_ATOMIC ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -519,10 +519,22 @@ string(REPLACE ";" " " NONRDC_EMITTER_OPTS_STR "${NONRDC_EMITTER_OPTS}")
 # SPIR-V step to clang-linker-wrapper and prints no extension list at all, and
 # the versioned OFFLOAD_TRIPLE because the HIPSPV allow list is only selected
 # for it; a plain spirv64 triple takes an upstream path that passes +all and
-# would answer a different question. Re-probed on every
-# configure, so pointing an existing build directory at a different toolchain
-# re-decides instead of keeping the first answer.
-if(CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND AND NOT CHIP_CACHE_BYPASS_CHOSEN_BY_PROBE)
+# would answer a different question. Re-probed on every configure unless the
+# option was set explicitly, so pointing an existing build directory at a
+# different toolchain re-decides instead of keeping the first answer.
+#
+# The probe records the value it chose, not just that it chose one, so an
+# explicit -DCHIP_ATOMICS_CACHE_BYPASS_WORKAROUND=ON in an already configured
+# build directory reads as a change and wins over the probe's answer.
+set(_cc_requested 0)
+if(CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND)
+  set(_cc_requested 1)
+endif()
+set(_cc_verdict 0)
+if(DEFINED CHIP_CACHE_BYPASS_PROBE_VERDICT)
+  set(_cc_verdict "${CHIP_CACHE_BYPASS_PROBE_VERDICT}")
+endif()
+if(_cc_requested AND NOT "${_cc_requested}" EQUAL "${_cc_verdict}")
   # Explicitly requested; the target cannot take the decorations at all.
   message(STATUS "CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND=ON was requested: "
                  "volatile accesses lower to relaxed device-scope atomics")
@@ -550,17 +562,27 @@ else()
   endif()
 
   if(_cc_supported)
+    if(_cc_requested)
+      message(WARNING "CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND is ON but this "
+                      "toolchain lists SPV_INTEL_cache_controls, so the probe "
+                      "turns it OFF and volatile accesses lower to cache-control "
+                      "decorations. Re-run cmake with "
+                      "-DCHIP_ATOMICS_CACHE_BYPASS_WORKAROUND=ON to keep the "
+                      "atomic lowering.")
+    endif()
     set(CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND OFF CACHE BOOL "" FORCE)
+    set(CHIP_CACHE_BYPASS_PROBE_VERDICT 0 CACHE INTERNAL
+        "the value the configure probe last chose for CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND")
     message(STATUS "SPV_INTEL_cache_controls available: volatile accesses lower "
                    "to cache-control decorations")
   else()
     set(CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND ON CACHE BOOL "" FORCE)
+    set(CHIP_CACHE_BYPASS_PROBE_VERDICT 1 CACHE INTERNAL
+        "the value the configure probe last chose for CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND")
     message(STATUS "SPV_INTEL_cache_controls is not in this toolchain's HIPSPV "
                    "extension list; enabling CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND "
                    "so volatile accesses lower to atomics instead")
   endif()
-  set(CHIP_CACHE_BYPASS_CHOSEN_BY_PROBE TRUE CACHE INTERNAL
-      "CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND was set by the configure probe, not by the user")
 endif()
 
 add_subdirectory(llvm_passes)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -519,70 +519,61 @@ string(REPLACE ";" " " NONRDC_EMITTER_OPTS_STR "${NONRDC_EMITTER_OPTS}")
 # SPIR-V step to clang-linker-wrapper and prints no extension list at all, and
 # the versioned OFFLOAD_TRIPLE because the HIPSPV allow list is only selected
 # for it; a plain spirv64 triple takes an upstream path that passes +all and
-# would answer a different question. Re-probed on every configure unless the
-# option was set explicitly, so pointing an existing build directory at a
-# different toolchain re-decides instead of keeping the first answer.
+# would answer a different question. Re-probed on every configure, so pointing
+# an existing build directory at a different toolchain re-decides instead of
+# keeping the first answer.
 #
-# The probe records the value it chose, not just that it chose one, so an
-# explicit -DCHIP_ATOMICS_CACHE_BYPASS_WORKAROUND=ON in an already configured
-# build directory reads as a change and wins over the probe's answer.
-set(_cc_requested 0)
-if(CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND)
-  set(_cc_requested 1)
-endif()
-set(_cc_verdict 0)
-if(DEFINED CHIP_CACHE_BYPASS_PROBE_VERDICT)
-  set(_cc_verdict "${CHIP_CACHE_BYPASS_PROBE_VERDICT}")
-endif()
-if(_cc_requested AND NOT "${_cc_requested}" EQUAL "${_cc_verdict}")
-  # Explicitly requested; the target cannot take the decorations at all.
-  message(STATUS "CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND=ON was requested: "
-                 "volatile accesses lower to relaxed device-scope atomics")
+# The probe writes its own internal variable and never the user's option, so
+# there is no value in the cache that the user did not put there and a later
+# -DCHIP_ATOMICS_CACHE_BYPASS_WORKAROUND=ON is honoured on the configure that
+# passes it.
+set(_cc_probe_src "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/chip_cache_controls_probe.hip")
+file(WRITE "${_cc_probe_src}" "__attribute__((device)) void chipCacheControlsProbe(void) {}\n")
+execute_process(
+  COMMAND ${CLANG_ROOT_PATH_BIN}/clang++ "-###" -x hip -nogpulib -nogpuinc -c
+          --offload-device-only --offload=${OFFLOAD_TRIPLE} ${SPIRV_EMITTER_OPTS}
+          "${_cc_probe_src}"
+  OUTPUT_VARIABLE _cc_out ERROR_VARIABLE _cc_err RESULT_VARIABLE _cc_rc)
+set(_cc_cmds "${_cc_out}${_cc_err}")
+# Either the extension is listed for the producer, or the list is unrestricted.
+if(_cc_cmds MATCHES "spirv-ext=[^ \"]*(\\+all|\\+SPV_INTEL_cache_controls)")
+  set(_cc_supported ON)
 else()
-  set(_cc_probe_src "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/chip_cache_controls_probe.hip")
-  file(WRITE "${_cc_probe_src}" "__attribute__((device)) void chipCacheControlsProbe(void) {}\n")
-  execute_process(
-    COMMAND ${CLANG_ROOT_PATH_BIN}/clang++ "-###" -x hip -nogpulib -nogpuinc -c
-            --offload-device-only --offload=${OFFLOAD_TRIPLE} ${SPIRV_EMITTER_OPTS}
-            "${_cc_probe_src}"
-    OUTPUT_VARIABLE _cc_out ERROR_VARIABLE _cc_err RESULT_VARIABLE _cc_rc)
-  set(_cc_cmds "${_cc_out}${_cc_err}")
-  # Either the extension is listed for the producer, or the list is unrestricted.
-  if(_cc_cmds MATCHES "spirv-ext=[^ \"]*(\\+all|\\+SPV_INTEL_cache_controls)")
-    set(_cc_supported TRUE)
-  else()
-    set(_cc_supported FALSE)
-  endif()
-  if(NOT _cc_cmds MATCHES "spirv-ext=")
-    # No extension list at all means the probe did not reach a device
-    # compilation, so its answer says nothing about the toolchain.
-    message(WARNING "Could not read an extension list from ${CLANG_ROOT_PATH_BIN}/clang++ "
-                    "(exit ${_cc_rc}); assuming SPV_INTEL_cache_controls is unavailable")
-    set(_cc_supported FALSE)
-  endif()
+  set(_cc_supported OFF)
+endif()
+if(NOT _cc_cmds MATCHES "spirv-ext=")
+  # No extension list at all means the probe did not reach a device
+  # compilation, so its answer says nothing about the toolchain.
+  message(WARNING "Could not read an extension list from ${CLANG_ROOT_PATH_BIN}/clang++ "
+                  "(exit ${_cc_rc}); assuming SPV_INTEL_cache_controls is unavailable")
+  set(_cc_supported OFF)
+endif()
+set(CHIP_CACHE_CONTROLS_SUPPORTED ${_cc_supported} CACHE INTERNAL
+    "the configured toolchain's HIPSPV extension list carries SPV_INTEL_cache_controls")
 
-  if(_cc_supported)
-    if(_cc_requested)
-      message(WARNING "CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND is ON but this "
-                      "toolchain lists SPV_INTEL_cache_controls, so the probe "
-                      "turns it OFF and volatile accesses lower to cache-control "
-                      "decorations. Re-run cmake with "
-                      "-DCHIP_ATOMICS_CACHE_BYPASS_WORKAROUND=ON to keep the "
-                      "atomic lowering.")
-    endif()
-    set(CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND OFF CACHE BOOL "" FORCE)
-    set(CHIP_CACHE_BYPASS_PROBE_VERDICT 0 CACHE INTERNAL
-        "the value the configure probe last chose for CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND")
-    message(STATUS "SPV_INTEL_cache_controls available: volatile accesses lower "
-                   "to cache-control decorations")
+# An earlier chipStar let the probe overwrite the option, so a build directory
+# configured by one holds a value nobody asked for. Drop it.
+if(DEFINED CHIP_CACHE_BYPASS_CHOSEN_BY_PROBE)
+  get_property(_cc_doc CACHE CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND PROPERTY HELPSTRING)
+  set(CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND OFF CACHE BOOL "${_cc_doc}" FORCE)
+  unset(CHIP_CACHE_BYPASS_CHOSEN_BY_PROBE CACHE)
+endif()
+
+# The single variable every consumer of the choice reads.
+if(CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND OR NOT CHIP_CACHE_CONTROLS_SUPPORTED)
+  set(CHIP_VOLATILE_LOWERING_ATOMIC ON)
+  if(CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND)
+    message(STATUS "CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND=ON was requested: "
+                   "volatile accesses lower to relaxed device-scope atomics")
   else()
-    set(CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND ON CACHE BOOL "" FORCE)
-    set(CHIP_CACHE_BYPASS_PROBE_VERDICT 1 CACHE INTERNAL
-        "the value the configure probe last chose for CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND")
     message(STATUS "SPV_INTEL_cache_controls is not in this toolchain's HIPSPV "
-                   "extension list; enabling CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND "
-                   "so volatile accesses lower to atomics instead")
+                   "extension list: volatile accesses lower to relaxed "
+                   "device-scope atomics instead")
   endif()
+else()
+  set(CHIP_VOLATILE_LOWERING_ATOMIC OFF)
+  message(STATUS "SPV_INTEL_cache_controls available: volatile accesses lower "
+                 "to cache-control decorations")
 endif()
 
 add_subdirectory(llvm_passes)

--- a/llvm-patches/llvm-23/llvm/0001-hipspv-in-tree-spirv-backend.patch
+++ b/llvm-patches/llvm-23/llvm/0001-hipspv-in-tree-spirv-backend.patch
@@ -399,7 +399,7 @@ index 64d5d22..3a262a2 100644
 -// CHIPSTAR-SAME: "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups"
 +//      CHIPSTAR: {{".*clang.*"}} "-cc1" "-triple" "spirv64-unknown-chipstar"
 +// CHIPSTAR-SAME: "-emit-obj"
-+// CHIPSTAR-SAME: "-mllvm" "-spirv-ext=+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups,+SPV_KHR_bit_instructions,+SPV_EXT_shader_atomic_float_add,+SPV_KHR_non_semantic_info,+SPV_INTEL_optnone"
++// CHIPSTAR-SAME: "-mllvm" "-spirv-ext=+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups,+SPV_KHR_bit_instructions,+SPV_EXT_shader_atomic_float_add,+SPV_KHR_non_semantic_info,+SPV_INTEL_optnone,+SPV_INTEL_cache_controls"
  // CHIPSTAR-SAME: [[LOWER_BC]] "-o" "[[SPIRV_OUT:.*img]]"
  
  // RUN: %clang -### --no-default-config -o %t.dummy.img \
@@ -411,7 +411,7 @@ index 64d5d22..3a262a2 100644
 -// CHIPSTAR-SUBARCH-SAME: "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups"
 +//      CHIPSTAR-SUBARCH: {{".*clang.*"}} "-cc1" "-triple" "spirv64v1.3-unknown-chipstar"
 +// CHIPSTAR-SUBARCH-SAME: "-emit-obj"
-+// CHIPSTAR-SUBARCH-SAME: "-mllvm" "-spirv-ext=+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups,+SPV_KHR_bit_instructions,+SPV_EXT_shader_atomic_float_add,+SPV_KHR_non_semantic_info,+SPV_INTEL_optnone"
++// CHIPSTAR-SUBARCH-SAME: "-mllvm" "-spirv-ext=+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups,+SPV_KHR_bit_instructions,+SPV_EXT_shader_atomic_float_add,+SPV_KHR_non_semantic_info,+SPV_INTEL_optnone,+SPV_INTEL_cache_controls"
  // CHIPSTAR-SUBARCH-SAME: [[LOWER_BC]] "-o" "[[SPIRV_OUT:.*img]]"
  
 +// -fno-integrated-objemitter selects the external llvm-spirv translator.
@@ -425,7 +425,7 @@ index 64d5d22..3a262a2 100644
 +// CHIPSTAR-XTOR-SAME: "-passes=hip-post-link-passes" "-o" [[LOWER_BC:".*bc"]]
 +
 +//      CHIPSTAR-XTOR: {{".*llvm-spirv.*"}} "--spirv-max-version=1.2"
-+// CHIPSTAR-XTOR-SAME: "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups,+SPV_KHR_bit_instructions,+SPV_EXT_shader_atomic_float_add"
++// CHIPSTAR-XTOR-SAME: "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups,+SPV_KHR_bit_instructions,+SPV_EXT_shader_atomic_float_add,+SPV_INTEL_cache_controls"
 +// CHIPSTAR-XTOR-SAME: "--spirv-ext=+SPV_KHR_non_semantic_info,+SPV_INTEL_optnone"
 +// CHIPSTAR-XTOR-SAME: "--spirv-debug-info-version=nonsemantic-shader-200"
 +// CHIPSTAR-XTOR-SAME: [[LOWER_BC]] "-o" "{{.*img}}"

--- a/llvm_passes/CMakeLists.txt
+++ b/llvm_passes/CMakeLists.txt
@@ -213,6 +213,6 @@ target_compile_definitions(LLVMHipPasses PRIVATE CHIP_COMBINED_PASS_PLUGIN)
 
 # Selects the volatile access lowering baked into the pass. See the header of
 # HipLowerVolatileAccesses.cpp for why the default is cache controls.
-if(CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND)
+if(CHIP_VOLATILE_LOWERING_ATOMIC)
   target_compile_definitions(LLVMHipPasses PRIVATE CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND)
 endif()

--- a/llvm_passes/HipLowerVolatileAccesses.cpp
+++ b/llvm_passes/HipLowerVolatileAccesses.cpp
@@ -246,9 +246,11 @@ bool lowerVolatileAccesses(Function &F) {
 
   if (!UseAtomics) {
     // SPV_INTEL_cache_controls: UncachedINTEL at cache level 0, the level
-    // closest to the processing unit. IGC maps it to an L1-uncached but
-    // L3-cached access (.uc.ca on pvc, dg2 and bmg), which is what a volatile
-    // access needs and is what AMD's own volatile lowering does with glc/dlc.
+    // closest to the processing unit, which is the same thing AMD's volatile
+    // lowering spells glc/dlc. IGC maps a load to .uc.ca and a store to
+    // .uc.wb, and drops the control on two shapes: any indexed access on dg2,
+    // and a 64 bit store to a uniform address on pvc, dg2 and bmg. See
+    // CHIP-SPV/chipStar#1616.
     Type *I32 = Type::getInt32Ty(Ctx);
     auto MakeDeco = [&](unsigned DecoId) {
       Metadata *Ops[] = {ConstantAsMetadata::get(ConstantInt::get(I32, DecoId)),

--- a/llvm_passes/HipLowerVolatileAccesses.cpp
+++ b/llvm_passes/HipLowerVolatileAccesses.cpp
@@ -71,12 +71,12 @@
 // through a shadow buffer, so a volatile load reads a value the host never
 // published under either lowering. Both columns are equally wrong there.
 //
-// Neither form is durable against every IGC version: on DG2 the
-// stateless-to-stateful promotion rewrites a decorated indexed access to a
-// bindless a32 message and drops the cache control, at both widths and in both
-// directions, so such a target needs an explicit
-// -DCHIP_ATOMICS_CACHE_BYPASS_WORKAROUND=ON; nothing picks it per device.
-// TestFixVolatileLoadLoweringISA.bash is what makes that drop visible.
+// Neither form is durable against every IGC version: on the Xe-HPG and Xe-LPG
+// parts (dg2, mtl and arl, all measured) the stateless-to-stateful promotion
+// rewrites a decorated indexed access to a bindless a32 message and drops the
+// cache control, at both widths and in both directions, so such a target needs
+// an explicit -DCHIP_ATOMICS_CACHE_BYPASS_WORKAROUND=ON; nothing picks it per
+// device. TestFixVolatileLoadLoweringISA.bash is what makes that drop visible.
 //
 // A third form, the Nontemporal memory operand, is deliberately not used. It is
 // only a hint ("Hints that the accessed address is not likely to be accessed
@@ -250,8 +250,9 @@ bool lowerVolatileAccesses(Function &F) {
     // SPV_INTEL_cache_controls: UncachedINTEL at cache level 0, the level
     // closest to the processing unit, which is the same thing AMD's volatile
     // lowering spells glc/dlc. IGC maps a load to .uc.ca and a store to
-    // .uc.wb, and drops the control on two shapes: any indexed access on dg2,
-    // and a 64 bit store to a uniform address on pvc, dg2 and bmg. See
+    // .uc.wb, and drops the control on two shapes: any indexed access on the
+    // a32-promoting Xe-HPG and Xe-LPG parts (dg2, mtl, arl), and a 64 bit
+    // store to a uniform address on every part measured. See
     // CHIP-SPV/chipStar#1616.
     Type *I32 = Type::getInt32Ty(Ctx);
     auto MakeDeco = [&](unsigned DecoId) {

--- a/llvm_passes/HipLowerVolatileAccesses.cpp
+++ b/llvm_passes/HipLowerVolatileAccesses.cpp
@@ -71,10 +71,12 @@
 // through a shadow buffer, so a volatile load reads a value the host never
 // published under either lowering. Both columns are equally wrong there.
 //
-// Neither form is durable against every IGC version: the stateless-to-stateful
-// promotion rewrites a decorated load to ldraw.indexed and drops the cache
-// control on DG2 and MTL, which is why those parts are built with the atomic
-// fallback rather than the default.
+// Neither form is durable against every IGC version: on DG2 the
+// stateless-to-stateful promotion rewrites a decorated indexed access to a
+// bindless a32 message and drops the cache control, at both widths and in both
+// directions, so such a target needs an explicit
+// -DCHIP_ATOMICS_CACHE_BYPASS_WORKAROUND=ON; nothing picks it per device.
+// TestFixVolatileLoadLoweringISA.bash is what makes that drop visible.
 //
 // A third form, the Nontemporal memory operand, is deliberately not used. It is
 // only a hint ("Hints that the accessed address is not likely to be accessed

--- a/tests/compiler/volatileAccesses/CMakeLists.txt
+++ b/tests/compiler/volatileAccesses/CMakeLists.txt
@@ -23,7 +23,7 @@
 
 # The pass emits one of two shapes and the build picks it, so the fixture has to
 # assert the one this build produces.
-if(CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND)
+if(CHIP_VOLATILE_LOWERING_ATOMIC)
   set(VOLATILE_LOWERING "atomic")
 else()
   set(VOLATILE_LOWERING "cachectl")

--- a/tests/configure_llvm_pinned_fetch.bash
+++ b/tests/configure_llvm_pinned_fetch.bash
@@ -122,7 +122,7 @@ WF_DIR="$(dirname "${SCRIPT}")/../.github/workflows"
 if [ -d "${WF_DIR}" ]; then
   WIPES=$(awk '
     /^[[:space:]]*-[[:space:]]*name:/ { step = ""; rms = "" }
-    /rm -rf/ && $0 !~ /rm -rf scripts llvm-patches/ {
+    /rm -rf/ && $0 !~ /^[[:space:]]*rm -rf scripts llvm-patches[[:space:]]*$/ {
       line = $0; sub(/^[[:space:]]+/, "", line); rms = rms FILENAME ":" FNR ": " line "\n"
     }
     /configure_llvm\.sh/ { if (rms != "" && step == "") { printf "%s", rms; step = "seen" } }

--- a/tests/configure_llvm_pinned_fetch.bash
+++ b/tests/configure_llvm_pinned_fetch.bash
@@ -113,6 +113,27 @@ if [ "${FETCHES}" -ne 1 ]; then
   FAILED=1
 fi
 
+# Every check above is about the path taken when the checkout is still there,
+# so a workflow that deletes it first makes all of them unreachable: the script
+# reclones instead, and the clone is what a throttled runner fails on. The only
+# removal a configure step needs is the copied-in scripts and patches, so any
+# other rm -rf beside a configure_llvm.sh call is that deletion coming back.
+WF_DIR="$(dirname "${SCRIPT}")/../.github/workflows"
+if [ -d "${WF_DIR}" ]; then
+  WIPES=$(awk '
+    /^[[:space:]]*-[[:space:]]*name:/ { step = ""; rms = "" }
+    /rm -rf/ && $0 !~ /rm -rf scripts llvm-patches/ {
+      line = $0; sub(/^[[:space:]]+/, "", line); rms = rms FILENAME ":" FNR ": " line "\n"
+    }
+    /configure_llvm\.sh/ { if (rms != "" && step == "") { printf "%s", rms; step = "seen" } }
+  ' "${WF_DIR}"/*.yml)
+  if [ -n "${WIPES}" ]; then
+    echo "FAIL: a configure step deletes the checkout configure_llvm.sh reuses:"
+    printf '%s\n' "${WIPES}" | sed 's/^/        /'
+    FAILED=1
+  fi
+fi
+
 read -r RC CALLS CMD <<< "$(run_case pinned-tag)"
 echo "pinned tag already local -> rc=${RC} fetches=${CALLS} cmd=[${CMD}]"
 if [ "${RC}" -ne 0 ] || [ "${CALLS}" -ne 0 ]; then

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -69,7 +69,7 @@ endfunction()
 # add_shell_test(<script-file>)
 # The pass emits one of two shapes and the build picks it, so the shell gates
 # have to assert the one this build produces.
-if(CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND)
+if(CHIP_VOLATILE_LOWERING_ATOMIC)
   set(VOLATILE_LOWERING "atomic")
 else()
   set(VOLATILE_LOWERING "cachectl")

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -242,8 +242,7 @@ add_shell_test(TestFixVolatileLoadLoweringSPIRV.bash)
 # The SPIR-V check above proves what chipStar emits; this one proves what the
 # consumer generates from it. IGC discards a cache hint when it widens adjacent
 # stores, which let an A380 run unfixed code while every SPIR-V level check
-# passed. Only the atomic lowering can be checked this way, so it skips under
-# the other one. Uses ocloc, which is an offline compiler and needs no GPU.
+# passed. Uses ocloc, which is an offline compiler and needs no GPU.
 add_shell_test(TestFixVolatileLoadLoweringISA.bash)
 
 add_shell_test(../run_testenvvars.sh)

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -216,10 +216,6 @@ add_shell_test(TestFix1592ExtractorExitStatus.bash)
 # Catch2 case name containing a space was being re-split by the shell.
 add_shell_test(TestFix1600ExtractorArgvBoundaries.bash)
 
-# Volatile 32 and 64 bit global accesses must reach the SPIR-V producer as
-# relaxed device-scope atomics (Kokkos::volatile_load on PVC reads stale L1
-# data otherwise). Inspects the lowered device bitcode of
-
 # The two volatile reproducers above are deliberately not registered as ctests:
 # both PASS on a chipStar built without HipLowerVolatileAccessesPass, so neither
 # can gate a regression. TestFixVolatileLoadLowering only checks that the

--- a/tests/runtime/TestFixVolatileLoadLoweringISA.bash
+++ b/tests/runtime/TestFixVolatileLoadLoweringISA.bash
@@ -30,7 +30,7 @@
 # Needs no GPU: ocloc is an offline compiler and -device names a target.
 set -u
 
-# Set by cmake from CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND: "atomic" or "cachectl".
+# Set by cmake from CHIP_VOLATILE_LOWERING_ATOMIC: "atomic" or "cachectl".
 LOWERING="@VOLATILE_LOWERING@"
 
 HIPCC="@CMAKE_BINARY_DIR@/bin/hipcc"
@@ -115,9 +115,11 @@ for DEV in pvc bmg dg2 mtl arl; do
       if grep -qE "${DIR}\.ugm\.${SHAPE}\.a[0-9]+\.uc" "${ASM}"; then
         if [ "${KEEPS}" = "0" ]; then
           echo "FAIL: -device ${DEV} kept the .uc cache control on the ${WIDTH} bit ${DIR}."
-          echo "      IGC no longer drops it here, so this part does not need"
-          echo "      -DCHIP_ATOMICS_CACHE_BYPASS_WORKAROUND=ON. Take ${DEV} out of the"
-          echo "      part list in HipLowerVolatileAccesses.cpp and out of the case above."
+          echo "      IGC no longer drops it for this access. Check the other three"
+          echo "      before concluding anything about the part: only once all four"
+          echo "      keep the control does ${DEV} stop needing"
+          echo "      -DCHIP_ATOMICS_CACHE_BYPASS_WORKAROUND=ON, and come out of the"
+          echo "      part list in HipLowerVolatileAccesses.cpp and the case above."
           STATUS=1
         fi
       elif [ "${KEEPS}" = "1" ]; then

--- a/tests/runtime/TestFixVolatileLoadLoweringISA.bash
+++ b/tests/runtime/TestFixVolatileLoadLoweringISA.bash
@@ -13,13 +13,19 @@
 # accesses must come out as atomic ugm messages: an atomic is coherent by
 # construction, so it cannot be widened or cached away the way a hint can.
 # Under the cache-control lowering they must come out as ordinary messages that
-# still carry the L1-uncached control, at both widths and in both directions;
-# IGC's stateless-to-stateful promotion rewrites a decorated indexed access to
-# a bindless a32 message and drops the control, which makes the lowering a
-# no-op on the Xe-HPG and Xe-LPG parts (dg2, mtl, arl). Only that indexed shape
-# is gated here; the uniform-address 64 bit store loses the control on every
-# part measured and is described in HipLowerVolatileAccesses.cpp, untested.
-# See CHIP-SPV/chipStar#1616.
+# still carry the L1-uncached control, at both widths and in both directions,
+# on the parts that keep it.
+#
+# Not every part does. IGC's stateless-to-stateful promotion rewrites a
+# decorated indexed access to a bindless a32 message and drops the control, so
+# on dg2, mtl and arl the lowering is a no-op and those parts need the atomic
+# fallback. Each part is asserted against what it actually does, which makes
+# this fail in both directions: a control lost where one is expected, and a
+# control kept on a part that is only on the fallback because it drops one. The
+# second is the canary: it goes red the day IGC stops promoting, and the part
+# comes off the fallback list. Only that indexed shape is gated; the
+# uniform-address 64 bit store is described in HipLowerVolatileAccesses.cpp,
+# untested. See CHIP-SPV/chipStar#1616.
 #
 # Needs no GPU: ocloc is an offline compiler and -device names a target.
 set -u
@@ -60,7 +66,7 @@ fi
 
 STATUS=0
 CHECKED=""
-for DEV in pvc dg2 mtl; do
+for DEV in pvc bmg dg2 mtl arl; do
   DDIR="${OUT}/dump-${DEV}"
   rm -rf "${DDIR}"; mkdir -p "${DDIR}"
   ( cd "${DDIR}" && IGC_ShaderDumpEnable=1 IGC_DumpToCustomDir="${DDIR}" \
@@ -93,6 +99,10 @@ for DEV in pvc dg2 mtl; do
   fi
   echo "-device ${DEV}: memory messages of volatileAccess:"
   grep -ohE '(load|store)[a-z0-9_.]*\.ugm[a-z0-9_.]*' "${ASM}" | sort | uniq -c | sed 's/^/        /'
+  case "${DEV}" in
+    pvc|bmg) KEEPS=1 ;;
+    *)       KEEPS=0 ;;
+  esac
   # A 64 bit access is d64 or, where IGC splits it, d32x2; the trailing t marks
   # a transposed (uniform address) message.
   for DIR in load store; do
@@ -102,7 +112,15 @@ for DEV in pvc dg2 mtl; do
       else
         SHAPE='(d64(x1)?t?|d32x2t?)'
       fi
-      if ! grep -qE "${DIR}\.ugm\.${SHAPE}\.a[0-9]+\.uc" "${ASM}"; then
+      if grep -qE "${DIR}\.ugm\.${SHAPE}\.a[0-9]+\.uc" "${ASM}"; then
+        if [ "${KEEPS}" = "0" ]; then
+          echo "FAIL: -device ${DEV} kept the .uc cache control on the ${WIDTH} bit ${DIR}."
+          echo "      IGC no longer drops it here, so this part does not need"
+          echo "      -DCHIP_ATOMICS_CACHE_BYPASS_WORKAROUND=ON. Take ${DEV} out of the"
+          echo "      part list in HipLowerVolatileAccesses.cpp and out of the case above."
+          STATUS=1
+        fi
+      elif [ "${KEEPS}" = "1" ]; then
         echo "FAIL: -device ${DEV} generated no ${WIDTH} bit ${DIR} carrying the .uc"
         echo "      cache control, so the decoration was dropped and the volatile"
         echo "      ${DIR} still hits the core-private cache."
@@ -114,12 +132,6 @@ done
 
 if [ -z "${CHECKED}" ]; then
   echo "HIP_SKIP_THIS_TEST: ocloc built for no target, nothing inspected"
-  exit 0
-fi
-# pvc keeps the cache control whether or not the decorations survive, so a run
-# that reached only pvc says nothing about the drop this gate exists for.
-if [ "${LOWERING}" != "atomic" ] && ! echo "${CHECKED}" | grep -qE 'dg2|mtl'; then
-  echo "HIP_SKIP_THIS_TEST: ocloc reached none of the parts that promote to a32 (${CHECKED} )"
   exit 0
 fi
 [ "${STATUS}" -ne 0 ] && { echo "See ${OUT} for the shader dumps"; exit 1; }

--- a/tests/runtime/TestFixVolatileLoadLoweringISA.bash
+++ b/tests/runtime/TestFixVolatileLoadLoweringISA.bash
@@ -16,7 +16,10 @@
 # still carry the L1-uncached control, at both widths and in both directions;
 # IGC's stateless-to-stateful promotion rewrites a decorated indexed access to
 # a bindless a32 message and drops the control, which makes the lowering a
-# no-op on the affected part (CHIP-SPV/chipStar#1616).
+# no-op on the Xe-HPG and Xe-LPG parts (dg2, mtl, arl). Only that indexed shape
+# is gated here; the uniform-address 64 bit store loses the control on every
+# part measured and is described in HipLowerVolatileAccesses.cpp, untested.
+# See CHIP-SPV/chipStar#1616.
 #
 # Needs no GPU: ocloc is an offline compiler and -device names a target.
 set -u
@@ -36,15 +39,28 @@ fi
 rm -rf "${OUT}"; mkdir -p "${OUT}"; cd "${OUT}" || exit 1
 
 "${HIPCC}" -O2 --save-temps=cwd -c "${SRC}" -o probe.o > hipcc.log 2>&1
-SPV=$(ls "${OUT}"/*.out 2>/dev/null | head -1)
+# --save-temps leaves the SPIR-V module as a *.img under clang's new offload
+# driver, the default from LLVM 23 on, and as a *.out under the old one, and a
+# new-driver *.out is a clang offload binary rather than a module. So the file
+# is chosen by its magic number, and finding none is a failure: it means this
+# gate would otherwise pass without inspecting anything.
+SPV=""
+for CAND in "${OUT}"/*.img "${OUT}"/*.out; do
+  [ -f "${CAND}" ] || continue
+  case "$(od -An -tx1 -N4 "${CAND}" | tr -d ' \n')" in
+    03022307|07230203) SPV="${CAND}"; break ;;
+  esac
+done
 if [ -z "${SPV}" ]; then
-  echo "HIP_SKIP_THIS_TEST: no SPIR-V module produced (integrated backend build keeps no *.out)"
-  exit 0
+  echo "FAIL: hipcc produced no SPIR-V module under ${OUT}, which holds:"
+  ls -1 "${OUT}" | sed 's/^/        /'
+  echo "See ${OUT}/hipcc.log"
+  exit 1
 fi
 
 STATUS=0
-CHECKED=0
-for DEV in pvc dg2; do
+CHECKED=""
+for DEV in pvc dg2 mtl; do
   DDIR="${OUT}/dump-${DEV}"
   rm -rf "${DDIR}"; mkdir -p "${DDIR}"
   ( cd "${DDIR}" && IGC_ShaderDumpEnable=1 IGC_DumpToCustomDir="${DDIR}" \
@@ -53,7 +69,7 @@ for DEV in pvc dg2; do
     echo "NOTE: ocloc could not build for -device ${DEV}, skipping that target"
     continue
   fi
-  CHECKED=$((CHECKED + 1))
+  CHECKED="${CHECKED} ${DEV}"
   if [ "${LOWERING}" = "atomic" ]; then
     # Every volatile global access must reach the hardware as an atomic message.
     N=$(cat "${DDIR}"/*.asm 2>/dev/null | grep -c -oE 'atomic[a-z_.0-9]*\.(ugm|slm)' || true)
@@ -96,8 +112,14 @@ for DEV in pvc dg2; do
   done
 done
 
-if [ "${CHECKED}" -eq 0 ]; then
+if [ -z "${CHECKED}" ]; then
   echo "HIP_SKIP_THIS_TEST: ocloc built for no target, nothing inspected"
+  exit 0
+fi
+# pvc keeps the cache control whether or not the decorations survive, so a run
+# that reached only pvc says nothing about the drop this gate exists for.
+if [ "${LOWERING}" != "atomic" ] && ! echo "${CHECKED}" | grep -qE 'dg2|mtl'; then
+  echo "HIP_SKIP_THIS_TEST: ocloc reached none of the parts that promote to a32 (${CHECKED} )"
   exit 0
 fi
 [ "${STATUS}" -ne 0 ] && { echo "See ${OUT} for the shader dumps"; exit 1; }

--- a/tests/runtime/TestFixVolatileLoadLoweringISA.bash
+++ b/tests/runtime/TestFixVolatileLoadLoweringISA.bash
@@ -130,6 +130,16 @@ for DEV in pvc bmg dg2 mtl arl; do
   done
 done
 
+# Only the parts that keep the control assert that it was ever emitted; on the
+# rest an absent control is the expected answer, which an empty module gives
+# just as well. So a run that reached none of them proved nothing and must say
+# so rather than report the drops it did see as a pass.
+if [ "${LOWERING}" != "atomic" ] && ! echo "${CHECKED}" | grep -qE 'pvc|bmg'; then
+  echo "FAIL: ocloc reached none of the parts that keep the cache control"
+  echo "      (reached:${CHECKED}), so nothing here shows the decorations"
+  echo "      survived at all. Every assertion that ran expects them absent."
+  exit 1
+fi
 if [ -z "${CHECKED}" ]; then
   echo "HIP_SKIP_THIS_TEST: ocloc built for no target, nothing inspected"
   exit 0

--- a/tests/runtime/TestFixVolatileLoadLoweringISA.bash
+++ b/tests/runtime/TestFixVolatileLoadLoweringISA.bash
@@ -11,24 +11,18 @@
 # This test closes that gap by compiling the module the way a driver does, with
 # ocloc, and inspecting the generated ISA. Under the atomic lowering the
 # accesses must come out as atomic ugm messages: an atomic is coherent by
-# construction, so it cannot be widened or cached away the way a hint can. The
-# cache-control lowering emits ordinary messages carrying .uc controls and needs
-# a decoration-aware IGC to check, so this test skips there.
+# construction, so it cannot be widened or cached away the way a hint can.
+# Under the cache-control lowering they must come out as ordinary messages that
+# still carry the L1-uncached control, at both widths and in both directions;
+# IGC's stateless-to-stateful promotion rewrites a decorated indexed access to
+# a bindless a32 message and drops the control, which makes the lowering a
+# no-op on the affected part (CHIP-SPV/chipStar#1616).
 #
 # Needs no GPU: ocloc is an offline compiler and -device names a target.
 set -u
 
 # Set by cmake from CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND: "atomic" or "cachectl".
 LOWERING="@VOLATILE_LOWERING@"
-if [ "${LOWERING}" != "atomic" ]; then
-  # This check exists because IGC widens adjacent stores and drops a cache
-  # hint carried on them. It asserts atomic ugm messages,
-  # which only the atomic lowering produces; the cache-control lowering emits
-  # ordinary messages carrying .uc cache controls and needs its own check
-  # against a decoration-aware IGC.
-  echo "HIP_SKIP_THIS_TEST: build lowers volatile accesses with ${LOWERING}, not atomics"
-  exit 0
-fi
 
 HIPCC="@CMAKE_BINARY_DIR@/bin/hipcc"
 SRC="@CMAKE_CURRENT_SOURCE_DIR@/TestFixVolatileLoadLowering.hip"
@@ -60,16 +54,46 @@ for DEV in pvc dg2; do
     continue
   fi
   CHECKED=$((CHECKED + 1))
-  # Every volatile global access must reach the hardware as an atomic message.
-  N=$(cat "${DDIR}"/*.asm 2>/dev/null | grep -c -oE 'atomic[a-z_.0-9]*\.(ugm|slm)' || true)
-  echo "-device ${DEV}: ${N} atomic ugm/slm messages in the generated ISA"
-  if [ "${N}" -lt 1 ]; then
-    echo "FAIL: -device ${DEV} generated no atomic messages, so the volatile"
-    echo "      accesses were NOT lowered to atomics by the time IGC saw them."
-    echo "      Generated memory messages were:"
-    cat "${DDIR}"/*.asm 2>/dev/null | grep -ohE '(load|store)\.ugm[a-z0-9._]*' | sort | uniq -c | sed 's/^/        /'
-    STATUS=1
+  if [ "${LOWERING}" = "atomic" ]; then
+    # Every volatile global access must reach the hardware as an atomic message.
+    N=$(cat "${DDIR}"/*.asm 2>/dev/null | grep -c -oE 'atomic[a-z_.0-9]*\.(ugm|slm)' || true)
+    echo "-device ${DEV}: ${N} atomic ugm/slm messages in the generated ISA"
+    if [ "${N}" -lt 1 ]; then
+      echo "FAIL: -device ${DEV} generated no atomic messages, so the volatile"
+      echo "      accesses were NOT lowered to atomics by the time IGC saw them."
+      echo "      Generated memory messages were:"
+      cat "${DDIR}"/*.asm 2>/dev/null | grep -ohE '(load|store)\.ugm[a-z0-9._]*' | sort | uniq -c | sed 's/^/        /'
+      STATUS=1
+    fi
+    continue
   fi
+
+  # IGC dumps one .asm per kernel and names it on the first line.
+  ASM=$(grep -l '^//\.kernel _Z[0-9]*volatileAccess' "${DDIR}"/*.asm 2>/dev/null | head -1)
+  if [ -z "${ASM}" ]; then
+    echo "FAIL: -device ${DEV} produced no ISA dump for the volatileAccess kernel"
+    STATUS=1
+    continue
+  fi
+  echo "-device ${DEV}: memory messages of volatileAccess:"
+  grep -ohE '(load|store)[a-z0-9_.]*\.ugm[a-z0-9_.]*' "${ASM}" | sort | uniq -c | sed 's/^/        /'
+  # A 64 bit access is d64 or, where IGC splits it, d32x2; the trailing t marks
+  # a transposed (uniform address) message.
+  for DIR in load store; do
+    for WIDTH in 32 64; do
+      if [ "${WIDTH}" = "32" ]; then
+        SHAPE='d32(x1)?t?'
+      else
+        SHAPE='(d64(x1)?t?|d32x2t?)'
+      fi
+      if ! grep -qE "${DIR}\.ugm\.${SHAPE}\.a[0-9]+\.uc" "${ASM}"; then
+        echo "FAIL: -device ${DEV} generated no ${WIDTH} bit ${DIR} carrying the .uc"
+        echo "      cache control, so the decoration was dropped and the volatile"
+        echo "      ${DIR} still hits the core-private cache."
+        STATUS=1
+      fi
+    done
+  done
 done
 
 if [ "${CHECKED}" -eq 0 ]; then

--- a/tests/runtime/TestFixVolatileLoadLoweringSPIRV.bash
+++ b/tests/runtime/TestFixVolatileLoadLoweringSPIRV.bash
@@ -129,8 +129,17 @@ if echo "${LEFT}" | grep -qE '(load|store) atomic'; then
   echo "${LEFT}" | grep -E '(load|store) atomic'
 fi
 
-# SPIR-V level check.
-SPV=$(ls "${OUT}"/*.out 2>/dev/null | head -1)
+# SPIR-V level check. --save-temps leaves the module as a *.img under clang's
+# new offload driver, the default from LLVM 23 on, and as a *.out under the old
+# one, and a new-driver *.out is a clang offload binary rather than a module, so
+# the file is chosen by its magic number.
+SPV=""
+for CAND in "${OUT}"/*.img "${OUT}"/*.out; do
+  [ -f "${CAND}" ] || continue
+  case "$(od -An -tx1 -N4 "${CAND}" | tr -d ' \n')" in
+    03022307|07230203) SPV="${CAND}"; break ;;
+  esac
+done
 if [ -n "${SPV}" ] && [ -n "${SPIRV_DIS}" ] && [ -x "${SPIRV_DIS}" ]; then
   "${SPIRV_DIS}" "${SPV}" > module.spvasm
   if grep -q "Generator: Khronos LLVM/SPIR-V Translator" module.spvasm; then
@@ -139,7 +148,7 @@ if [ -n "${SPV}" ] && [ -n "${SPIRV_DIS}" ] && [ -x "${SPIRV_DIS}" ]; then
       # module rather than inside the kernel.
       DECOS=$(grep -c -E 'OpDecorate .*CacheControl(Load|Store)INTEL' module.spvasm || true)
       if [ "${DECOS}" -lt 4 ]; then
-        fail "SPIR-V module has ${DECOS} CacheControlLoadINTEL/CacheControlStoreINTEL decorations, expected at least 4"
+        fail "SPIR-V module has ${DECOS} CacheControlLoadINTEL/CacheControlStoreINTEL decorations, expected at least the 4 of volatileAccess"
         grep -E 'OpDecorate|OpExtension|OpCapability' module.spvasm || true
       fi
     else

--- a/tests/runtime/TestFixVolatileLoadLoweringSPIRV.bash
+++ b/tests/runtime/TestFixVolatileLoadLoweringSPIRV.bash
@@ -77,8 +77,7 @@ if [ -z "${ACCESS}" ]; then
 fi
 if [ "${LOWERING}" = "cachectl" ]; then
   # The default lowering leaves the access plain and volatile and decorates its
-  # pointer instead, so assert that shape and stop: the atomic patterns below
-  # are the other lowering's.
+  # pointer instead.
   DECORATED=$(echo "${ACCESS}" | grep -cE 'getelementptr .*!spirv\.Decorations' || true)
   if [ "${DECORATED}" -lt 4 ]; then
     fail "volatileAccess has ${DECORATED} decorated pointers, expected at least 4 (one per 32/64 bit global access):"
@@ -88,33 +87,27 @@ if [ "${LOWERING}" = "cachectl" ]; then
     fail "the cache-control lowering made accesses atomic, which faults on an allocation whose device reports no atomic support:"
     echo "${ACCESS}" | grep -E '(load|store) atomic'
   fi
-  if echo "${ACCESS}" | grep -qE '!nontemporal'; then
-    fail "volatileAccess carries a !nontemporal marking, which no lowering emits:"
-    echo "${ACCESS}" | grep -E '!nontemporal'
+else
+  for PATTERN in 'load atomic volatile i32.*syncscope\("device"\) monotonic' \
+                 'load atomic volatile i64.*syncscope\("device"\) monotonic' \
+                 'store atomic volatile i32 .*syncscope\("device"\) monotonic' \
+                 'store atomic volatile i64 .*syncscope\("device"\) monotonic'; do
+    if ! echo "${ACCESS}" | grep -qE "${PATTERN}"; then
+      fail "volatileAccess has no '${PATTERN}' after the pass pipeline"
+    fi
+  done
+  # The 16 bit accesses of the same kernel must NOT be rewritten: OpenCL SPIR-V
+  # allows atomics on 32 bit types only, so a 16 bit one would be invalid, and
+  # both lowerings share the filter.
+  if echo "${ACCESS}" | grep -qE '(load|store) atomic volatile i16'; then
+    fail "volatileAccess had its 16 bit accesses made atomic; the OpenCL SPIR-V environment allows atomics on 32 bit types only:"
+    echo "${ACCESS}" | grep -E '(load|store) volatile i16'
   fi
-  echo "PASSED"
-  exit 0
-fi
-
-for PATTERN in 'load atomic volatile i32.*syncscope\("device"\) monotonic' \
-               'load atomic volatile i64.*syncscope\("device"\) monotonic' \
-               'store atomic volatile i32 .*syncscope\("device"\) monotonic' \
-               'store atomic volatile i64 .*syncscope\("device"\) monotonic'; do
-  if ! echo "${ACCESS}" | grep -qE "${PATTERN}"; then
-    fail "volatileAccess has no '${PATTERN}' after the pass pipeline"
+  PLAIN=$(echo "${ACCESS}" | grep -E '(load|store) volatile (i32|i64)' | grep -v 'atomic' || true)
+  if [ -n "${PLAIN}" ]; then
+    fail "volatileAccess still has non-atomic 32 or 64 bit volatile global accesses:"
+    echo "${PLAIN}"
   fi
-done
-# The 16 bit accesses of the same kernel must NOT be rewritten: OpenCL SPIR-V
-# allows atomics on 32 bit types only, so a 16 bit one would be invalid, and
-# both lowerings share the filter.
-if echo "${ACCESS}" | grep -qE '(load|store) atomic volatile i16'; then
-  fail "volatileAccess had its 16 bit accesses made atomic; the OpenCL SPIR-V environment allows atomics on 32 bit types only:"
-  echo "${ACCESS}" | grep -E '(load|store) volatile i16'
-fi
-PLAIN=$(echo "${ACCESS}" | grep -E '(load|store) volatile (i32|i64)' | grep -v 'atomic' || true)
-if [ -n "${PLAIN}" ]; then
-  fail "volatileAccess still has non-atomic 32 or 64 bit volatile global accesses:"
-  echo "${PLAIN}"
 fi
 if echo "${ACCESS}" | grep -qE '!nontemporal'; then
   fail "volatileAccess carries a !nontemporal marking, which no lowering emits:"
@@ -141,21 +134,31 @@ SPV=$(ls "${OUT}"/*.out 2>/dev/null | head -1)
 if [ -n "${SPV}" ] && [ -n "${SPIRV_DIS}" ] && [ -x "${SPIRV_DIS}" ]; then
   "${SPIRV_DIS}" "${SPV}" > module.spvasm
   if grep -q "Generator: Khronos LLVM/SPIR-V Translator" module.spvasm; then
-    # The entry point id is a number or, when the translator kept an OpName,
-    # the mangled name. Translators from LLVM 21 on emit the entry point as
-    # a wrapper whose only instruction is an OpFunctionCall to the kernel
-    # body, so a wrapper is followed to its callee before inspecting the body.
-    KID=$(grep -E 'OpEntryPoint Kernel %[^ ]+ "_Z[0-9]+volatileAccess' module.spvasm |
-          sed -E 's/.*Kernel (%[^ ]+) .*/\1/')
-    FUNC=$(sed -n "/^ *${KID} = OpFunction /,/OpFunctionEnd/p" module.spvasm)
-    CALLEE=$(echo "${FUNC}" | grep -oE 'OpFunctionCall %[^ ]+ %[^ ]+' | awk '{print $3}' | head -1)
-    if [ -n "${CALLEE}" ]; then
-      FUNC=$(sed -n "/^ *${CALLEE} = OpFunction /,/OpFunctionEnd/p" module.spvasm)
-    fi
-    LOADS=$(echo "${FUNC}" | grep -c -E 'OpAtomicLoad' || true)
-    STORES=$(echo "${FUNC}" | grep -c -E 'OpAtomicStore' || true)
-    if [ "${LOADS}" -lt 2 ] || [ "${STORES}" -lt 2 ]; then
-      fail "SPIR-V volatileAccess has ${LOADS} OpAtomicLoad and ${STORES} OpAtomicStore, expected at least 2 each"
+    if [ "${LOWERING}" = "cachectl" ]; then
+      # The decorations are module scope, so they are counted over the whole
+      # module rather than inside the kernel.
+      DECOS=$(grep -c -E 'OpDecorate .*CacheControl(Load|Store)INTEL' module.spvasm || true)
+      if [ "${DECOS}" -lt 4 ]; then
+        fail "SPIR-V module has ${DECOS} CacheControlLoadINTEL/CacheControlStoreINTEL decorations, expected at least 4"
+        grep -E 'OpDecorate|OpExtension|OpCapability' module.spvasm || true
+      fi
+    else
+      # The entry point id is a number or, when the translator kept an OpName,
+      # the mangled name. Translators from LLVM 21 on emit the entry point as
+      # a wrapper whose only instruction is an OpFunctionCall to the kernel
+      # body, so a wrapper is followed to its callee before inspecting the body.
+      KID=$(grep -E 'OpEntryPoint Kernel %[^ ]+ "_Z[0-9]+volatileAccess' module.spvasm |
+            sed -E 's/.*Kernel (%[^ ]+) .*/\1/')
+      FUNC=$(sed -n "/^ *${KID} = OpFunction /,/OpFunctionEnd/p" module.spvasm)
+      CALLEE=$(echo "${FUNC}" | grep -oE 'OpFunctionCall %[^ ]+ %[^ ]+' | awk '{print $3}' | head -1)
+      if [ -n "${CALLEE}" ]; then
+        FUNC=$(sed -n "/^ *${CALLEE} = OpFunction /,/OpFunctionEnd/p" module.spvasm)
+      fi
+      LOADS=$(echo "${FUNC}" | grep -c -E 'OpAtomicLoad' || true)
+      STORES=$(echo "${FUNC}" | grep -c -E 'OpAtomicStore' || true)
+      if [ "${LOADS}" -lt 2 ] || [ "${STORES}" -lt 2 ]; then
+        fail "SPIR-V volatileAccess has ${LOADS} OpAtomicLoad and ${STORES} OpAtomicStore, expected at least 2 each"
+      fi
     fi
     echo "SPIR-V module checked (Khronos translator)"
   else

--- a/tests/runtime/TestFixVolatileLoadLoweringSPIRV.bash
+++ b/tests/runtime/TestFixVolatileLoadLoweringSPIRV.bash
@@ -142,32 +142,38 @@ for CAND in "${OUT}"/*.img "${OUT}"/*.out; do
 done
 if [ -n "${SPV}" ] && [ -n "${SPIRV_DIS}" ] && [ -x "${SPIRV_DIS}" ]; then
   "${SPIRV_DIS}" "${SPV}" > module.spvasm
-  if grep -q "Generator: Khronos LLVM/SPIR-V Translator" module.spvasm; then
-    if [ "${LOWERING}" = "cachectl" ]; then
-      # The decorations are module scope, so they are counted over the whole
-      # module rather than inside the kernel.
-      DECOS=$(grep -c -E 'OpDecorate .*CacheControl(Load|Store)INTEL' module.spvasm || true)
-      if [ "${DECOS}" -lt 4 ]; then
-        fail "SPIR-V module has ${DECOS} CacheControlLoadINTEL/CacheControlStoreINTEL decorations, expected at least the 4 of volatileAccess"
-        grep -E 'OpDecorate|OpExtension|OpCapability' module.spvasm || true
-      fi
-    else
-      # The entry point id is a number or, when the translator kept an OpName,
-      # the mangled name. Translators from LLVM 21 on emit the entry point as
-      # a wrapper whose only instruction is an OpFunctionCall to the kernel
-      # body, so a wrapper is followed to its callee before inspecting the body.
-      KID=$(grep -E 'OpEntryPoint Kernel %[^ ]+ "_Z[0-9]+volatileAccess' module.spvasm |
-            sed -E 's/.*Kernel (%[^ ]+) .*/\1/')
-      FUNC=$(sed -n "/^ *${KID} = OpFunction /,/OpFunctionEnd/p" module.spvasm)
-      CALLEE=$(echo "${FUNC}" | grep -oE 'OpFunctionCall %[^ ]+ %[^ ]+' | awk '{print $3}' | head -1)
-      if [ -n "${CALLEE}" ]; then
-        FUNC=$(sed -n "/^ *${CALLEE} = OpFunction /,/OpFunctionEnd/p" module.spvasm)
-      fi
-      LOADS=$(echo "${FUNC}" | grep -c -E 'OpAtomicLoad' || true)
-      STORES=$(echo "${FUNC}" | grep -c -E 'OpAtomicStore' || true)
-      if [ "${LOADS}" -lt 2 ] || [ "${STORES}" -lt 2 ]; then
-        fail "SPIR-V volatileAccess has ${LOADS} OpAtomicLoad and ${STORES} OpAtomicStore, expected at least 2 each"
-      fi
+  if [ "${LOWERING}" = "cachectl" ]; then
+    # Module-scope decorations, so they are counted over the whole module
+    # rather than inside the kernel, and both producers spell them the same:
+    # "OpDecorate %<id> CacheControlLoadINTEL 0 UncachedINTEL" comes out of the
+    # in-tree SPIR-V backend and the Khronos translator alike. Asking which
+    # produced the module would only turn this arm off for one of them.
+    #
+    # This is also what holds the emission to an unoptimized final compile. The
+    # decoration rides a zero-index getelementptr, which an optimizing pipeline
+    # folds away: the same bitcode through llc keeps six at -O0 and none at -O1.
+    DECOS=$(grep -c -E 'OpDecorate .*CacheControl(Load|Store)INTEL' module.spvasm || true)
+    if [ "${DECOS}" -lt 4 ]; then
+      fail "SPIR-V module has ${DECOS} CacheControlLoadINTEL/CacheControlStoreINTEL decorations, expected at least the 4 of volatileAccess"
+      grep -E 'OpDecorate|OpExtension|OpCapability' module.spvasm || true
+    fi
+    echo "SPIR-V module checked (${DECOS} cache-control decorations)"
+  elif grep -q "Generator: Khronos LLVM/SPIR-V Translator" module.spvasm; then
+    # The entry point id is a number or, when the translator kept an OpName,
+    # the mangled name. Translators from LLVM 21 on emit the entry point as
+    # a wrapper whose only instruction is an OpFunctionCall to the kernel
+    # body, so a wrapper is followed to its callee before inspecting the body.
+    KID=$(grep -E 'OpEntryPoint Kernel %[^ ]+ "_Z[0-9]+volatileAccess' module.spvasm |
+          sed -E 's/.*Kernel (%[^ ]+) .*/\1/')
+    FUNC=$(sed -n "/^ *${KID} = OpFunction /,/OpFunctionEnd/p" module.spvasm)
+    CALLEE=$(echo "${FUNC}" | grep -oE 'OpFunctionCall %[^ ]+ %[^ ]+' | awk '{print $3}' | head -1)
+    if [ -n "${CALLEE}" ]; then
+      FUNC=$(sed -n "/^ *${CALLEE} = OpFunction /,/OpFunctionEnd/p" module.spvasm)
+    fi
+    LOADS=$(echo "${FUNC}" | grep -c -E 'OpAtomicLoad' || true)
+    STORES=$(echo "${FUNC}" | grep -c -E 'OpAtomicStore' || true)
+    if [ "${LOADS}" -lt 2 ] || [ "${STORES}" -lt 2 ]; then
+      fail "SPIR-V volatileAccess has ${LOADS} OpAtomicLoad and ${STORES} OpAtomicStore, expected at least 2 each"
     fi
     echo "SPIR-V module checked (Khronos translator)"
   else

--- a/tests/runtime/TestFixVolatileLoadLoweringSPIRV.bash
+++ b/tests/runtime/TestFixVolatileLoadLoweringSPIRV.bash
@@ -25,9 +25,11 @@
 #
 # Compiles TestFixVolatileLoadLowering.hip with --save-temps and inspects the
 # lowered device bitcode, the SPIR-V producer's input: the global accesses must
-# carry the selected form, the work-group local ones must be untouched. When the
-# module was produced by the Khronos translator and spirv-dis is available, the
-# SPIR-V module is checked for the matching operand as well.
+# carry the selected form, the work-group local ones must be untouched. Where
+# spirv-dis is available the SPIR-V module is checked for the matching operand
+# as well: the cache-control decorations whichever producer emitted them, and
+# the atomic operands only from the Khronos translator, whose entry-point shape
+# the walk below depends on.
 set -u
 
 # Set by cmake from CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND: "atomic" or "cachectl".
@@ -152,9 +154,9 @@ if [ -n "${SPV}" ] && [ -n "${SPIRV_DIS}" ] && [ -x "${SPIRV_DIS}" ]; then
     # This is also what holds the emission to an unoptimized final compile. The
     # decoration rides a zero-index getelementptr, which an optimizing pipeline
     # folds away: the same bitcode through llc keeps six at -O0 and none at -O1.
-    DECOS=$(grep -c -E 'OpDecorate .*CacheControl(Load|Store)INTEL' module.spvasm || true)
+    DECOS=$(grep -c -E 'OpDecorate .*CacheControl(Load|Store)INTEL 0 UncachedINTEL' module.spvasm || true)
     if [ "${DECOS}" -lt 4 ]; then
-      fail "SPIR-V module has ${DECOS} CacheControlLoadINTEL/CacheControlStoreINTEL decorations, expected at least the 4 of volatileAccess"
+      fail "SPIR-V module has ${DECOS} UncachedINTEL cache-control decorations at level 0, expected at least the 4 of volatileAccess"
       grep -E 'OpDecorate|OpExtension|OpCapability' module.spvasm || true
     fi
     echo "SPIR-V module checked (${DECOS} cache-control decorations)"


### PR DESCRIPTION
Fixes #1616.

The cache-control branch of `TestFixVolatileLoadLoweringSPIRV.bash` called `fail()` and then exited 0, so the gate for the lowering a default build ships could not fail; it now falls through to the shared status check and gained the SPIR-V decoration check it never had. `TestFixVolatileLoadLoweringISA.bash` no longer returns early under that lowering: it asserts, per width and per direction, that the volatile accesses still carry the `.uc` cache control in the generated ISA, which turns the silent drop on the a32-promoting parts into a failure. Both gates find the SPIR-V module by its magic number instead of by `ls *.out`, which under clang's new offload driver is an offload binary rather than a module.

The `CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND` probe no longer writes the user's option at all. It records only `CHIP_CACHE_CONTROLS_SUPPORTED`, and the lowering is derived as `CHIP_ATOMICS_CACHE_BYPASS_WORKAROUND OR NOT CHIP_CACHE_CONTROLS_SUPPORTED`, so a `-DCHIP_ATOMICS_CACHE_BYPASS_WORKAROUND=ON` in an existing build directory takes effect on the configure that passes it. The llvm-23 patch's three pinned `CHECK` lines for `clang/test/Driver/hipspv-toolchain.hip` gain `,+SPV_INTEL_cache_controls`, matching the two extension lists the same patch adds to the driver.

The pass itself is unchanged. Measurement with `ocloc 26.27.39122.11` over the matrix of 32/64 bit, load/store and uniform/indexed address says the comment describing the mapping was wrong rather than the code: a store maps to `.uc.wb`, not `.uc.ca`, and the control is dropped for a 64 bit store to a uniform address on every part measured, and for every indexed access on dg2, mtl and arl. Routing 8 byte stores to the atomic form would fault on an allocation whose device reports no `ZE_MEMORY_ACCESS_CAP_FLAG_ATOMIC`, which is the reason atomics are the fallback and not the default, so the comment is corrected instead.
